### PR TITLE
Add "--ignore-existing" flag.

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -248,6 +248,15 @@ modification times in the same way as rclone.
 When using this flag, rclone won't update mtimes of remote files if
 they are incorrect as it would normally.
 
+### --ignore-existing ###
+
+Using this option will make rclone unconditionally skip all files
+that exist on the destination, no matter the content of these files.
+
+While this isn't a generally recommendable option, it can be useful
+in cases where your files change due to encryption. However, it cannot
+correct partial transfers in case a transfer was interrupted.
+
 ### --stats=TIME ###
 
 Rclone will print stats at regular intervals to show its progress.

--- a/fs/config.go
+++ b/fs/config.go
@@ -50,6 +50,7 @@ var (
 	configFile     = pflag.StringP("config", "", ConfigPath, "Config file.")
 	checkSum       = pflag.BoolP("checksum", "c", false, "Skip based on checksum & size, not mod-time & size")
 	sizeOnly       = pflag.BoolP("size-only", "", false, "Skip based on size only, not mod-time or checksum")
+	ignoreExisting = pflag.BoolP("ignore-existing", "", false, "Skip all files that exist on destination")
 	dryRun         = pflag.BoolP("dry-run", "n", false, "Do a trial run with no permanent changes")
 	connectTimeout = pflag.DurationP("contimeout", "", 60*time.Second, "Connect timeout")
 	timeout        = pflag.DurationP("timeout", "", 5*60*time.Second, "IO idle timeout")
@@ -156,6 +157,7 @@ type ConfigInfo struct {
 	DryRun             bool
 	CheckSum           bool
 	SizeOnly           bool
+	IgnoreExisting     bool
 	ModifyWindow       time.Duration
 	Checkers           int
 	Transfers          int
@@ -249,6 +251,7 @@ func LoadConfig() {
 	Config.ConnectTimeout = *connectTimeout
 	Config.CheckSum = *checkSum
 	Config.SizeOnly = *sizeOnly
+	Config.IgnoreExisting = *ignoreExisting
 	Config.DumpHeaders = *dumpHeaders
 	Config.DumpBodies = *dumpBodies
 	Config.InsecureSkipVerify = *skipVerify

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -281,6 +281,11 @@ func checkOne(pair ObjectPair, out ObjectPairChan) {
 	if !src.Storable() {
 		return
 	}
+	// If we should ignore existing files, don't transfer
+	if Config.IgnoreExisting {
+		Debug(src, "Destination exists, skipping")
+		return
+	}
 	// Check to see if changed or not
 	if Equal(src, dst) {
 		Debug(src, "Unchanged skipping")

--- a/fs/operations_test.go
+++ b/fs/operations_test.go
@@ -306,6 +306,31 @@ func TestSyncSizeOnly(t *testing.T) {
 	cleanTempDir(t)
 }
 
+func TestSyncIgnoreExisting(t *testing.T) {
+	WriteFile("existing", "potato", t1)
+	fs.Config.IgnoreExisting = true
+	err := fs.Sync(fremote, flocal)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	items := []fstest.Item{
+		{Path: "existing", Size: 6, ModTime: t1, Md5sum: "8ee2027983915ec78acc45027d874316"},
+	}
+	fstest.CheckListingWithPrecision(t, flocal, items, fs.Config.ModifyWindow)
+	fstest.CheckListingWithPrecision(t, fremote, items, fs.Config.ModifyWindow)
+
+	// Change everything
+	WriteFile("existing", "newpotatoes", t2)
+	err = fs.Sync(fremote, flocal)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	// Items should not change
+	fstest.CheckListingWithPrecision(t, fremote, items, fs.Config.ModifyWindow)
+	fs.Config.IgnoreExisting = false
+	cleanTempDir(t)
+}
+
 func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	WriteFile("empty space", "", t1)
 


### PR DESCRIPTION
Add option to completely ignore existing files and not consider them for transfer.

Fixes #274