### PR TITLE
Change Put/Update interface

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -39,7 +39,7 @@ const (
 
 // Register with Fs
 func init() {
-	fs.Register(&fs.Info{
+	fs.Register(&fs.RegInfo{
 		Name:  "b2",
 		NewFs: NewFs,
 		Options: []fs.Option{{
@@ -455,13 +455,13 @@ func (f *Fs) ListDir() fs.DirChan {
 // Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
-func (f *Fs) Put(in io.Reader, remote string, modTime time.Time, size int64) (fs.Object, error) {
+func (f *Fs) Put(in io.Reader, src fs.ObjectInfo) (fs.Object, error) {
 	// Temporary Object under construction
 	fs := &Object{
 		fs:     f,
-		remote: remote,
+		remote: src.Remote(),
 	}
-	return fs, fs.Update(in, modTime, size)
+	return fs, fs.Update(in, src)
 }
 
 // Mkdir creates the bucket if it doesn't exist
@@ -592,7 +592,7 @@ func (f *Fs) Hashes() fs.HashSet {
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
-func (o *Object) Fs() fs.Fs {
+func (o *Object) Fs() fs.Info {
 	return o.fs
 }
 
@@ -868,7 +868,10 @@ func urlEncode(in string) string {
 // Update the object with the contents of the io.Reader, modTime and size
 //
 // The new object may have been created if an error is returned
-func (o *Object) Update(in io.Reader, modTime time.Time, size int64) (err error) {
+func (o *Object) Update(in io.Reader, src fs.ObjectInfo) (err error) {
+	size := src.Size()
+	modTime := src.ModTime()
+
 	// Open a temp file to copy the input
 	fd, err := ioutil.TempFile("", "rclone-b2-")
 	if err != nil {

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -84,7 +84,7 @@ var (
 
 // Register with Fs
 func init() {
-	fs.Register(&fs.Info{
+	fs.Register(&fs.RegInfo{
 		Name:  "drive",
 		NewFs: NewFs,
 		Config: func(name string) {
@@ -600,7 +600,11 @@ func (f *Fs) createFileInfo(remote string, modTime time.Time, size int64) (*Obje
 // Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
-func (f *Fs) Put(in io.Reader, remote string, modTime time.Time, size int64) (fs.Object, error) {
+func (f *Fs) Put(in io.Reader, src fs.ObjectInfo) (fs.Object, error) {
+	remote := src.Remote()
+	size := src.Size()
+	modTime := src.ModTime()
+
 	o, createInfo, err := f.createFileInfo(remote, modTime, size)
 	if err != nil {
 		return nil, err
@@ -818,7 +822,7 @@ func (f *Fs) Hashes() fs.HashSet {
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
-func (o *Object) Fs() fs.Fs {
+func (o *Object) Fs() fs.Info {
 	return o.fs
 }
 
@@ -1025,7 +1029,9 @@ func (o *Object) Open() (in io.ReadCloser, err error) {
 // Copy the reader into the object updating modTime and size
 //
 // The new object may have been created if an error is returned
-func (o *Object) Update(in io.Reader, modTime time.Time, size int64) error {
+func (o *Object) Update(in io.Reader, src fs.ObjectInfo) error {
+	size := src.Size()
+	modTime := src.ModTime()
 	if o.isDocument {
 		return fmt.Errorf("Can't update a google document")
 	}

--- a/dropbox/dropbox.go
+++ b/dropbox/dropbox.go
@@ -44,7 +44,7 @@ var (
 
 // Register with Fs
 func init() {
-	fs.Register(&fs.Info{
+	fs.Register(&fs.RegInfo{
 		Name:   "dropbox",
 		NewFs:  NewFs,
 		Config: configHelper,
@@ -379,13 +379,13 @@ func (rc *readCloser) Close() error {
 // Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
-func (f *Fs) Put(in io.Reader, remote string, modTime time.Time, size int64) (fs.Object, error) {
+func (f *Fs) Put(in io.Reader, src fs.ObjectInfo) (fs.Object, error) {
 	// Temporary Object under construction
 	o := &Object{
 		fs:     f,
-		remote: remote,
+		remote: src.Remote(),
 	}
-	return o, o.Update(in, modTime, size)
+	return o, o.Update(in, src)
 }
 
 // Mkdir creates the container if it doesn't exist
@@ -531,7 +531,7 @@ func (f *Fs) Hashes() fs.HashSet {
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
-func (o *Object) Fs() fs.Fs {
+func (o *Object) Fs() fs.Info {
 	return o.fs
 }
 
@@ -656,7 +656,7 @@ func (o *Object) Open() (in io.ReadCloser, err error) {
 // Copy the reader into the object updating modTime and size
 //
 // The new object may have been created if an error is returned
-func (o *Object) Update(in io.Reader, modTime time.Time, size int64) error {
+func (o *Object) Update(in io.Reader, src fs.ObjectInfo) error {
 	remote := o.remotePath()
 	if ignoredFiles.MatchString(remote) {
 		fs.Log(o, "File name disallowed - not uploading")

--- a/fs/limited.go
+++ b/fs/limited.go
@@ -71,12 +71,13 @@ func (f *Limited) NewFsObject(remote string) Object {
 // May create the object even if it returns an error - if so
 // will return the object and the error, otherwise will return
 // nil and the error
-func (f *Limited) Put(in io.Reader, remote string, modTime time.Time, size int64) (Object, error) {
+func (f *Limited) Put(in io.Reader, src ObjectInfo) (Object, error) {
+	remote := src.Remote()
 	obj := f.NewFsObject(remote)
 	if obj == nil {
 		return nil, fmt.Errorf("Can't create %q in limited fs", remote)
 	}
-	return obj, obj.Update(in, modTime, size)
+	return obj, obj.Update(in, src)
 }
 
 // Mkdir make the directory (container, bucket)

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -221,10 +221,10 @@ tryAgain:
 
 		if doUpdate {
 			actionTaken = "Copied (updated existing)"
-			err = dst.Update(in, src.ModTime(), src.Size())
+			err = dst.Update(in, src)
 		} else {
 			actionTaken = "Copied (new)"
-			dst, err = f.Put(in, src.Remote(), src.ModTime(), src.Size())
+			dst, err = f.Put(in, src)
 		}
 		inErr = in.Close()
 	}

--- a/fs/operations_test.go
+++ b/fs/operations_test.go
@@ -188,7 +188,8 @@ func (r *Run) WriteObjectTo(f fs.Fs, remote, content string, modTime time.Time) 
 	}
 	for tries := 1; ; tries++ {
 		in := bytes.NewBufferString(content)
-		_, err := f.Put(in, remote, modTime, int64(len(content)))
+		objinfo := fs.NewStaticObjectInfo(remote, modTime, int64(len(content)), true, nil, nil)
+		_, err := f.Put(in, objinfo)
 		if err == nil {
 			break
 		}

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -164,7 +164,8 @@ func testPut(t *testing.T, file *fstest.Item) {
 	in := io.TeeReader(buf, hash)
 
 	file.Size = int64(buf.Len())
-	obj, err := remote.Put(in, file.Path, file.ModTime, file.Size)
+	obji := fs.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
+	obj, err := remote.Put(in, obji)
 	if err != nil {
 		t.Fatal("Put error", err)
 	}
@@ -551,7 +552,8 @@ func TestObjectUpdate(t *testing.T) {
 
 	file1.Size = int64(buf.Len())
 	obj := findObject(t, file1.Path)
-	err := obj.Update(in, file1.ModTime, file1.Size)
+	obji := fs.NewStaticObjectInfo("", file1.ModTime, file1.Size, true, nil, obj.Fs())
+	err := obj.Update(in, obji)
 	if err != nil {
 		t.Fatal("Update error", err)
 	}

--- a/hubic/hubic.go
+++ b/hubic/hubic.go
@@ -44,7 +44,7 @@ var (
 
 // Register with Fs
 func init() {
-	fs.Register(&fs.Info{
+	fs.Register(&fs.RegInfo{
 		Name:  "hubic",
 		NewFs: NewFs,
 		Config: func(name string) {


### PR DESCRIPTION
Create separate interface for object information; `ObjectInfo`.

See discussion at #282.

The read-only parts of the Fs has also been separated out in to `FsInfo`, so there cannot be any unintentional changes made to the source Fs.