### PR TITLE
Remove errcheck to fix CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ go:
 
 install:
  - go get ./...
- - go get -u github.com/kisielk/errcheck
  - go get -u golang.org/x/tools/cmd/goimports
  - go get -u github.com/golang/lint/golint
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ test:	rclone
 
 check:	rclone
 	go vet ./...
-	errcheck ./...
 	goimports -d . | grep . ; test $$? -eq 1
 	golint ./... | grep -E -v '(StorageUrl|CdnUrl)' ; test $$? -eq 1
 


### PR DESCRIPTION
I don't know if the author want to fix it:

See https://github.com/kisielk/errcheck/issues/89

We can always re-add it in a year, when 1.4 is long gone, or we can fork it in the meantime, if it is that important.