### PR TITLE
New B2 API endpoint (API domain)

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultEndpoint  = "https://api.backblaze.com"
+	defaultEndpoint  = "https://api.backblazeb2.com"
 	headerPrefix     = "x-bz-info-" // lower case as that is what the server returns
 	timeKey          = "src_last_modified_millis"
 	timeHeader       = headerPrefix + timeKey


### PR DESCRIPTION
Backblaze changed API endpoints on August 16, 2016. The old endpoints are still valid, but will be removed Feb 2nd 2017.

See https://help.backblaze.com/hc/en-us/articles/224959187-B2-Domain-Migration-Plan