### PR TITLE
Log source duplicates after normalize+lower casing.

### DIFF
--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -427,7 +427,7 @@ var _ io.ReadCloser = &Account{}
 // logCaseDupes will print out all duplicates encountered
 // in the object stream.
 func logCaseDupes(in ObjectsChan) (out ObjectsChan) {
-	out = make(ObjectsChan, len(in))
+	out = make(ObjectsChan, cap(in))
 	go func() {
 		// We could trade a little speed for a little memory and store SHA1 for instance.
 		var found = make(map[string]struct{})
@@ -436,7 +436,7 @@ func logCaseDupes(in ObjectsChan) (out ObjectsChan) {
 			lname := strings.ToLower(norm.NFC.String(name))
 			_, ok := found[lname]
 			if ok {
-				Log(o.Fs(), "Warning: Found file with same name, but different case at %q", name)
+				Debug(o.Fs(), "Warning: Found file with same name, but different case at %q", name)
 			}
 			out <- o
 			found[lname] = struct{}{}

--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/VividCortex/ewma"
 	"github.com/tsenart/tb"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Globals
@@ -422,3 +423,25 @@ func (file *Account) Close() error {
 
 // Check it satisfies the interface
 var _ io.ReadCloser = &Account{}
+
+// logCaseDupes will print out all duplicates encountered
+// in the object stream.
+func logCaseDupes(in ObjectsChan) (out ObjectsChan) {
+	out = make(ObjectsChan, len(in))
+	go func() {
+		// We could trade a little speed for a little memory and store SHA1 for instance.
+		var found = make(map[string]struct{})
+		for o := range in {
+			name := o.Remote()
+			lname := strings.ToLower(norm.NFC.String(name))
+			_, ok := found[lname]
+			if ok {
+				Log(o.Fs(), "Warning: Found file with same name, but different case at %q", name)
+			}
+			out <- o
+			found[lname] = struct{}{}
+		}
+		close(out)
+	}()
+	return
+}

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -454,7 +454,8 @@ func syncCopyMove(fdst, fsrc Fs, Delete bool, DoMove bool) error {
 	}
 
 	go func() {
-		for src := range fsrc.List() {
+		osrc := logCaseDupes(fsrc.List())
+		for src := range osrc {
 			if !Config.Filter.IncludeObject(src) {
 				Debug(src, "Excluding from sync")
 			} else {


### PR DESCRIPTION
Takes an input stream of file objects, and ensures that it hasn't been encountered before.

Relates to #107 & #119.

This does not detect where a file on src is present on dst, but with another case. This can be handled easier after merging #293.