### PR TITLE
Large files support for swift was added

### DIFF
--- a/swift/swift.go
+++ b/swift/swift.go
@@ -518,7 +518,7 @@ func (o *FsObjectSwift) Update(in io.Reader, modTime time.Time, size int64) erro
 		for left > 0 {
 			n := min(left, int64(chunkSize))
 			segmentReader := io.LimitReader(in, n)
-			segmentPath := fmt.Sprintf("%s%s/%s/%d/%09d", o.swift.root, o.remote, nowFloat, size, i)
+			segmentPath := fmt.Sprintf("%s%s/%s/%d/%08d", o.swift.root, o.remote, nowFloat, size, i)
 			_, err := o.swift.c.ObjectPut(segmentsContainerName, segmentPath, segmentReader, true, "", "", m.ObjectHeaders())
 			if err != nil {
 				return err

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -68,10 +68,10 @@ type FsSwift struct {
 //
 // Will definitely have info but maybe not meta
 type FsObjectSwift struct {
-	swift  *FsSwift        // what this object is part of
-	remote string          // The remote path
-	info   swift.Object    // Info from the swift object if known
-	meta   *swift.Metadata // The object metadata if known
+	swift   *FsSwift       // what this object is part of
+	remote  string         // The remote path
+	info    swift.Object   // Info from the swift object if known
+	headers *swift.Headers // The object headers if known
 }
 
 // ------------------------------------------------------------
@@ -189,10 +189,10 @@ func (f *FsSwift) newFsObjectWithInfo(remote string, info *swift.Object) fs.Obje
 		remote: remote,
 	}
 	if info != nil {
-		// Set info but not meta
+		// Set info but not headers
 		fs.info = *info
 	} else {
-		err := fs.readMetaData() // reads info and meta, returning an error
+		err := fs.readMetaData() // reads info and headers, returning an error
 		if err != nil {
 			// logged already FsDebug("Failed to read info: %s", err)
 			return nil
@@ -393,7 +393,7 @@ func (o *FsObjectSwift) Size() int64 {
 //
 // it also sets the info
 func (o *FsObjectSwift) readMetaData() (err error) {
-	if o.meta != nil {
+	if o.headers != nil {
 		return nil
 	}
 	info, h, err := o.swift.c.Object(o.swift.container, o.swift.root+o.remote)
@@ -401,9 +401,8 @@ func (o *FsObjectSwift) readMetaData() (err error) {
 		fs.Debug(o, "Failed to read info: %s", err)
 		return err
 	}
-	meta := h.ObjectMetadata()
 	o.info = info
-	o.meta = &meta
+	o.headers = &h
 	return nil
 }
 
@@ -418,7 +417,7 @@ func (o *FsObjectSwift) ModTime() time.Time {
 		// fs.Log(o, "Failed to read metadata: %s", err)
 		return o.info.LastModified
 	}
-	modTime, err := o.meta.GetModTime()
+	modTime, err := o.headers.ObjectMetadata().GetModTime()
 	if err != nil {
 		// fs.Log(o, "Failed to read mtime from object: %s", err)
 		return o.info.LastModified
@@ -434,8 +433,9 @@ func (o *FsObjectSwift) SetModTime(modTime time.Time) {
 		fs.ErrorLog(o, "Failed to read metadata: %s", err)
 		return
 	}
-	o.meta.SetModTime(modTime)
-	err = o.swift.c.ObjectUpdate(o.swift.container, o.swift.root+o.remote, o.meta.ObjectHeaders())
+	meta := o.headers.ObjectMetadata()
+	meta.SetModTime(modTime)
+	err = o.swift.c.ObjectUpdate(o.swift.container, o.swift.root+o.remote, meta.ObjectHeaders())
 	if err != nil {
 		fs.Stats.Error()
 		fs.ErrorLog(o, "Failed to update remote mtime: %s", err)
@@ -465,7 +465,7 @@ func (o *FsObjectSwift) Update(in io.Reader, modTime time.Time, size int64) erro
 		return err
 	}
 	// Read the metadata from the newly created object
-	o.meta = nil // wipe old metadata
+	o.headers = nil // wipe old metadata
 	err = o.readMetaData()
 	return err
 }

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -487,6 +487,22 @@ func min(x, y int64) int64 {
 	return y
 }
 
+
+// Turns a number of ns into a floating point string in seconds like the "swift" tool
+func nsToSwiftFloatString(ns int64) string {
+	if ns < 0 {
+		return "-" + nsToSwiftFloatString(-ns)
+	}
+	result := fmt.Sprintf("%010d", ns)
+	split := len(result) - 9
+	result, decimals := result[:split], result[split:split+2]
+	if decimals != "" {
+		result += "."
+		result += decimals
+	}
+	return result
+}
+
 // Update the object with the contents of the io.Reader, modTime and size
 //
 // The new object may have been created if an error is returned
@@ -498,7 +514,7 @@ func (o *FsObjectSwift) Update(in io.Reader, modTime time.Time, size int64) erro
 		segmentsContainerName := o.swift.container + "_segments"
 		left := size
 		i := 0
-		nowFloat := swift.TimeToFloatString(time.Now())
+		nowFloat := nsToSwiftFloatString(time.Now().UnixNano())
 		for left > 0 {
 			n := min(left, int64(chunkSize))
 			segmentReader := io.LimitReader(in, n)


### PR DESCRIPTION
This must close #46 
It's a quick fix and this is my first experience with Go, so I ask for code review.

For make it works with large files you must add to your rclone.conf ```segment-size = 5368709120``` and start rclone operations with param ```--size-only=true``, because md5 hash of manifest file isn't equals md5 of original file.

Also in sync copy mode rclone removes segments files, I don't know how to fix this logic in app architecture level. May be we need to add some config flag and handle it in operations.go:409 or operations.go:460.