### PR TITLE
Add domain option for openstack (v3 auth)

### DIFF
--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -72,6 +72,8 @@ Choose a number from below, or type in your own value
  6 / OVH
    \ "https://auth.cloud.ovh.net/v2.0"
 auth> 1
+User domain - optional (v3 auth)
+domain> Default
 Tenant name - optional
 tenant> 
 Region name - optional

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -63,7 +63,7 @@ func init() {
 			}},
 		}, {
 			Name: "domain",
-			Help: "User domain - optional (v3)",
+			Help: "User domain - optional (v3 auth)",
 		}, {
 			Name: "tenant",
 			Help: "Tenant name - optional",

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -62,6 +62,9 @@ func init() {
 				Value: "https://auth.cloud.ovh.net/v2.0",
 			}},
 		}, {
+			Name: "domain",
+			Help: "User domain - optional (v3)",
+		}, {
 			Name: "tenant",
 			Help: "Tenant name - optional",
 		}, {
@@ -155,6 +158,7 @@ func swiftConnection(name string) (*swift.Connection, error) {
 		UserAgent:      fs.UserAgent,
 		Tenant:         fs.ConfigFile.MustValue(name, "tenant"),
 		Region:         fs.ConfigFile.MustValue(name, "region"),
+		Domain:         fs.ConfigFile.MustValue(name, "domain"),
 		ConnectTimeout: 10 * fs.Config.ConnectTimeout, // Use the timeouts in the transport
 		Timeout:        10 * fs.Config.Timeout,        // Use the timeouts in the transport
 		Transport:      fs.Config.Transport(),


### PR DESCRIPTION
For a generic OpenStack there should be also `TenantDomain` und maybe even `DomainId` and `TenantDomainID` but I didn't want to litter the swift options for now. Thoughts?