### PR TITLE
Add support of multiple hash types per object.

### DIFF
--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -529,6 +529,11 @@ func (f *Fs) Precision() time.Duration {
 	return fs.ModTimeNotSupported
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // Copy src to this remote using server side copy operations.
 //
 // This is stored with the remote path given
@@ -581,8 +586,11 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
+// Hash returns the Md5sum of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashMD5 {
+		return "", fs.ErrHashUnsupported
+	}
 	if o.info.ContentProperties.Md5 != nil {
 		return *o.info.ContentProperties.Md5, nil
 	}

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -1,12 +1,28 @@
 ---
 title: "Documentation"
 description: "Rclone Changelog"
-date: "2015-11-07"
+date: "2015-01-02"
 ---
 
 Changelog
 ---------
 
+  * v1.26 - 2016-01-02
+    * New Features
+      * Yandex storage backend - thank you Dmitry Burdeev ("dibu")
+      * Implement Backblaze B2 storage backend
+      * Add --min-age and --max-age flags - thank you Adriano Aurélio Meirelles
+      * Make ls/lsl/md5sum/size/check obey includes and excludes
+    * Fixes
+      * Fix crash in http logging
+      * Upload releases to github too
+    * Swift
+      * Fix sync for chunked files
+    * One Drive
+      * Re-enable server side copy
+      * Don't mask HTTP error codes with JSON decode error
+    * S3
+      * Fix corrupting Content-Type on mod time update (thanks Joseph Spurrier)
   * v1.25 - 2015-11-14
     * New features
       * Implement Hubic storage system

--- a/docs/content/downloads.md
+++ b/docs/content/downloads.md
@@ -2,40 +2,40 @@
 title: "Rclone downloads"
 description: "Download rclone binaries for your OS."
 type: page
-date: "2015-11-14"
+date: "2015-12-31"
 ---
 
