### PR TITLE
fix docs link typo for googlecloudstorage

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -23,7 +23,7 @@ See the following for detailed instructions for
   * [Amazon S3](/s3/)
   * [Swift / Rackspace Cloudfiles / Memset Memstore](/swift/)
   * [Dropbox](/dropbox/)
-  * [Google Cloud Storage](/googlcloudstorage/)
+  * [Google Cloud Storage](/googlecloudstorage/)
   * [Local filesystem](/local/)
 
 Usage


### PR DESCRIPTION
fixed the link to Google Cloud Storage in docs.md... Issue #120