### PR TITLE
Remove call to deleted method SetOpaque from googleapi

### DIFF
--- a/googlecloudstorage/googlecloudstorage.go
+++ b/googlecloudstorage/googlecloudstorage.go
@@ -661,9 +661,6 @@ func (o *Object) Open() (in io.ReadCloser, err error) {
 	if err != nil {
 		return nil, err
 	}
-	// SetOpaque sets Opaque such that HTTP requests to it don't
-	// alter any hex-escaped characters
-	googleapi.SetOpaque(req.URL)
 	req.Header.Set("User-Agent", fs.UserAgent)
 	res, err := o.fs.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
SetOpaque was removed from googleapi package as noted by
@simos in #660.

The SetOpaque call is unnecessary here
because http.NewRequest() called just before is setting
the required members of URL struct to ensure that URL
is escaped correctly. This pattern is in line with the
changes done in google projects:
https://code-review.googlesource.com/#/c/7111/7

Change-Id: I3cf76d79ec5327bec2bbde65ed74c874f7c26123