### PR TITLE
Implement compliant pacing scheme for Amazon Cloud Drive

### DIFF
--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -129,6 +129,7 @@ var retryErrorCodes = []int{
 	429, // Rate exceeded.
 	500, // Get occasional 500 Internal Server Error
 	409, // Conflict - happens in the unit tests a lot
+	503, // Service Unavailable
 }
 
 // shouldRetry returns a boolean as to whether this resp and err
@@ -172,7 +173,7 @@ func NewFs(name, root string) (fs.Fs, error) {
 		name:  name,
 		root:  root,
 		c:     c,
-		pacer: pacer.New().SetMinSleep(minSleep).SetMaxSleep(maxSleep).SetDecayConstant(decayConstant),
+		pacer: pacer.New().SetMinSleep(minSleep).SetPacer(pacer.AmazonCloudDrivePacer),
 	}
 
 	// Update endpoints


### PR DESCRIPTION
I'm trying to exactly meet the requirements of the backoff algorithms on the Amazon docs - see Client Request Retry guidance section

https://developer.amazon.com/public/apis/experience/cloud-drive/content/restful-api-best-practices

Do you think this does it?

I'd be grateful if you'd review the code, and add things to this branch if you see stuff which needs fixing

As far as performance it seems to perform as well as the default strategy or maybe better - perhaps the amazon cloud drive rate limits are tuned for this sort of backoff strategy.

Thanks

Nick