### PR TITLE
Details about Hubic "default" folder

### DIFF
--- a/docs/content/hubic.md
+++ b/docs/content/hubic.md
@@ -100,6 +100,10 @@ List all the files in your Hubic
 To copy a local directory to an Hubic directory called backup
 
     rclone copy /home/source remote:backup
+    
+If you want the directory to be visible in the official *Hubic browser*, you need to copy your files in the directory *default*
+
+     rclone copy /home/source remote:default/backup
 
 ### Modified time ###
 


### PR DESCRIPTION
This PR is about the "default" folder visible in the hubic browser.