### PR TITLE
Add support to toggle bandwidth limits via SIGUSR2.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -854,6 +854,12 @@ For example to limit bandwidth usage to 10 MBytes/s use `--bwlimit 10M`
 This only limits the bandwidth of the data transfer, it doesn't limit
 the bandwith of the directory listings etc.
 
+For Linux/Unix operating systems: rclone will toggle the bandwidth limiter on
+and off upon receipt of the SIGUSR2 signal. This feature allows the user to
+remove the bandwidth limitations of a long running rclone transfer during
+off-peak hours, and to restore it back to the value specified with --bwlimit
+again when needed.
+
 ### --checkers=N ###
 
 The number of checkers to run in parallel.  Checkers do the equality

--- a/fs/accounting_unix.go
+++ b/fs/accounting_unix.go
@@ -1,0 +1,35 @@
+// Accounting and limiting reader
+// Unix specific functions.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package fs
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// startSignalHandler() sets a signal handler to catch SIGUSR2 and toggle throttling.
+func startSignalHandler() {
+	// Don't do anything if no bandwidth limits requested.
+	if bwLimit <= 0 {
+		return
+	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGUSR2)
+
+	go func() {
+		// This runs forever, but blocks until the signal is received.
+		for {
+			<-signals
+			if tokenBucket == nil {
+				tokenBucket = origTokenBucket
+			} else {
+				tokenBucket = nil
+			}
+		}
+	}()
+}

--- a/fs/accounting_windows.go
+++ b/fs/accounting_windows.go
@@ -1,0 +1,10 @@
+// Accounting and limiting reader
+// Windows specific functions.
+
+// +build windows
+
+package fs
+
+// startSignalHandler() is Unix specific and does nothing under windows
+// platforms.
+func startSignalHandler() {}


### PR DESCRIPTION
Sending rclone a SIGUSR2 signal will toggle the limiter between off and
the limit set with the --bwlimit command-line option.