### PR TITLE
#111 add support for custom metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ build_dep:
 	go get -u github.com/kisielk/errcheck
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/golang/lint/golint
+	go get -u github.com/davecheney/xattr
 
 # Update dependencies
 update:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ build_dep:
 	go get -u github.com/kisielk/errcheck
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/golang/lint/golint
-	go get -u github.com/davecheney/xattr
 
 # Update dependencies
 update:

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -203,10 +203,10 @@ type ObjectInfo interface {
 	Storable() bool
 }
 
-// ObjectInfoWithMetada contains an object with its associated metadata
+// ObjectInfoWithMetadata contains an object with its associated metadata
 type ObjectInfoWithMetadata interface {
 	ObjectInfo
-	
+
 	// User defined metadata on this object
 	UserMetadata() map[string]string
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -203,6 +203,14 @@ type ObjectInfo interface {
 	Storable() bool
 }
 
+// ObjectInfoWithMetada contains an object with its associated metadata
+type ObjectInfoWithMetadata interface {
+	ObjectInfo
+	
+	// User defined metadata on this object
+	UserMetadata() map[string]string
+}
+
 // Purger is an optional interfaces for Fs
 type Purger interface {
 	// Purge all files in the root and the root directory

--- a/local/local.go
+++ b/local/local.go
@@ -15,9 +15,9 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/davecheney/xattr"
 	"github.com/ncw/rclone/fs"
 	"github.com/pkg/errors"
-	"github.com/davecheney/xattr"
 )
 
 // Register with Fs
@@ -52,12 +52,12 @@ type Fs struct {
 
 // Object represents a local filesystem object
 type Object struct {
-	fs     *Fs                    // The Fs this object is part of
-	remote string                 // The remote path - properly UTF-8 encoded - for rclone
-	path   string                 // The local path - may not be properly UTF-8 encoded - for OS
-	info   os.FileInfo            // Interface for file info (always present)
-	hashes map[fs.HashType]string // Hashes
-	metadata map[string] string
+	fs       *Fs                    // The Fs this object is part of
+	remote   string                 // The remote path - properly UTF-8 encoded - for rclone
+	path     string                 // The local path - may not be properly UTF-8 encoded - for OS
+	info     os.FileInfo            // Interface for file info (always present)
+	hashes   map[fs.HashType]string // Hashes
+	metadata map[string]string
 }
 
 // ------------------------------------------------------------
@@ -550,8 +550,8 @@ func (o *Object) Storable() bool {
 	return true
 }
 
-// Return the map of metadata
-func (o* Object) UserMetadata() map[string]string {
+// UserMetadata Return the map of metadata
+func (o *Object) UserMetadata() map[string]string {
 	return o.metadata
 }
 
@@ -638,19 +638,18 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo) error {
 	if err != nil {
 		return err
 	}
-	
+
 	// Set the metadata
 	switch src.(type) {
-		case fs.ObjectInfoWithMetadata:
-		    srcm := src.(fs.ObjectInfoWithMetadata)
-			for attr, value := range srcm.UserMetadata() {
-				err := xattr.Setxattr(o.path, "user.user-metadata." + attr, []byte(value))
-				if err != nil {
-					fs.Debug(o, "Could not set attribute", err);
-				}
+	case fs.ObjectInfoWithMetadata:
+		srcm := src.(fs.ObjectInfoWithMetadata)
+		for attr, value := range srcm.UserMetadata() {
+			err := xattr.Setxattr(o.path, "user.user-metadata."+attr, []byte(value))
+			if err != nil {
+				fs.Debug(o, "Could not set attribute", err)
 			}
+		}
 	}
-	
 
 	// ReRead info now that we have finished
 	return o.lstat()
@@ -682,7 +681,6 @@ func (o *Object) lattr() error {
 	}
 	return err
 }
-
 
 // Remove an object
 func (o *Object) Remove() error {

--- a/local/local.go
+++ b/local/local.go
@@ -1,4 +1,4 @@
-q// Package local provides a filesystem interface
+// Package local provides a filesystem interface
 package local
 
 import (

--- a/local/local.go
+++ b/local/local.go
@@ -15,7 +15,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/davecheney/xattr"
 	"github.com/ncw/rclone/fs"
 	"github.com/pkg/errors"
 )
@@ -642,7 +641,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo) error {
 	// Set the metadata
 	if srcm, ok := src.(fs.ObjectInfoWithMetadata); ok {
 		for attr, value := range srcm.UserMetadata() {
-			xerr := xattr.Setxattr(o.path, "user.user-metadata."+attr, []byte(value))
+			xerr := setxattr(o.path, "user.user-metadata."+attr, []byte(value))
 			if xerr != nil {
 				fs.Debug(o, "Could not set attribute", xerr)
 			}
@@ -665,7 +664,7 @@ var userMetadata = regexp.MustCompile(`^user\.user-metadata\.(.*)`)
 
 // Stat a Object into info
 func (o *Object) lattr() error {
-	listAttr, xerr := xattr.Listxattr(o.path)
+	listAttr, xerr := listxattr(o.path)
 	fs.Debug(o, "Listing attrs returned", listAttr, xerr)
 	for _, attr := range listAttr {
 		parts := userMetadata.FindStringSubmatch(attr)
@@ -674,7 +673,7 @@ func (o *Object) lattr() error {
 			if o.metadata == nil {
 				o.metadata = make(map[string]string)
 			}
-			bytes, xerr := xattr.Getxattr(o.path, attr)
+			bytes, xerr := getxattr(o.path, attr)
 			if xerr != nil {
 				fs.Debug(o, "Could not get attribute", xerr)
 			} else {

--- a/local/local.go
+++ b/local/local.go
@@ -644,7 +644,10 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo) error {
 		case fs.ObjectInfoWithMetadata:
 		    srcm := src.(fs.ObjectInfoWithMetadata)
 			for attr, value := range srcm.UserMetadata() {
-				xattr.Setxattr(o.path, "user.user-metadata." + attr, []byte(value))
+				err := xattr.Setxattr(o.path, "user.user-metadata." + attr, []byte(value))
+				if err != nil {
+					fs.Debug(o, "Could not set attribute", err);
+				}
 			}
 	}
 	

--- a/local/xattr_linux.go
+++ b/local/xattr_linux.go
@@ -1,0 +1,22 @@
+// +build linux
+
+package local
+
+import (
+	"github.com/davecheney/xattr"
+)
+
+// listxattr lists the extended attributes on the file
+func listxattr(path string) ([]string, error) {
+	return xattr.Listxattr(path)
+}
+
+// getxattr returns a specific attribute on a file
+func getxattr(path, name string) ([]byte, error) {
+	return xattr.Getxattr(path, name)
+}
+
+// setxattr sets a specific extended attribute on a file
+func setxattr(path, name string, data []byte) error {
+	return xattr.Setxattr(path, name, data)
+}

--- a/local/xattr_other.go
+++ b/local/xattr_other.go
@@ -1,0 +1,22 @@
+// +build !linux
+
+package local
+
+import (
+	"github.com/pkg/errors"
+)
+
+// listxattr lists the extended attributes on the file
+func listxattr(path string) ([]string, error) {
+	return []string{}, errors.New("extended attributes not supported")
+}
+
+// getxattr returns a specific attribute on a file
+func getxattr(path, name string) ([]byte, error) {
+	return []byte{}, errors.New("extended attributes not supported")
+}
+
+// setxattr sets a specific extended attribute on a file
+func setxattr(path, name string, data []byte) error {
+	return errors.New("extended attributes not supported")
+}


### PR DESCRIPTION
This demonstrates the usage of user metadata on the local fs

The naming convention (prepending ```user.user-metadata.``` to the attribute) is the same as the one used on JClouds "filesystem" blobstore.


This makes use of the "we pass the source object to the Put methods. Do a type assertion at that point to break out the metadata" suggestion from https://github.com/ncw/rclone/issues/111

