### PR TITLE
Use "password:" instead of "password>" prompt

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -451,7 +451,7 @@ func getPassword(q string) {
 	}
 	for {
 		fmt.Println(q)
-		fmt.Print("password>")
+		fmt.Print("password:")
 		err := setPassword(ReadPassword())
 		if err == nil {
 			return


### PR DESCRIPTION
Fixes #410