### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ os:
 # - osx
 
 go:
-  - 1.4.2
-  - 1.5.3
-
-# - tip
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip
 
 install:
  - go get -t ./...
  - '[[ `go version` =~ go1.[0-4][^0-9] ]] || go get -u github.com/kisielk/errcheck'
  - go get -u golang.org/x/tools/cmd/goimports
- - go get -u github.com/golang/lint/golint
+ - '[[ `go version` =~ go1.[0-4][^0-9] ]] || go get -u github.com/golang/lint/golint'
 
 script:
   - make check

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ check:	rclone
 	go vet ./...
 	[[ `go version` =~ go1.[0-4][^0-9] ]] || errcheck ./...
 	goimports -d . | grep . ; test $$? -eq 1
-	golint ./... | grep -E -v '(StorageUrl|CdnUrl)' ; test $$? -eq 1
+	[[ `go version` =~ go1.[0-4][^0-9] ]] || { golint ./... | grep -E -v '(StorageUrl|CdnUrl)' ; test $$? -eq 1;}
 
 doc:	rclone.1 MANUAL.html MANUAL.txt
 


### PR DESCRIPTION
* Only use golint if version is > Go 1.4
* Add Go 1.6 and tip as test targets.
* Use latest release instead of a specific. Should result in less future updates.

I am trying adding tip - it is good to have. In some instances it can be early warning of future problems to come.