### PR TITLE
Fix description of max-size on amazon drive

### DIFF
--- a/MANUAL.html
+++ b/MANUAL.html
@@ -1793,7 +1793,7 @@ y/e/d&gt; y</code></pre>
 <p>Amazon Drive has rate limiting so you may notice errors in the sync (429 errors). rclone will automatically retry the sync up to 3 times by default (see <code>--retries</code> flag) which should hopefully work around this problem.</p>
 <p>Amazon Drive has an internal limit of file sizes that can be uploaded to the service. This limit is not officially published, but all files larger than this will fail.</p>
 <p>At the time of writing (Jan 2016) is in the area of 50GB per file. This means that larger files are likely to fail.</p>
-<p>Unfortunatly there is no way for rclone to see that this failure is because of file size, so it will retry the operation, as any other failure. To avoid this problem, use <code>--max-size=50GB</code> option to limit the maximum size of uploaded files.</p>
+<p>Unfortunatly there is no way for rclone to see that this failure is because of file size, so it will retry the operation, as any other failure. To avoid this problem, use <code>--max-size=50G</code> option to limit the maximum size of uploaded files.</p>
 <h2 id="microsoft-one-drive">Microsoft One Drive</h2>
 <p>Paths are specified as <code>remote:path</code></p>
 <p>Paths may be as deep as required, eg <code>remote:directory/subdirectory</code>.</p>

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -3008,7 +3008,7 @@ This means that larger files are likely to fail.
 
 Unfortunatly there is no way for rclone to see that this failure is 
 because of file size, so it will retry the operation, as any other
-failure. To avoid this problem, use `--max-size=50GB` option to limit
+failure. To avoid this problem, use `--max-size=50G` option to limit
 the maximum size of uploaded files.
 
 Microsoft One Drive

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2953,7 +2953,7 @@ means that larger files are likely to fail.
 
 Unfortunatly there is no way for rclone to see that this failure is
 because of file size, so it will retry the operation, as any other
-failure. To avoid this problem, use --max-size=50GB option to limit the
+failure. To avoid this problem, use --max-size=50G option to limit the
 maximum size of uploaded files.
 
 

--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -548,7 +548,7 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo) (fs.Object, error) {
 		return nil, err
 	}
 	if size > warnFileSize {
-		fs.Debug(f, "Warning: file %q may fail because it is too big. Use --max-size=%dGB to skip large files.", remote, warnFileSize>>30)
+		fs.Debug(f, "Warning: file %q may fail because it is too big. Use --max-size=%dG to skip large files.", remote, warnFileSize>>30)
 	}
 	folder := acd.FolderFromId(directoryID, o.fs.c.Nodes)
 	var info *acd.File

--- a/docs/content/amazonclouddrive.md
+++ b/docs/content/amazonclouddrive.md
@@ -154,5 +154,5 @@ This means that larger files are likely to fail.
 
 Unfortunatly there is no way for rclone to see that this failure is 
 because of file size, so it will retry the operation, as any other
-failure. To avoid this problem, use `--max-size=50GB` option to limit
+failure. To avoid this problem, use `--max-size=50G` option to limit
 the maximum size of uploaded files.


### PR DESCRIPTION
Should be `--max-size=50G`, not `--max-size=50GB`.