### PR TITLE
segment container should start with a leading dot which allows it to …

### DIFF
--- a/swift/swift.go
+++ b/swift/swift.go
@@ -168,7 +168,7 @@ func NewFs(name, root string) (fs.Fs, error) {
 		name:              name,
 		c:                 *c,
 		container:         container,
-		segmentsContainer: container + "_segments",
+		segmentsContainer: ".segments_" + container,
 		root:              directory,
 	}
 	if f.root != "" {


### PR DESCRIPTION
…be hidden when using gui tools such as cyberduck to reduce end user confusion.

while the current standard in the swift community is container + "_segments" all developers I spoke to acknowledge that this is not optimal as there are many GUI tools that show these segment containers and 
This change will allow GUI clients such as Expandrive, Cloudberry, Cyberduck, SME to hide these folders and greatly increase end user experience and reduce helpdesk tickets to IT departments ("What is this _segment stuff, can I delete it ?") . 
The new naming convention would be consistent with the swift stack undelete feature https://github.com/swiftstack/swift_undelete which creates trash cans starting with .trash /etc/  but also with Swift Commander