### PR TITLE
Add support for server side move operations on ACD

### DIFF
--- a/amazonclouddrive/amazonclouddrive.go
+++ b/amazonclouddrive/amazonclouddrive.go
@@ -668,6 +668,51 @@ func (f *Fs) Hashes() fs.HashSet {
 	return fs.HashSet(fs.HashMD5)
 }
 
+func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+	srcObj, ok := src.(*Object)
+	if !ok {
+		fs.Debug(src, "Can't move - not same remote type")
+		return nil, fs.ErrorCantMove
+	}
+
+	// Temporary Object under construction
+	dstObj := &Object{
+		fs:     f,
+		remote: remote,
+	}
+
+	var err error
+	_, directoryID, err := f.dirCache.FindPath(remote, false)
+	if err != nil {
+		return nil, err
+	}
+
+	var info *acd.Node
+	var resp *http.Response
+	if directoryID == srcObj.info.Parents[0] {
+		// Do the rename
+		err = f.pacer.Call(func() (bool, error) {
+			info, resp, err = srcObj.info.Rename(remote)
+			return srcObj.fs.shouldRetry(resp, err)
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Do the move
+		err = f.pacer.Call(func() (bool, error) {
+			info, resp, err = srcObj.info.Move(directoryID)
+			return srcObj.fs.shouldRetry(resp, err)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	dstObj.info = info
+	return dstObj, nil
+}
+
 // Copy src to this remote using server side copy operations.
 //
 // This is stored with the remote path given
@@ -875,7 +920,7 @@ var (
 	_ fs.Fs     = (*Fs)(nil)
 	_ fs.Purger = (*Fs)(nil)
 	//	_ fs.Copier   = (*Fs)(nil)
-	//	_ fs.Mover    = (*Fs)(nil)
+	_ fs.Mover    = (*Fs)(nil)
 	//	_ fs.DirMover = (*Fs)(nil)
 	_ fs.Object    = (*Object)(nil)
 	_ fs.MimeTyper = &Object{}


### PR DESCRIPTION
Depends on pull request at https://github.com/ncw/go-acd/pull/1 CI test is going to fail due to this.

https://github.com/ncw/rclone/issues/795
https://github.com/ncw/rclone/issues/830
https://github.com/ncw/rclone/issues/809
Can be closed as a result of this pull request as well, although 830 also highlights an issue with overlapping not being prevented on crypted fs.

https://github.com/ncw/rclone/issues/122
Can be updated
