### PR TITLE
Add --checksum flag to only discard transfers by checksum.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ Checks the files in the source and destination match.  It
 compares sizes and MD5SUMs and prints a report of files which
 don't match.  It doesn't alter the source or destination.
 
-    rclone config 
+    rclone config
 
 Enter an interactive configuration session.
 
-    rclone help 
+    rclone help
 
 This help.
 
@@ -136,6 +136,7 @@ General options:
 ```
       --bwlimit=0: Bandwidth limit in kBytes/s, or use suffix k|M|G
       --checkers=8: Number of checkers to run in parallel.
+      -c, --checksum=false: Skip based on checksum, not mod-time & size
       --config="~/.rclone.conf": Config file.
       --contimeout=1m0s: Connect timeout
   -n, --dry-run=false: Do a trial run with no permanent changes

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -106,17 +106,18 @@ Checks the files in the source and destination match.  It
 compares sizes and MD5SUMs and prints a report of files which
 don't match.  It doesn't alter the source or destination.
 
-    rclone config 
+    rclone config
 
 Enter an interactive configuration session.
 
-    rclone help 
+    rclone help
 
 This help.
 
 ```
       --bwlimit=0: Bandwidth limit in kBytes/s, or use suffix k|M|G
       --checkers=8: Number of checkers to run in parallel.
+      -c, --checksum=false: Skip based on checksum, not mod-time & size
       --config="~/.rclone.conf": Config file.
       --contimeout=1m0s: Connect timeout
   -n, --dry-run=false: Do a trial run with no permanent changes

--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -153,6 +153,13 @@ func (s *StatsInfo) DoneChecking(o Object) {
 	s.checks += 1
 }
 
+// GetTransfers reads the number of transfers
+func (s *StatsInfo) GetTransfers() int64 {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.transfers
+}
+
 // Transferring adds a transfer into the stats
 func (s *StatsInfo) Transferring(o Object) {
 	s.lock.Lock()

--- a/fs/config.go
+++ b/fs/config.go
@@ -44,6 +44,7 @@ var (
 	checkers       = pflag.IntP("checkers", "", 8, "Number of checkers to run in parallel.")
 	transfers      = pflag.IntP("transfers", "", 4, "Number of file transfers to run in parallel.")
 	configFile     = pflag.StringP("config", "", ConfigPath, "Config file.")
+	checkSum       = pflag.BoolP("checksum", "c", false, "Skip based on checksum, not mod-time & size")
 	dryRun         = pflag.BoolP("dry-run", "n", false, "Do a trial run with no permanent changes")
 	connectTimeout = pflag.DurationP("contimeout", "", 60*time.Second, "Connect timeout")
 	timeout        = pflag.DurationP("timeout", "", 5*60*time.Second, "IO idle timeout")
@@ -119,6 +120,7 @@ type ConfigInfo struct {
 	Verbose        bool
 	Quiet          bool
 	DryRun         bool
+	CheckSum       bool
 	ModifyWindow   time.Duration
 	Checkers       int
 	Transfers      int
@@ -194,6 +196,7 @@ func LoadConfig() {
 	Config.DryRun = *dryRun
 	Config.Timeout = *timeout
 	Config.ConnectTimeout = *connectTimeout
+	Config.CheckSum = *checkSum
 
 	ConfigPath = *configFile
 

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"path"
 	"sync"
+	"time"
 )
 
 // Work out modify window for fses passed in - sets Config.ModifyWindow
@@ -71,16 +72,20 @@ func Equal(src, dst Object) bool {
 		return false
 	}
 
-	// Size the same so check the mtime
-	srcModTime := src.ModTime()
-	dstModTime := dst.ModTime()
-	dt := dstModTime.Sub(srcModTime)
-	ModifyWindow := Config.ModifyWindow
-	if dt >= ModifyWindow || dt <= -ModifyWindow {
-		Debug(src, "Modification times differ by %s: %v, %v", dt, srcModTime, dstModTime)
-	} else {
-		Debug(src, "Size and modification time the same (differ by %s, within tolerance %s)", dt, ModifyWindow)
-		return true
+	var srcModTime time.Time
+	if !Config.CheckSum {
+
+		// Size the same so check the mtime
+		srcModTime = src.ModTime()
+		dstModTime := dst.ModTime()
+		dt := dstModTime.Sub(srcModTime)
+		ModifyWindow := Config.ModifyWindow
+		if dt >= ModifyWindow || dt <= -ModifyWindow {
+			Debug(src, "Modification times differ by %s: %v, %v", dt, srcModTime, dstModTime)
+		} else {
+			Debug(src, "Size and modification time the same (differ by %s, within tolerance %s)", dt, ModifyWindow)
+			return true
+		}
 	}
 
 	// mtime is unreadable or different but size is the same so
@@ -91,9 +96,11 @@ func Equal(src, dst Object) bool {
 		return false
 	}
 
-	// Size and MD5 the same but mtime different so update the
-	// mtime of the dst object here
-	dst.SetModTime(srcModTime)
+	if !Config.CheckSum {
+		// Size and MD5 the same but mtime different so update the
+		// mtime of the dst object here
+		dst.SetModTime(srcModTime)
+	}
 
 	Debug(src, "Size and MD5SUM of src and dst objects identical")
 	return true


### PR DESCRIPTION
Useful for S3 backends where checksum fetching is fast.

Replaces #72 as a fix for #61 

Controversial parts include:
 - exposing ``Transfers`` from stats for use in tests.
 - ``Equal`` having a disjointed paths (with regard to the setModTime)