### PR TITLE
Read folders in separate goroutines.

### DIFF
--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -39,8 +39,8 @@ const (
 	assetKind          = "ASSET"
 	statusAvailable    = "AVAILABLE"
 	timeFormat         = time.RFC3339 // 2014-03-07T22:31:12.173Z
-	minSleep           = 100 * time.Millisecond
-	maxSleep           = 256 * time.Second
+	minSleep           = 20 * time.Millisecond
+	maxSleep           = 15 * time.Second
 	decayConstant      = 2 // bigger for slower decay, exponential
 )
 

--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -346,7 +346,7 @@ func (f *FsAcd) listDirRecursive(dirId string, path string, out fs.ObjectsChan) 
 		case folderKind:
 			wg.Add(1)
 			folder := path + *node.Name + "/"
-			fs.Log(f, "Reading %s", folder)
+			fs.Debug(f, "Reading %s", folder)
 			go func() {
 				defer wg.Done()
 				err := f.listDirRecursive(*node.Id, folder, out)
@@ -366,7 +366,7 @@ func (f *FsAcd) listDirRecursive(dirId string, path string, out fs.ObjectsChan) 
 		return false
 	})
 	wg.Wait()
-	fs.Log(f, "Finished reading %s", path)
+	fs.Debug(f, "Finished reading %s", path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As proposed in the FIXME, read folders in parallel.
This appears to fix "Next token is expired" on very big directories.
The only downside is that this doesn't abort at once if an error is found.
I added some logging, so there is some output for "-v".