### PR TITLE
Refactor List/ListDir

### DIFF
--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -337,7 +337,7 @@ OUTER:
 //
 // This fetches the minimum amount of stuff but does more API calls
 // which makes it slow
-func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) error {
+func (f *Fs) listDirRecursive(dirID string, path string, out fs.ListOpts) error {
 	var subError error
 	// Make the API request
 	var wg sync.WaitGroup
@@ -352,6 +352,7 @@ func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) err
 				defer wg.Done()
 				err := f.listDirRecursive(*node.Id, folder, out)
 				if err != nil {
+					out.SetError(err)
 					subError = err
 					fs.ErrorLog(f, "Error reading %s:%s", folder, err)
 				}
@@ -359,7 +360,9 @@ func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) err
 			return false
 		case fileKind:
 			if fs := f.newFsObjectWithInfo(path+*node.Name, node); fs != nil {
-				out <- fs
+				if out.Add(fs) {
+					return true
+				}
 			}
 		default:
 			// ignore ASSET etc
@@ -369,6 +372,7 @@ func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) err
 	wg.Wait()
 	fs.Debug(f, "Finished reading %s", path)
 	if err != nil {
+		out.SetError(err)
 		return err
 	}
 	if subError != nil {
@@ -378,52 +382,50 @@ func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) err
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
-	go func() {
-		defer close(out)
-		err := f.dirCache.FindRoot(false)
+func (f *Fs) List(out fs.ListOpts) {
+	defer out.Finished()
+	err := f.dirCache.FindRoot(false)
+	if err != nil {
+		out.SetError(err)
+		fs.Stats.Error()
+		fs.ErrorLog(f, "Couldn't find root: %s", err)
+	} else {
+		err = f.listDirRecursive(f.dirCache.RootID(), "", out)
 		if err != nil {
+			out.SetError(err)
 			fs.Stats.Error()
-			fs.ErrorLog(f, "Couldn't find root: %s", err)
-		} else {
-			err = f.listDirRecursive(f.dirCache.RootID(), "", out)
-			if err != nil {
-				fs.Stats.Error()
-				fs.ErrorLog(f, "List failed: %s", err)
-			}
+			fs.ErrorLog(f, "List failed: %s", err)
 		}
-	}()
-	return out
+	}
 }
 
 // ListDir lists the directories