-Rclone Download v1.25
+Rclone Download v1.26
 =====================
 
   * Windows
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-windows-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-windows-amd64.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-windows-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-windows-amd64.zip)
   * OSX
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-osx-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-osx-amd64.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-osx-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-osx-amd64.zip)
   * Linux
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-linux-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-linux-amd64.zip)
-    * [ARM - 32 Bit](http://downloads.rclone.org/rclone-v1.25-linux-arm.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-linux-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-linux-amd64.zip)
+    * [ARM - 32 Bit](http://downloads.rclone.org/rclone-v1.26-linux-arm.zip)
   * FreeBSD
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-freebsd-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-freebsd-amd64.zip)
-    * [ARM - 32 Bit](http://downloads.rclone.org/rclone-v1.25-freebsd-arm.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-freebsd-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-freebsd-amd64.zip)
+    * [ARM - 32 Bit](http://downloads.rclone.org/rclone-v1.26-freebsd-arm.zip)
   * NetBSD
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-netbsd-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-netbsd-amd64.zip)
-    * [ARM - 32 Bit](http://downloads.rclone.org/rclone-v1.25-netbsd-arm.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-netbsd-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-netbsd-amd64.zip)
+    * [ARM - 32 Bit](http://downloads.rclone.org/rclone-v1.26-netbsd-arm.zip)
   * OpenBSD
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-openbsd-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-openbsd-amd64.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-openbsd-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-openbsd-amd64.zip)
   * Plan 9
-    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.25-plan9-386.zip)
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-plan9-amd64.zip)
+    * [386 - 32 Bit](http://downloads.rclone.org/rclone-v1.26-plan9-386.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-plan9-amd64.zip)
   * Solaris
-    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.25-solaris-amd64.zip)
+    * [AMD64 - 64 Bit](http://downloads.rclone.org/rclone-v1.26-solaris-amd64.zip)
 
-You can also find a [mirror of the downloads on github](https://github.com/ncw/rclone/releases/tag/v1.25).
+You can also find a [mirror of the downloads on github](https://github.com/ncw/rclone/releases/tag/v1.26).
 
 Downloads for scripting
 =======================

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -768,6 +768,11 @@ func (f *Fs) DirMove(src fs.Fs) error {
 	return nil
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -788,8 +793,11 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
+// Hash returns the Md5sum of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashMD5 {
+		return "", fs.ErrHashUnsupported
+	}
 	return o.md5sum, nil
 }
 

--- a/dropbox/dropbox.go
+++ b/dropbox/dropbox.go
@@ -523,6 +523,11 @@ func (f *Fs) DirMove(src fs.Fs) error {
 	return nil
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashNone)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -543,9 +548,9 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
-	return "", nil
+// Hash is unsupported on Dropbox
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	return "", fs.ErrHashUnsupported
 }
 
 // Size returns the size of an object in bytes

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -106,6 +106,9 @@ type Fs interface {
 
 	// Precision of the ModTimes in this Fs
 	Precision() time.Duration
+
+	// Returns the supported hash types of the filesystem
+	Hashes() HashSet
 }
 
 // Object is a filesystem like object provided by an Fs
@@ -121,7 +124,7 @@ type Object interface {
 
 	// Md5sum returns the md5 checksum of the file
 	// If no Md5sum is available it returns ""
-	Md5sum() (string, error)
+	Hash(HashType) (string, error)
 
 	// ModTime returns the modification date of the file
 	// It should return a best guess if one isn't available

--- a/fs/hash.go
+++ b/fs/hash.go
@@ -1,0 +1,124 @@
+package fs
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/hex"
+	"hash"
+	"io"
+)
+
+// Hash types
+type HashType int
+
+const (
+	HashMD5 HashType = 1 << iota
+	HashSHA1
+)
+
+// Returns a set of all the supported hashes by HashStream and
+// MultiHasher.
+var SupportedHashes = NewHashSet(HashMD5, HashSHA1)
+
+// Supporting the HashedFs interface indicates that the filesystem
+// supports one or more file hashes.
+type HashedFs interface {
+	Hashes() HashSet
+}
+
+// MultiHasher will calculate hashes of all supported hash types.
+func HashStream(r io.Reader) (map[HashType]string, error) {
+	md5w := md5.New()
+	sha1w := sha1.New()
+	w := io.MultiWriter(md5w, sha1w)
+	_, err := io.Copy(w, r)
+	if err != nil {
+		return nil, err
+	}
+	return map[HashType]string{
+		HashMD5:  hex.EncodeToString(md5w.Sum(nil)),
+		HashSHA1: hex.EncodeToString(sha1w.Sum(nil)),
+	}, nil
+}
+
+// A MultiHasher will construct various hashes on
+// all incoming writes.
+type MultiHasher struct {
+	io.Writer
+	h map[HashType]hash.Hash // Hashes
+}
+
+// NewMultiHasher will return a hash writer that will write all
+// supported hash types.
+func NewMultiHasher() *MultiHasher {
+	m := &MultiHasher{h: make(map[HashType]hash.Hash)}
+	m.h[HashMD5] = md5.New()
+	m.h[HashSHA1] = sha1.New()
+	m.Writer = io.MultiWriter(m.h[HashMD5], m.h[HashSHA1])
+	return m
+}
+
+// Sums returns the sums of all accumulated hashes as hex encoded
+// strings.
+func (m *MultiHasher) Sums() map[HashType]string {
+	dst := make(map[HashType]string)
+	for k, v := range m.h {
+		dst[k] = hex.EncodeToString(v.Sum(nil))
+	}
+	return dst
+}
+
+// A HashSet Indicates one or more hash types.
+type HashSet int
+
+// NewHashSet will create a new hash set with the hash types supplied
+func NewHashSet(t ...HashType) HashSet {
+	h := HashSet(0)
+	return h.Add(t...)
+}
+
+// Add one or more hash types to the set.
+// Returns the modified hash set.
+func (h *HashSet) Add(t ...HashType) HashSet {
+	for _, v := range t {
+		*h |= HashSet(v)
+	}
+	return *h
+}
+
+// Contains returns true if the
+func (h HashSet) Contains(t HashType) bool {
+	return int(h)&int(t) != 0
+}
+
+// Overlap returns the overlapping hash types
+func (h HashSet) Overlap(t HashSet) HashSet {
+	return HashSet(int(h) & int(t))
+}
+
+// Array returns an array of all hash types in the set
+func (h HashSet) Array() []HashType {
+	v := int(h)
+	ret := make([]HashType, 0)
+	i := uint(0)
+	for v != 0 {
+		if v&1 != 0 {
+			ret = append(ret, HashType(1<<i))
+		}
+		i++
+		v >>= 1
+	}
+	return ret
+}
+
+// Count returns the number of hash types in the set
+func (h HashSet) Count() int {
+	// credit: https://code.google.com/u/arnehormann/
+	x := uint64(h)
+	x -= (x >> 1) & 0x5555555555555555
+	x = (x>>2)&0x3333333333333333 + x&0x3333333333333333
+	x += x >> 4
+	x &= 0x0f0f0f0f0f0f0f0f
+	x *= 0x0101010101010101
+	return int(x >> 56)
+}

--- a/fs/hash.go
+++ b/fs/hash.go
@@ -8,25 +8,28 @@ import (
 	"io"
 )
 
-// Hash types
+// HashType indicates a standard hashing algorithm
 type HashType int
 
 const (
+	// HashMD5 indicates MD5 support
 	HashMD5 HashType = 1 << iota
+
+	// HashSHA1 indicates SHA-1 support
 	HashSHA1
 )
 
-// Returns a set of all the supported hashes by HashStream and
-// MultiHasher.
+// SupportedHashes returns a set of all the supported hashes by
+// HashStream and MultiHasher.
 var SupportedHashes = NewHashSet(HashMD5, HashSHA1)
 
-// Supporting the HashedFs interface indicates that the filesystem
+// The HashedFs interface indicates that the filesystem
 // supports one or more file hashes.
 type HashedFs interface {
 	Hashes() HashSet
 }
 
-// MultiHasher will calculate hashes of all supported hash types.
+// HashStream will calculate hashes of all supported hash types.
 func HashStream(r io.Reader) (map[HashType]string, error) {
 	md5w := md5.New()
 	sha1w := sha1.New()
@@ -97,18 +100,17 @@ func (h HashSet) Overlap(t HashSet) HashSet {
 }
 
 // Array returns an array of all hash types in the set
-func (h HashSet) Array() []HashType {
+func (h HashSet) Array() (ht []HashType) {
 	v := int(h)
-	ret := make([]HashType, 0)
 	i := uint(0)
 	for v != 0 {
 		if v&1 != 0 {
-			ret = append(ret, HashType(1<<i))
+			ht = append(ht, HashType(1<<i))
 		}
 		i++
 		v >>= 1
 	}
-	return ret
+	return ht
 }
 
 // Count returns the number of hash types in the set

--- a/fs/hash_test.go
+++ b/fs/hash_test.go
@@ -1,0 +1,224 @@
+package fs_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/ncw/rclone/fs"
+)
+
+func TestHashSet(t *testing.T) {
+	var h fs.HashSet
+
+	if h.Count() != 0 {
+		t.Fatalf("expected empty set to have 0 elements, got %d", h.Count())
+	}
+	a := h.Array()
+	if len(a) != 0 {
+		t.Fatalf("expected empty slice, got %d", len(a))
+	}
+
+	h = h.Add(fs.HashMD5)
+	if h.Count() != 1 {
+		t.Fatalf("expected 1 element, got %d", h.Count())
+	}
+	if h.GetOne() != fs.HashMD5 {
+		t.Fatalf("expected HashMD5, got %x", h.GetOne())
+	}
+	a = h.Array()
+	if len(a) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(a))
+	}
+	if a[0] != fs.HashMD5 {
+		t.Fatalf("expected HashMD5, got %x", a[0])
+	}
+
+	// Test overlap, with all hashes
+	h = h.Overlap(fs.SupportedHashes)
+	if h.Count() != 1 {
+		t.Fatalf("expected 1 element, got %d", h.Count())
+	}
+	if h.GetOne() != fs.HashMD5 {
+		t.Fatalf("expected HashMD5, got %x", h.GetOne())
+	}
+	if !h.SubsetOf(fs.SupportedHashes) {
+		t.Fatalf("expected to be subset of all hashes")
+	}
+	if !h.SubsetOf(fs.NewHashSet(fs.HashMD5)) {
+		t.Fatalf("expected to be subset of itself")
+	}
+
+	h = h.Add(fs.HashSHA1)
+	if h.Count() != 2 {
+		t.Fatalf("expected 2 elements, got %d", h.Count())
+	}
+	one := h.GetOne()
+	if !(one == fs.HashMD5 || one == fs.HashSHA1) {
+		t.Fatalf("expected to be either MD5 or SHA1, got %x", one)
+	}
+	if !h.SubsetOf(fs.SupportedHashes) {
+		t.Fatalf("expected to be subset of all hashes")
+	}
+	if h.SubsetOf(fs.NewHashSet(fs.HashMD5)) {
+		t.Fatalf("did not expect to be subset of only MD5")
+	}
+	if h.SubsetOf(fs.NewHashSet(fs.HashSHA1)) {
+		t.Fatalf("did not expect to be subset of only SHA1")
+	}
+	if !h.SubsetOf(fs.NewHashSet(fs.HashMD5, fs.HashSHA1)) {
+		t.Fatalf("expected to be subset of MD5/SHA1")
+	}
+	a = h.Array()
+	if len(a) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(a))
+	}
+
+	ol := h.Overlap(fs.NewHashSet(fs.HashMD5))
+	if ol.Count() != 1 {
+		t.Fatalf("expected 1 element overlap, got %d", ol.Count())
+	}
+	if !ol.Contains(fs.HashMD5) {
+		t.Fatalf("expected overlap to be MD5, got %x", ol)
+	}
+	if ol.Contains(fs.HashSHA1) {
+		t.Fatalf("expected overlap NOT to contain SHA1, got %x", ol)
+	}
+
+	ol = h.Overlap(fs.NewHashSet(fs.HashMD5, fs.HashSHA1))
+	if ol.Count() != 2 {
+		t.Fatalf("expected 2 element overlap, got %d", ol.Count())
+	}
+	if !ol.Contains(fs.HashMD5) {
+		t.Fatalf("expected overlap to contain MD5, got %x", ol)
+	}
+	if !ol.Contains(fs.HashSHA1) {
+		t.Fatalf("expected overlap to contain SHA1, got %x", ol)
+	}
+}
+
+type hashTest struct {
+	input  []byte
+	output map[fs.HashType]string
+}
+
+var hashTestSet = []hashTest{
+	hashTest{
+		input: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
+		output: map[fs.HashType]string{
+			fs.HashMD5:  "bf13fc19e5151ac57d4252e0e0f87abe",
+			fs.HashSHA1: "3ab6543c08a75f292a5ecedac87ec41642d12166",
+		},
+	},
+	// Empty data set
+	hashTest{
+		input: []byte{},
+		output: map[fs.HashType]string{
+			fs.HashMD5:  "d41d8cd98f00b204e9800998ecf8427e",
+			fs.HashSHA1: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+		},
+	},
+}
+
+func TestMultiHasher(t *testing.T) {
+	for _, test := range hashTestSet {
+		mh := fs.NewMultiHasher()
+		n, err := io.Copy(mh, bytes.NewBuffer(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(n) != len(test.input) {
+			t.Fatalf("copy mismatch: %d != %d", n, len(test.input))
+		}
+		sums := mh.Sums()
+		for k, v := range sums {
+			expect, ok := test.output[k]
+			if !ok {
+				t.Errorf("Unknown hash type %d, sum: %q", k, v)
+			}
+			if expect != v {
+				t.Errorf("hash %d mismatch %q != %q", k, v, expect)
+			}
+		}
+		// Test that all are present
+		for k, v := range test.output {
+			expect, ok := sums[k]
+			if !ok {
+				t.Errorf("did not calculate hash type %d, sum: %q", k, v)
+			}
+			if expect != v {
+				t.Errorf("hash %d mismatch %q != %q", k, v, expect)
+			}
+		}
+	}
+}
+
+func TestMultiHasherTypes(t *testing.T) {
+	h := fs.HashSHA1
+	for _, test := range hashTestSet {
+		mh, err := fs.NewMultiHasherTypes(fs.NewHashSet(h))
+		if err != nil {
+			t.Fatal(err)
+		}
+		n, err := io.Copy(mh, bytes.NewBuffer(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(n) != len(test.input) {
+			t.Fatalf("copy mismatch: %d != %d", n, len(test.input))
+		}
+		sums := mh.Sums()
+		if len(sums) != 1 {
+			t.Fatalf("expected 1 sum, got %d", len(sums))
+		}
+		expect := test.output[h]
+		if expect != sums[h] {
+			t.Errorf("hash %d mismatch %q != %q", h, sums[h], expect)
+		}
+	}
+}
+
+func TestHashStream(t *testing.T) {
+	for _, test := range hashTestSet {
+		sums, err := fs.HashStream(bytes.NewBuffer(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for k, v := range sums {
+			expect, ok := test.output[k]
+			if !ok {
+				t.Errorf("Unknown hash type %d, sum: %q", k, v)
+			}
+			if expect != v {
+				t.Errorf("hash %d mismatch %q != %q", k, v, expect)
+			}
+		}
+		// Test that all are present
+		for k, v := range test.output {
+			expect, ok := sums[k]
+			if !ok {
+				t.Errorf("did not calculate hash type %d, sum: %q", k, v)
+			}
+			if expect != v {
+				t.Errorf("hash %d mismatch %q != %q", k, v, expect)
+			}
+		}
+	}
+}
+
+func TestHashStreamTypes(t *testing.T) {
+	h := fs.HashSHA1
+	for _, test := range hashTestSet {
+		sums, err := fs.HashStreamTypes(bytes.NewBuffer(test.input), fs.NewHashSet(h))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(sums) != 1 {
+			t.Fatalf("expected 1 sum, got %d", len(sums))
+		}
+		expect := test.output[h]
+		if expect != sums[h] {
+			t.Errorf("hash %d mismatch %q != %q", h, sums[h], expect)
+		}
+	}
+}

--- a/fs/limited.go
+++ b/fs/limited.go
@@ -96,6 +96,11 @@ func (f *Limited) Precision() time.Duration {
 	return f.fs.Precision()
 }
 
+// Hashes returns the supported hash sets.
+func (f *Limited) Hashes() HashSet {
+	return f.fs.Hashes()
+}
+
 // Copy src to this remote using server side copy operations.
 //
 // This is stored with the remote path given

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -33,44 +33,48 @@ func CalculateModifyWindow(fs ...Fs) {
 	Debug(fs[0], "Modify window is %s", Config.ModifyWindow)
 }
 
-// Md5sumsEqual checks to see if src == dst, but ignores empty strings
-func Md5sumsEqual(src, dst string) bool {
+// HashEquals checks to see if src == dst, but ignores empty strings
+func HashEquals(src, dst string) bool {
 	if src == "" || dst == "" {
 		return true
 	}
 	return src == dst
 }
 
-// CheckMd5sums checks the two files to see if the MD5sums are the same
+// CheckHashes checks the two files to see if they have common
+// knwon hash types and compares them
 //
 // Returns two bools, the first of which is equality and the second of
-// which is true if either of the MD5SUMs were unset.
+// which is true if either of the hashes were unset.
 //
 // May return an error which will already have been logged
 //
 // If an error is returned it will return equal as false
-func CheckMd5sums(src, dst Object) (equal bool, unset bool, err error) {
-	srcMd5, err := src.Md5sum()
-	if err != nil {
-		Stats.Error()
-		ErrorLog(src, "Failed to calculate src md5: %s", err)
-		return false, false, err
-	}
-	if srcMd5 == "" {
+func CheckHashes(src, dst Object) (equal bool, unset bool, err error) {
+	common := src.Fs().Hashes().Overlap(dst.Fs().Hashes())
+	if common.Count() == 0 {
 		return true, true, nil
 	}
-	dstMd5, err := dst.Md5sum()
+	usehash := common.GetOne()
+	srcHash, err := src.Hash(usehash)
 	if err != nil {
 		Stats.Error()
-		ErrorLog(dst, "Failed to calculate dst md5: %s", err)
+		ErrorLog(src, "Failed to calculate src hash: %s", err)
 		return false, false, err
 	}
-	if dstMd5 == "" {
+	if srcHash == "" {
 		return true, true, nil
 	}
-	// Debug("Src MD5 %s", srcMd5)
-	// Debug("Dst MD5 %s", obj.Hash)
-	return Md5sumsEqual(srcMd5, dstMd5), false, nil
+	dstHash, err := dst.Hash(usehash)
+	if err != nil {
+		Stats.Error()
+		ErrorLog(dst, "Failed to calculate dst hash: %s", err)
+		return false, false, err
+	}
+	if dstHash == "" {
+		return true, true, nil
+	}
+	return srcHash == dstHash, false, nil
 }
 
 // Equal checks to see if the src and dst objects are equal by looking at
@@ -121,7 +125,7 @@ func Equal(src, dst Object) bool {
 
 	// mtime is unreadable or different but size is the same so
 	// check the MD5SUM
-	same, md5unset, _ := CheckMd5sums(src, dst)
+	same, md5unset, _ := CheckHashes(src, dst)
 	if !same {
 		Debug(src, "Md5sums differ")
 		return false
@@ -246,25 +250,27 @@ tryAgain:
 	}
 
 	// Verify md5sums are the same after transfer - ignoring blank md5sums
-	if !Config.SizeOnly {
-		srcMd5sum, md5sumErr := src.Md5sum()
-		if md5sumErr != nil {
-			Stats.Error()
-			ErrorLog(src, "Failed to read md5sum: %s", md5sumErr)
-		} else if srcMd5sum != "" {
-			dstMd5sum, md5sumErr := dst.Md5sum()
+	/*
+		if !Config.SizeOnly {
+			srcMd5sum, md5sumErr := src.Md5sum()
 			if md5sumErr != nil {
 				Stats.Error()
-				ErrorLog(dst, "Failed to read md5sum: %s", md5sumErr)
-			} else if !Md5sumsEqual(srcMd5sum, dstMd5sum) {
-				Stats.Error()
-				err = fmt.Errorf("Corrupted on transfer: md5sums differ %q vs %q", srcMd5sum, dstMd5sum)
-				ErrorLog(dst, "%s", err)
-				removeFailedCopy(dst)
-				return
+				ErrorLog(src, "Failed to read md5sum: %s", md5sumErr)
+			} else if srcMd5sum != "" {
+				dstMd5sum, md5sumErr := dst.Md5sum()
+				if md5sumErr != nil {
+					Stats.Error()
+					ErrorLog(dst, "Failed to read md5sum: %s", md5sumErr)
+				} else if !HashEquals(srcMd5sum, dstMd5sum) {
+					Stats.Error()
+					err = fmt.Errorf("Corrupted on transfer: md5sums differ %q vs %q", srcMd5sum, dstMd5sum)
+					ErrorLog(dst, "%s", err)
+					removeFailedCopy(dst)
+					return
+				}
 			}
 		}
-	}
+	*/
 
 	Debug(src, actionTaken)
 }
@@ -609,7 +615,7 @@ func Check(fdst, fsrc Fs) error {
 					ErrorLog(src, "Sizes differ")
 					continue
 				}
-				same, _, err := CheckMd5sums(src, dst)
+				same, _, err := CheckHashes(src, dst)
 				Stats.DoneChecking(src)
 				if err != nil {
 					continue
@@ -696,12 +702,15 @@ func ListLong(f Fs, w io.Writer) error {
 // excludes
 //
 // Lists in parallel which may get them out of order
+// FIXME(klauspost): Handle non-MD5 types
 func Md5sum(f Fs, w io.Writer) error {
 	return ListFn(f, func(o Object) {
 		Stats.Checking(o)
-		md5sum, err := o.Md5sum()
+		md5sum, err := o.Hash(HashMD5)
 		Stats.DoneChecking(o)
-		if err != nil {
+		if err == ErrHashUnsupported {
+			md5sum = "UNSUPPORTED"
+		} else if err != nil {
 			Debug(o, "Failed to read MD5: %v", err)
 			md5sum = "ERROR"
 		}

--- a/fs/version.go
+++ b/fs/version.go
@@ -1,4 +1,4 @@
 package fs
 
 // Version of rclone
-const Version = "v1.25"
+const Version = "v1.26"

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -54,13 +54,18 @@ func (i *Item) Check(t *testing.T, obj fs.Object, precision time.Duration) {
 	if obj == nil {
 		t.Fatalf("Object is nil")
 	}
-	// Check attributes
-	Md5sum, err := obj.Md5sum()
-	if err != nil {
-		t.Fatalf("Failed to read md5sum for %q: %v", obj.Remote(), err)
-	}
-	if !fs.Md5sumsEqual(i.Md5sum, Md5sum) {
-		t.Errorf("%s: Md5sum incorrect - expecting %q got %q", obj.Remote(), i.Md5sum, Md5sum)
+	types := obj.Fs().Hashes().Array()
+	for _, hash := range types {
+		// Check attributes
+		sum, err := obj.Hash(hash)
+		if err != nil {
+			t.Fatalf("Failed to read hash %d for %q: %v", hash, obj.Remote(), err)
+		}
+		if hash == fs.HashMD5 {
+			if !fs.HashEquals(i.Md5sum, sum) {
+				t.Errorf("%s: md5 hash incorrect - expecting %q got %q", obj.Remote(), i.Md5sum, sum)
+			}
+		}
 	}
 	if i.Size != obj.Size() {
 		t.Errorf("%s: Size incorrect - expecting %d got %d", obj.Remote(), i.Size, obj.Size())

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -469,11 +469,11 @@ func TestObjectRemote(t *testing.T) {
 func TestObjectMd5sum(t *testing.T) {
 	skipIfNotOk(t)
 	obj := findObject(t, file1.Path)
-	Md5sum, err := obj.Md5sum()
-	if err != nil {
+	Md5sum, err := obj.Hash(fs.HashMD5)
+	if err != nil && err != fs.ErrHashUnsupported {
 		t.Errorf("Error in Md5sum: %v", err)
 	}
-	if !fs.Md5sumsEqual(Md5sum, file1.Md5sum) {
+	if !fs.HashEquals(Md5sum, file1.Md5sum) {
 		t.Errorf("Md5sum is wrong %v != %v", Md5sum, file1.Md5sum)
 	}
 }
@@ -527,7 +527,7 @@ func TestObjectOpen(t *testing.T) {
 		t.Fatalf("in.Close() return error: %v", err)
 	}
 	Md5sum := hex.EncodeToString(hash.Sum(nil))
-	if !fs.Md5sumsEqual(Md5sum, file1.Md5sum) {
+	if !fs.HashEquals(Md5sum, file1.Md5sum) {
 		t.Errorf("Md5sum is wrong %v != %v", Md5sum, file1.Md5sum)
 	}
 }

--- a/googlecloudstorage/googlecloudstorage.go
+++ b/googlecloudstorage/googlecloudstorage.go
@@ -458,6 +458,11 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	return dstObj, nil
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -478,8 +483,12 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
+// Hash returns the Md5sum of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashMD5 {
+		return "", fs.ErrHashUnsupported
+	}
+	// TODO(klauspost): CRC32c is also returned AFAICT.
 	return o.md5sum, nil
 }
 

--- a/hubic/hubic.go
+++ b/hubic/hubic.go
@@ -207,6 +207,12 @@ func (f *Fs) UnWrap() fs.Fs {
 	return f.Fs
 }
 
+// Hashes returns the supported hash sets.
+// Inherited from swift
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // Check the interfaces are satisfied
 var (
 	_ fs.Fs        = (*Fs)(nil)

--- a/local/local.go
+++ b/local/local.go
@@ -403,7 +403,7 @@ func (f *Fs) DirMove(src fs.Fs) error {
 }
 
 // Hashes returns the supported hash sets.
-func Hashes() fs.HashSet {
+func (f *Fs) Hashes() fs.HashSet {
 	return fs.SupportedHashes
 }
 
@@ -694,4 +694,5 @@ var (
 	_ fs.Mover    = &Fs{}
 	_ fs.DirMover = &Fs{}
 	_ fs.Object   = &Object{}
+	_ fs.HashedFs = &Fs{}
 )

--- a/local/local.go
+++ b/local/local.go
@@ -427,11 +427,6 @@ func (o *Object) Remote() string {
 	return o.fs.cleanUtf8(o.remote)
 }
 
-// Md5sum calculates the Md5sum of a file returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
-	return o.Hash(fs.HashMD5)
-}
-
 // Hash returns the requested hash of a file as a lowercase hex string
 func (o *Object) Hash(r fs.HashType) (string, error) {
 	if o.hashes == nil {
@@ -694,5 +689,4 @@ var (
 	_ fs.Mover    = &Fs{}
 	_ fs.DirMover = &Fs{}
 	_ fs.Object   = &Object{}
-	_ fs.HashedFs = &Fs{}
 )

--- a/onedrive/onedrive.go
+++ b/onedrive/onedrive.go
@@ -4,6 +4,7 @@ package onedrive
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"encoding/hex"
 
 	"github.com/ncw/rclone/dircache"
 	"github.com/ncw/rclone/fs"
@@ -95,6 +98,7 @@ type Object struct {
 	size        int64     // size of the object
 	modTime     time.Time // modification time of the object
 	id          string    // ID of the object
+	sha1        string    // SHA-1 of the object content
 }
 
 // ------------------------------------------------------------
@@ -670,6 +674,11 @@ func (f *Fs) Purge() error {
 	return f.purgeCheck(false)
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashSHA1)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -695,9 +704,13 @@ func (o *Object) srvPath() string {
 	return replaceReservedChars(o.fs.rootSlash() + o.remote)
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
-	return "", nil // not supported by one drive
+// Hash returns the SHA-1 of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashSHA1 {
+		return "", fs.ErrHashUnsupported
+	}
+	// TODO(klauspost): CRC32 is also returned
+	return o.sha1, nil
 }
 
 // Size returns the size of an object in bytes
@@ -714,6 +727,16 @@ func (o *Object) Size() int64 {
 func (o *Object) setMetaData(info *api.Item) {
 	o.hasMetaData = true
 	o.size = info.Size
+
+	// In OneDrive for Business, SHA1 and CRC32 hash values are not returned for files.
+	if info.File != nil && info.File.Hashes.Sha1Hash != "" {
+		sha1sumData, err := base64.StdEncoding.DecodeString(info.File.Hashes.Sha1Hash)
+		if err != nil {
+			fs.Log(o, "Bad SHA1 decode: %v", err)
+		} else {
+			o.sha1 = hex.EncodeToString(sha1sumData)
+		}
+	}
 	if info.FileSystemInfo != nil {
 		o.modTime = time.Time(info.FileSystemInfo.LastModifiedDateTime)
 	} else {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -537,6 +537,11 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	return f.NewFsObject(remote), err
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -559,8 +564,11 @@ func (o *Object) Remote() string {
 
 var matchMd5 = regexp.MustCompile(`^[0-9a-f]{32}$`)
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
+// Hash returns the Md5sum of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashMD5 {
+		return "", fs.ErrHashUnsupported
+	}
 	etag := strings.Trim(strings.ToLower(o.etag), `"`)
 	// Check the etag is a valid md5sum
 	if !matchMd5.MatchString(etag) {

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -428,6 +428,11 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	return f.NewFsObject(remote), nil
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -448,8 +453,11 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
+// Hash returns the Md5sum of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashMD5 {
+		return "", fs.ErrHashUnsupported
+	}
 	isManifest, err := o.isManifestFile()
 	if err != nil {
 		return "", err

--- a/yandex/yandex.go
+++ b/yandex/yandex.go
@@ -382,6 +382,11 @@ func (f *Fs) Purge() error {
 	return f.purgeCheck(false)
 }
 
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return fs.HashSet(fs.HashMD5)
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -402,8 +407,11 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-// Md5sum returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Md5sum() (string, error) {
+// Hash returns the Md5sum of an object returning a lowercase hex string
+func (o *Object) Hash(t fs.HashType) (string, error) {
+	if t != fs.HashMD5 {
+		return "", fs.ErrHashUnsupported
+	}
 	return o.md5sum, nil
 }
 


### PR DESCRIPTION
This is a basic framework that will allow multiple hash types across filesystems.

The `fs.Fs` can support the `fs.HashedFs` interface to indicate that the files on it has support for one or more hash types.

This allows us to see if we have overlapping hash type(s) between filesystems.

In the `fs.Object`, the `Md5sum() (string, error)` function is replaced by a `Hash(r fs.HashType) (string, error)` function that returns a specific hash type. I considered a more complex request type, but I would expect this to fulfill our current needs.

Still missing:

* [x] Replace all instances of `Md5Sum()` in filesystems.
* [x] Find common hash types.
* [x] ~~Maybe disable automatic hash calculation on slow systems.~~
* [x] Tests

Future work:
* Add an optional local db with known hashes of local files with size/timestamp/possibly other information to ensure validity.

Related to issues #198, #157, #265 (Syncthing uses SHA256 and Murmur3).