### PR TITLE
Set the correct content-type on time update for S3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -644,6 +644,9 @@ func (o *Object) SetModTime(modTime time.Time) {
 	}
 	o.meta[metaMtime] = aws.String(swift.TimeToFloatString(modTime))
 
+	// Guess the content type
+	contentType := fs.MimeType(o)
+
 	// Copy the object to itself to update the metadata
 	key := o.fs.root + o.remote
 	sourceKey := o.fs.bucket + "/" + key
@@ -652,6 +655,7 @@ func (o *Object) SetModTime(modTime time.Time) {
 		Bucket:            &o.fs.bucket,
 		ACL:               &o.fs.perm,
 		Key:               &key,
+		ContentType:       &contentType,
 		CopySource:        &sourceKey,
 		Metadata:          o.meta,
 		MetadataDirective: &directive,


### PR DESCRIPTION
This fixes an issue where updating the modification time resets the content-type to the S3 default of binary/octet-stream which breaks static websites that expect an html file to have a content-type of text/html.