### PR TITLE
rclone requires Go v1.5 for compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,15 @@ os:
 # - osx
 
 go:
-  - 1.4.2
   - 1.5.3
   - 1.6
   - tip
 
 install:
  - go get -t ./...
- - '[[ `go version` =~ go1.[0-4][^0-9] ]] || go get -u github.com/kisielk/errcheck'
+ - go get -u github.com/kisielk/errcheck
  - go get -u golang.org/x/tools/cmd/goimports
- - '[[ `go version` =~ go1.[0-4][^0-9] ]] || go get -u github.com/golang/lint/golint'
+ - go get -u github.com/golang/lint/golint
 
 script:
   - make check

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -1,8 +1,8 @@
 ---
 title: "Install"
 description: "Rclone Installation"
-date: "2015-06-12"
----
+date: "2016-03-28"
+------------------
 
 Install
 -------
@@ -11,15 +11,15 @@ Rclone is a Go program and comes as a single binary file.
 
 [Download](/downloads/) the relevant binary.
 
-Or alternatively if you have Go installed use
+Or alternatively if you have Go 1.5+ installed use
 
     go get github.com/ncw/rclone
 
 and this will build the binary in `$GOPATH/bin`.  If you have built
 rclone before then you will want to update its dependencies first with
-this (remove `-f` if using go < 1.4)
+this
 
-    go get -u -v -f github.com/ncw/rclone/...
+    go get -u -v github.com/ncw/rclone/...
 
 See the [Usage section](/docs/) of the docs for how to use rclone, or
 run `rclone -h`.

--- a/versioncheck.go
+++ b/versioncheck.go
@@ -1,0 +1,6 @@
+//+build !go1.5
+
+package main
+
+// Upgrade to Go version 1.5 to compile rclone.
+func init() { Go_version_1_5_required_for_compilation() }


### PR DESCRIPTION
Google cloud package requires go v1.5 to compile, so we need to require the same for rclone.

Fixes #408