-func (f *Fs) ListDir() fs.DirChan {
-	out := make(fs.DirChan, fs.Config.Checkers)
-	go func() {
-		defer close(out)
-		err := f.dirCache.FindRoot(false)
-		if err != nil {
-			fs.Stats.Error()
-			fs.ErrorLog(f, "Couldn't find root: %s", err)
-		} else {
-			_, err := f.listAll(f.dirCache.RootID(), "", true, false, func(item *acd.Node) bool {
-				dir := &fs.Dir{
-					Name:  *item.Name,
-					Bytes: -1,
-					Count: -1,
-				}
-				dir.When, _ = time.Parse(timeFormat, *item.ModifiedDate)
-				out <- dir
-				return false
-			})
-			if err != nil {
-				fs.Stats.Error()
-				fs.ErrorLog(f, "ListDir failed: %s", err)
+func (f *Fs) ListDir(out fs.ListDirOpts) {
+	defer out.Finished()
+	err := f.dirCache.FindRoot(false)
+	if err != nil {
+		out.SetError(err)
+		fs.Stats.Error()
+		fs.ErrorLog(f, "Couldn't find root: %s", err)
+	} else {
+		_, err := f.listAll(f.dirCache.RootID(), "", true, false, func(item *acd.Node) bool {
+			dir := &fs.Dir{
+				Name:  *item.Name,
+				Bytes: -1,
+				Count: -1,
 			}
+			dir.When, _ = time.Parse(timeFormat, *item.ModifiedDate)
+			if out.Add(dir) {
+				return true
+			}
+			return false
+		})
+		if err != nil {
+			out.SetError(err)
+			fs.Stats.Error()
+			fs.ErrorLog(f, "ListDir failed: %s", err)
 		}
-	}()
-	return out
+	}
 }
 
 // Put the object into the container

--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -345,9 +345,18 @@ func (f *Fs) listDirRecursive(dirID string, path string, out fs.ListOpts) error 
 		// Recurse on directories
 		switch *node.Kind {
 		case folderKind:
-			wg.Add(1)
 			folder := path + *node.Name + "/"
 			fs.Debug(f, "Reading %s", folder)
+			dir := &fs.Dir{
+				Name:  *node.Name,
+				Bytes: -1,
+				Count: -1,
+			}
+			dir.When, _ = time.Parse(timeFormat, *node.ModifiedDate)
+			if out.AddDir(dir) {
+				return true
+			}
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				err := f.listDirRecursive(*node.Id, folder, out)
@@ -399,6 +408,7 @@ func (f *Fs) List(out fs.ListOpts) {
 	}
 }
 
+/*
 // ListDir lists the directories
 func (f *Fs) ListDir(out fs.ListDirOpts) {
 	defer out.Finished()
@@ -427,7 +437,7 @@ func (f *Fs) ListDir(out fs.ListDirOpts) {
 		}
 	}
 }
-
+*/
 // Put the object into the container
 //
 // Copy the reader in to the new object which is returned

--- a/b2/b2.go
+++ b/b2/b2.go
@@ -319,9 +319,19 @@ func (f *Fs) list(prefix string, limit int, hidden bool, fn listFn) error {
 func (f *Fs) List(out fs.ListOpts) {
 	defer out.Finished()
 	if f.bucket == "" {
-		out.SetError(fmt.Errorf("Can't list objects at root - choose a bucket using lsd"))
-		// Return no objects at top level list
-		fs.Stats.Error()
+		err := f.listBuckets(func(bucket *api.Bucket) {
+			out.AddDir(&fs.Dir{
+				Name:  bucket.Name,
+				Bytes: -1,
+				Count: -1,
+			})
+		})
+
+		if err != nil {
+			out.SetError(err)
+			// Return no objects at top level list
+			fs.Stats.Error()
+		}
 		return
 	}
 	// List the objects
@@ -395,6 +405,7 @@ func (f *Fs) clearBucketID() {
 	f.bucketIDMutex.Unlock()
 }
 
+/*
 // ListDir lists the buckets
 func (f *Fs) ListDir(out fs.ListDirOpts) {
 	defer out.Finished()
@@ -439,6 +450,7 @@ func (f *Fs) ListDir(out fs.ListDirOpts) {
 		}
 	}
 }
+*/
 
 // Put the object into the bucket
 //

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -360,7 +360,7 @@ func (f *Fs) CreateDir(pathID, leaf string) (newID string, err error) {
 //
 // This fetches the minimum amount of stuff but does more API calls
 // which makes it slow
-func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) error {
+func (f *Fs) listDirRecursive(dirID string, path string, out fs.ListOpts) error {
 	var subError error
 	// Make the API request
 	var wg sync.WaitGroup
@@ -418,7 +418,7 @@ func isAuthOwned(item *drive.File) bool {
 //
 // This is fast in terms of number of API calls, but slow in terms of
 // fetching more data than it needs
-func (f *Fs) listDirFull(dirID string, path string, out fs.ObjectsChan) error {
+func (f *Fs) listDirFull(dirID string, path string, out fs.ListOpts) error {
 	// Orphans waiting for their parent
 	orphans := make(map[string][]*drive.File)
 
@@ -483,8 +483,8 @@ func (f *Fs) listDirFull(dirID string, path string, out fs.ObjectsChan) error {
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) List() fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	go func() {
 		defer close(out)
 		err := f.dirCache.FindRoot(false)

--- a/dropbox/dropbox.go
+++ b/dropbox/dropbox.go
@@ -239,7 +239,7 @@ func (f *Fs) stripRoot(path string) *string {
 }
 
 // Walk the root returning a channel of FsObjects
-func (f *Fs) list(out fs.ObjectsChan) {
+func (f *Fs) list(out fs.ListOpts) {
 	// Track path component case, it could be different for entries coming from DropBox API
 	// See https://www.dropboxforum.com/hc/communities/public/questions/201665409-Wrong-character-case-of-folder-name-when-calling-listFolder-using-Sync-API?locale=en-us
 	// and https://github.com/ncw/rclone/issues/53
@@ -318,8 +318,8 @@ func (f *Fs) list(out fs.ObjectsChan) {
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) List() fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	go func() {
 		defer close(out)
 		f.list(out)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -79,11 +79,8 @@ type Fs interface {
 	// String returns a description of the FS
 	String() string
 
-	// List the Fs into a channel
+	// List the objects and directories of the Fs
 	List(ListOpts)
-
-	// ListDir lists the Fs directories/buckets/containers into a channel
-	ListDir(ListDirOpts)
 
 	// NewFsObject finds the Object at remote.  Returns nil if can't be found
 	NewFsObject(remote string) Object
@@ -208,27 +205,16 @@ type UnWrapper interface {
 // ObjectsChan is a channel of Objects
 type ObjectsChan chan Object
 
-type ListDirOpts interface {
-	// Add an object to the output.
-	// If the function returns true, the operation has been aborted.
-	// Multiple goroutines can safely add objects concurrently.
-	Add(dir *Dir) (abort bool)
-
-	// SetError will set an error state, and will cause the listing to
-	// be aborted.
-	// Multiple goroutines can set the error state concurrently,
-	// but only the first will be returned to the caller.
-	SetError(err error)
-
-	// Finished should be called when listing is finished
-	Finished()
-}
-
 type ListOpts interface {
 	// Add an object to the output.
 	// If the function returns true, the operation has been aborted.
 	// Multiple goroutines can safely add objects concurrently.
 	Add(obj Object) (abort bool)
+
+	// Add a directory to the output.
+	// If the function returns true, the operation has been aborted.
+	// Multiple goroutines can safely add objects concurrently.
+	AddDir(dir *Dir) (abort bool)
 
 	// SetError will set an error state, and will cause the listing to
 	// be aborted.
@@ -246,6 +232,7 @@ var ErrListAborted = fmt.Errorf("List aborted")
 // results back to the caller.
 type listOpts struct {
 	objects  chan Object
+	dirs     chan *Dir
 	errors   chan error
 	abort    chan struct{}
 	finished sync.Once
@@ -254,6 +241,7 @@ type listOpts struct {
 func newListOpts(buffer int) *listOpts {
 	return &listOpts{
 		objects: make(chan Object, buffer),
+		dirs:    make(chan *Dir, buffer),
 		errors:  make(chan error, 0),
 		abort:   make(chan struct{}, 0),
 	}
@@ -267,6 +255,18 @@ func (o *listOpts) Add(obj Object) (abort bool) {
 	case <-o.abort:
 		return true
 	case o.objects <- obj:
+		return false
+	}
+}
+
+// AddDir will a directory to the output.
+// If the function returns true, the operation has been aborted.
+// Multiple goroutines can safely add objects concurrently.
+func (o *listOpts) AddDir(dir *Dir) (abort bool) {
+	select {
+	case <-o.abort:
+		return true
+	case o.dirs <- dir:
 		return false
 	}
 }
@@ -290,105 +290,34 @@ func (o *listOpts) SetError(err error) {
 func (o *listOpts) Finished() {
 	o.finished.Do(func() {
 		close(o.objects)
+		close(o.dirs)
 	})
 }
 
-// get an object from the listing.
-// Will return (nil, nil) when all objects have been returned.
-func (o *listOpts) Get() (Object, error) {
+// Get an object from the listing.
+// Will return either an object or a directory, never both.
+// Will return (nil, nil, nil) when all objects have been returned.
+func (o *listOpts) Get() (Object, *Dir, error) {
 	select {
 	case <-o.abort:
-		return nil, ErrListAborted
+		return nil, nil, ErrListAborted
 	case err := <-o.errors:
 		close(o.abort)
-		return nil, err
+		return nil, nil, err
 	default:
 	}
 
 	// No error, or aborted, attempt to fetch an object.
 	select {
 	case obj := <-o.objects:
-		return obj, nil
+		return obj, nil, nil
+	case dir := <-o.dirs:
+		return nil, dir, nil
 	case err := <-o.errors:
 		close(o.abort)
-		return nil, err
+		return nil, nil, err
 	case <-o.abort:
-		return nil, ErrListAborted
-	}
-}
-
-// dirListOpts provides list options and channels
-// results back to the caller.
-type listDirOpts struct {
-	objects  chan *Dir
-	errors   chan error
-	abort    chan struct{}
-	finished sync.Once
-}
-
-func newListDirOpts(buffer int) *listDirOpts {
-	return &listDirOpts{
-		objects: make(chan *Dir, buffer),
-		errors:  make(chan error, 0),
-		abort:   make(chan struct{}, 0),
-	}
-}
-
-// Add an object to the output.
-// If the function returns true, the operation has been aborted.
-// Multiple goroutines can safely add objects concurrently.
-func (o *listDirOpts) Add(obj *Dir) (abort bool) {
-	select {
-	case <-o.abort:
-		return true
-	case o.objects <- obj:
-		return false
-	}
-}
-
-// SetError will set an error state, and will cause the listing to
-// be aborted.
-// Multiple goroutines can set the error state concurrently,
-// but only the first will be returned to the caller.
-func (o *listDirOpts) SetError(err error) {
-	// Be sure we don't set a nil error by accident
-	if err == nil {
-		return
-	}
-	select {
-	case <-o.abort:
-	case o.errors <- err:
-	}
-}
-
-// Finished should be called when listing is finished
-func (o *listDirOpts) Finished() {
-	o.finished.Do(func() {
-		close(o.objects)
-	})
-}
-
-// get an object from the listing.
-// Will return (nil, nil) when all objects have been returned.
-func (o *listDirOpts) Get() (*Dir, error) {
-	select {
-	case <-o.abort:
-		return nil, ErrListAborted
-	case err := <-o.errors:
-		close(o.abort)
-		return nil, err
-	default:
-	}
-
-	// No error, or aborted, attempt to fetch an object.
-	select {
-	case obj := <-o.objects:
-		return obj, nil
-	case err := <-o.errors:
-		close(o.abort)
-		return nil, err
-	case <-o.abort:
-		return nil, ErrListAborted
+		return nil, nil, ErrListAborted
 	}
 }
 

--- a/fs/limited.go
+++ b/fs/limited.go
@@ -47,11 +47,6 @@ func (f *Limited) List(opts ListOpts) {
 	}
 }
 
-// ListDir lists the Fs directories/buckets/containers into a channel
-func (f *Limited) ListDir(opts ListDirOpts) {
-	opts.Finished()
-}
-
 // NewFsObject finds the Object at remote.  Returns nil if can't be found
 func (f *Limited) NewFsObject(remote string) Object {
 	for _, obj := range f.objects {

--- a/fs/limited.go
+++ b/fs/limited.go
@@ -38,22 +38,18 @@ func (f *Limited) String() string {
 }
 
 // List the Fs into a channel
-func (f *Limited) List() ObjectsChan {
-	out := make(ObjectsChan, Config.Checkers)
-	go func() {
-		for _, obj := range f.objects {
-			out <- obj
+func (f *Limited) List(opts ListOpts) {
+	defer opts.Finished()
+	for _, obj := range f.objects {
+		if opts.Add(obj) {
+			return
 		}
-		close(out)
-	}()
-	return out
+	}
 }
 
 // ListDir lists the Fs directories/buckets/containers into a channel
-func (f *Limited) ListDir() DirChan {
-	out := make(DirChan, Config.Checkers)
-	close(out)
-	return out
+func (f *Limited) ListDir(opts ListDirOpts) {
+	opts.Finished()
 }
 
 // NewFsObject finds the Object at remote.  Returns nil if can't be found

--- a/googlecloudstorage/googlecloudstorage.go
+++ b/googlecloudstorage/googlecloudstorage.go
@@ -303,8 +303,8 @@ func (f *Fs) list(directories bool, fn func(string, *storage.Object)) {
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) List() fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	if f.bucket == "" {
 		// Return no objects at top level list
 		close(out)

--- a/onedrive/onedrive.go
+++ b/onedrive/onedrive.go
@@ -373,7 +373,7 @@ OUTER:
 //
 // This fetches the minimum amount of stuff but does more API calls
 // which makes it slow
-func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) error {
+func (f *Fs) listDirRecursive(dirID string, path string, out fs.ListOpts) error {
 	var subError error
 	// Make the API request
 	var wg sync.WaitGroup
@@ -410,8 +410,8 @@ func (f *Fs) listDirRecursive(dirID string, path string, out fs.ObjectsChan) err
 }
 
 // List walks the path returning a channel of Objects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) List() fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	go func() {
 		defer close(out)
 		err := f.dirCache.FindRoot(false)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -394,8 +394,8 @@ func (f *Fs) list(directories bool, fn func(string, *s3.Object)) {
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) List() fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	if f.bucket == "" {
 		// Return no objects at top level list
 		close(out)

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -297,8 +297,8 @@ func (f *Fs) list(directories bool, fn listFn) {
 // listFiles walks the path returning a channel of FsObjects
 //
 // if ignoreStorable is set then it outputs the file even if Storable() is false
-func (f *Fs) listFiles(ignoreStorable bool) fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) listFiles(ignoreStorable bool) fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	if f.container == "" {
 		// Return no objects at top level list
 		close(out)
@@ -324,7 +324,7 @@ func (f *Fs) listFiles(ignoreStorable bool) fs.ObjectsChan {
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
+func (f *Fs) List() fs.ListOpts {
 	return f.listFiles(false)
 }
 

--- a/yandex/yandex.go
+++ b/yandex/yandex.go
@@ -207,8 +207,8 @@ func (f *Fs) list(directories bool, fn func(string, yandex.ResourceInfoResponse)
 }
 
 // List walks the path returning a channel of FsObjects
-func (f *Fs) List() fs.ObjectsChan {
-	out := make(fs.ObjectsChan, fs.Config.Checkers)
+func (f *Fs) List() fs.ListOpts {
+	out := make(fs.ListOpts, fs.Config.Checkers)
 	// List the objects
 	go func() {
 		defer close(out)


### PR DESCRIPTION
WIP: DO NOT MERGE. Tests are expected to fail.

Concept proposal for #316

This shows the concept. All the heavy lifting is done in the "fs" package, making file system implementations a bit simpler.

/fs shows interfaces, and should compile.
/amazonclouddrive: Changed to new interface.
/b2: Changed to new interface.
/local: Changed to new interface.

The Fs no longer needs to create a separate goroutine when List/ListDir is called. Instead it can block as long as it likes. This simplifies implementations a bit (at least it doesn't become more complex).

Implementation is hidden in "fs" package, and only exposes the minimally needed interface, which of course can be extended.