### PR TITLE
Add service account support for GCS

### DIFF
--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -144,3 +144,32 @@ files in the bucket.
 Google google cloud storage stores md5sums natively and rclone stores
 modification times as metadata on the object, under the "mtime" key in
 RFC3339 format accurate to 1ns.
+
+## Service Account support ##
+
+You can set up `rcloud` with Google Cloud Storage in an unattended mode, i.e. not tied to a specific end-user Google 
+account. This is useful when you want to synchronise files onto machines that don't have actively logged-in users, for 
+example build machines.
+
+To get credentials for Google Cloud Platform [IAM Service Accounts](https://cloud.google.com/iam/docs/service-accounts),
+please head to the [Service Account](https://console.cloud.google.com/permissions/serviceaccounts) section of the 
+Google Developer Console. Service Accounts behave just like normal `User` permissions in 
+[Google Cloud Storage ACLs](https://cloud.google.com/storage/docs/access-control), so you can limit their access 
+(e.g. make them read only). After creating an account, a JSON file containing the Service Account's credentials will 
+be downloaded onto your machines. These credentials are what `rclone` will use for authentication.
+
+To use a Service Account instead of OAuth2 token flow, replace the `token` section of your `.rclone.conf` with a
+ `service_account_file` pointing to the JSON credentials. 
+
+For example, here's an example `.rclone.conf` that sets up read only access using a service account:
+
+```
+[readonly-sync]
+type = google cloud storage
+project_number = 123456789
+service_account_file = $HOME/.rclone-service_account.json
+object_acl = authenticatedRead
+bucket_acl = authenticatedRead
+```
+
+


### PR DESCRIPTION
This adds support for Google Cloud Platform [IAM service accounts](https://cloud.google.com/iam/docs/service-accounts).

Adds a `service_account_file` parameter to `rcloud.conf` that points to a SA's JSON credentials file. If that's present, the normal OAuth2 flow is ignored and the Google OAuth2 client function for obtaining a `http.Client` is used.