### PR TITLE
Minor adjustments to Unc path conversion function.

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -638,8 +638,8 @@ func filterPath(s string) string {
 	return s
 }
 
-// Pattern to match a windows absolute path: c:\temp path.
-var isAbsWinDrive = regexp.MustCompile(`[a-zA-Z]\:\\`)
+// Pattern to match a windows absolute path: "c:\" and similar
+var isAbsWinDrive = regexp.MustCompile(`^[a-zA-Z]\:\\`)
 
 // uncPath converts an absolute Windows path
 // to a UNC long path.
@@ -653,10 +653,11 @@ func uncPath(s string) string {
 		if strings.HasPrefix(s, `\\?\`) {
 			return s
 		}
-		// Trim "//" from path and add UNC prefix.
+
+		// Trim "\\" from path and add UNC prefix.
 		return `\\?\UNC\` + strings.TrimPrefix(s, `\\`)
 	}
-	if isAbsWinDrive.Match([]byte(s)) {
+	if isAbsWinDrive.MatchString(s) {
 		return `\\?\` + s
 	}
 	return s


### PR DESCRIPTION
Cosmetics, and absolute drive test now must *start* with `x:\`