### PR TITLE
Run travis builds on container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 
 go:
   - 1.1.2


### PR DESCRIPTION
See http://docs.travis-ci.com/user/migrating-from-legacy/
TL;DR It starts much faster