### PR TITLE
Use Dup2 library function instead of raw syscall

### DIFF
--- a/cmd/redirect_stderr_unix.go
+++ b/cmd/redirect_stderr_unix.go
@@ -7,12 +7,13 @@ package cmd
 import (
 	"log"
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // redirectStderr to the file passed in
 func redirectStderr(f *os.File) {
-	err := syscall.Dup2(int(f.Fd()), int(os.Stderr.Fd()))
+	err := unix.Dup2(int(f.Fd()), int(os.Stderr.Fd()))
 	if err != nil {
 		log.Fatalf("Failed to redirect stderr to file: %v", err)
 	}


### PR DESCRIPTION
The Dup2 syscall does not exist on 64-bit arm Linux while its replacement Dup3 does not exist on non-Linux systems.

Using the unix.Dup2 library function instead of raw syscalls improves the portability across more platforms.