### PR TITLE
Extend CI tests to include formatting + OSX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: go
 sudo: false
 
+os:
+  - linux
+  - osx
+
 go:
   - 1.3.3
   - 1.4.2
   - 1.5
+  - tip
+
+install:
+ - go get ./...
+ - go get -u github.com/golang/lint/golint
+ - go get -u golang.org/x/tools/cmd/goimports
 
 script:
-  - go get ./...
+  - go vet ./...
+  - diff <(goimports -d .) <(printf "")
+  - diff <(golint ./...) <(printf "")
   - go test -v ./...
   - go test -cpu=2 -race -v ./...

--- a/fs/config.go
+++ b/fs/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"crypto/tls"
+
 	"github.com/Unknwon/goconfig"
 	"github.com/mreiferson/go-httpclient"
 	"github.com/spf13/pflag"


### PR DESCRIPTION
CI tests now tests `go vet`, `go fmt` (via goimports) and `golint`.

Adds Travis experimental OSX support.
Add "tip" tests. Can give an early indication about issues in upcoming Go versions.

This makes contributing easier, since users will get automatic "style errors".