### PR TITLE
onedrive: Update login urls

### DIFF
--- a/onedrive/onedrive.go
+++ b/onedrive/onedrive.go
@@ -42,8 +42,8 @@ var (
 			"onedrive.readwrite", // r/w perms to all of a user's OneDrive files
 		},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  "https://login.live.com/oauth20_authorize.srf",
-			TokenURL: "https://login.live.com/oauth20_token.srf",
+			AuthURL:  "https://login.windows.net/oauth2/authorize",
+			TokenURL: "https://login.windows.net/oauth2/token",
 		},
 		ClientID:     rcloneClientID,
 		ClientSecret: fs.Reveal(rcloneEncryptedClientSecret),


### PR DESCRIPTION
Based on
https://blogs.msdn.microsoft.com/exchangedev/2014/03/25/using-oauth2-to-access-calendar-contact-and-mail-api-in-office-365-exchange-online/

Required for supporting Office365 accounts