### PR TITLE
Show more of the filename and align output.

### DIFF
--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -396,13 +396,14 @@ func (file *Account) String() string {
 		}
 	}
 	name := []rune(file.name)
-	if len(name) > 25 {
-		name = name[:25]
+	if len(name) > 45 {
+		where := len(name) - 42
+		name = append([]rune{'.','.','.'}, name[where:]...)
 	}
 	if b <= 0 {
-		return fmt.Sprintf("%s: avg:%7.1f, cur: %6.1f kByte/s. ETA: %s", string(name), avg/1024, cur/1024, etas)
+		return fmt.Sprintf("%45s: avg:%7.1f, cur: %6.1f kByte/s. ETA: %s", string(name), avg/1024, cur/1024, etas)
 	}
-	return fmt.Sprintf("%s: %2d%% done. avg: %6.1f, cur: %6.1f kByte/s. ETA: %s", string(name), int(100*float64(a)/float64(b)), avg/1024, cur/1024, etas)
+	return fmt.Sprintf("%45s: %2d%% done. avg: %6.1f, cur: %6.1f kByte/s. ETA: %s", string(name), int(100*float64(a)/float64(b)), avg/1024, cur/1024, etas)
 }
 
 // Close the object


### PR DESCRIPTION
Print more of the file name, and make the output aligned, so it is nicer on frequent updates.

Also shows the end of the file instead of the start. I may have accidentally removed that.