### PR TITLE
Swift storageURL overloading

### DIFF
--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -56,6 +56,8 @@ Choose a number from below, or type in your own value
 auth> 1
 Tenant name - optional
 tenant>
+Storage URL - optional
+storage_url>
 Remote config
 --------------------
 [remote]
@@ -63,6 +65,7 @@ user = user_name
 key = password_or_api_key
 auth = https://auth.api.rackspacecloud.com/v1.0
 tenant =
+storage_url =
 --------------------
 y) Yes this is OK
 e) Edit this remote

--- a/swift/auth.go
+++ b/swift/auth.go
@@ -1,0 +1,30 @@
+package swift
+
+import "github.com/ncw/swift"
+
+// auth is an authenticator for swift
+type auth struct {
+	swift.Authenticator
+	f          *Fs
+	storageUrl string
+}
+
+// newAuth creates a swift authenticator
+func newAuth(f *Fs, s string) *auth {
+	return &auth{
+		f:          f,
+		storageUrl: s,
+	}
+}
+
+// The public storage URL - set Internal to true to read
+// internal/service net URL
+func (a *auth) StorageUrl(Internal bool) string {
+	if a.storageUrl != "" {
+		return a.storageUrl
+	}
+	return a.f.c.Auth.StorageUrl(Internal)
+}
+
+// Check the interfaces are satisfied
+var _ swift.Authenticator = (*auth)(nil)

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -66,6 +66,9 @@ func init() {
 		}, {
 			Name: "region",
 			Help: "Region name - optional",
+		}, {
+			Name: "storage_url",
+			Help: "Storage URL - optional",
 		},
 		},
 	})
@@ -175,6 +178,12 @@ func NewFsWithConnection(name, root string, c *swift.Connection) (fs.Fs, error) 
 		container:         container,
 		segmentsContainer: container + "_segments",
 		root:              directory,
+	}
+	// StorageURL overloading
+	storageUrl := fs.ConfigFile.MustValue(name, "storage_url")
+	if storageUrl != "" {
+		f.c.StorageUrl = storageUrl
+		f.c.Auth = newAuth(f, storageUrl)
 	}
 	if f.root != "" {
 		f.root += "/"


### PR DESCRIPTION
As discussed in #167, this brings overloading support for storage URLs in a remote's configuration section. The `storage_url` key is read and if not empty then the connection's Storage URL is overloaded and the its Authenticator too so that this URL stays consistent across re-authentications.