### PR TITLE
AWS+S3 emulators are not consistent in their use of return codes.

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -383,6 +383,10 @@ func (f *FsS3) Mkdir() error {
 		if err.Code == "BucketAlreadyOwnedByYou" {
 			return nil
 		}
+		// Unfortunately AWS (and others) are not reliably returning
+		// BucketAlreadyOwnedByYou in all cases.
+		// Carry on and wait for failure later.
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
I experienced an issue using this with qstack (from greenqloud - which uses swift via an s3 emulated interface).

When looking at the AWS docs to file a bug with greenqloud, I discovered that even Amazon don't consistently seem to [return this error code](http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html). Although, to be fair in their case the original code intention would still work.

As is, I've raised an issue with Greenqloud and hopefully it will get fixed there.

If not, I'm interested in advice as to how to make this more stable. In the case of error, is there a way of asking "is this bucket owned by me?" - and do that instead of just returning?

  