### PR TITLE
swift: add support for non-default project domain.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1934,6 +1934,8 @@ This will guide you through an interactive setup process.
     domain> Default
     Tenant name - optional
     tenant> 
+    Tenant domain - optional (v3 auth)
+    tenant_domain>
     Region name - optional
     region> 
     Storage URL - optional

--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -76,6 +76,8 @@ User domain - optional (v3 auth)
 domain> Default
 Tenant name - optional
 tenant> 
+Tenant domain - optional (v3 auth)
+tenant_domain>
 Region name - optional
 region> 
 Storage URL - optional

--- a/rclone.1
+++ b/rclone.1
@@ -2416,6 +2416,8 @@ User\ domain\ \-\ optional\ (v3\ auth)
 domain>\ Default
 Tenant\ name\ \-\ optional
 tenant>\ 
+Tenant\ domain\ \-\ optional
+tenant_domain>\ 
 Region\ name\ \-\ optional
 region>\ 
 Storage\ URL\ \-\ optional

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -68,6 +68,9 @@ func init() {
 			Name: "tenant",
 			Help: "Tenant name - optional",
 		}, {
+			Name: "tenant_domain",
+			Help: "Tenant domain - optional (v3 auth)",
+		}, {
 			Name: "region",
 			Help: "Region name - optional",
 		}, {
@@ -163,6 +166,7 @@ func swiftConnection(name string) (*swift.Connection, error) {
 		Tenant:         fs.ConfigFile.MustValue(name, "tenant"),
 		Region:         fs.ConfigFile.MustValue(name, "region"),
 		Domain:         fs.ConfigFile.MustValue(name, "domain"),
+		TenantDomain:   fs.ConfigFile.MustValue(name, "tenant_domain"),
 		ConnectTimeout: 10 * fs.Config.ConnectTimeout, // Use the timeouts in the transport
 		Timeout:        10 * fs.Config.Timeout,        // Use the timeouts in the transport
 		Transport:      fs.Config.Transport(),


### PR DESCRIPTION
With Keystone V3 both users and projects (a.k.a. tenants) can belong
to different domains. This change allow specifying different domains
for the user and the project.