### PR TITLE
User-configurable Amazon S3 ACL

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -121,6 +121,25 @@ Choose a number from below, or type in your own value
  9 / South America (Sao Paulo) Region.
    \ "sa-east-1"
 location_constraint> 1
+Canned ACL used when creating buckets and/or storing objects in S3.
+For more info visit http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+Choose a number from below, or type in your own value
+ 1 / Owner gets FULL_CONTROL. No one else has access rights (default).
+   \ "private"
+ 2 / Owner gets FULL_CONTROL. The AllUsers group gets READ access.
+   \ "public-read"
+   / Owner gets FULL_CONTROL. The AllUsers group gets READ and WRITE access.
+ 3 | Granting this on a bucket is generally not recommended.
+   \ "public-read-write"
+ 4 / Owner gets FULL_CONTROL. The AuthenticatedUsers group gets READ access.
+   \ "authenticated-read"
+   / Object owner gets FULL_CONTROL. Bucket owner gets READ access.
+ 5 | If you specify this canned ACL when creating a bucket, Amazon S3 ignores it.
+   \ "bucket-owner-read"
+   / Both the object owner and the bucket owner get FULL_CONTROL over the object.
+ 6 | If you specify this canned ACL when creating a bucket, Amazon S3 ignores it.
+   \ "bucket-owner-full-control"
+acl> private
 The server-side encryption algorithm used when storing this object in S3.
 Choose a number from below, or type in your own value
  1 / None


### PR DESCRIPTION
Hi,
I needed to apply "public-read" ACL during upload to our Ceph/RadosGw. This simple patch works for me for now (newly uploaded objects have the right ACL, but subsequent sync doesn't seem to check/fix existing ones).

What was your idea to fix the FIXME? ;-) I would love to see official support for S3 _canned_ ACL in rclone and might spend some time implementing it.