### PR TITLE
report number of blocks in fuse

### DIFF
--- a/cmd/mount/file.go
+++ b/cmd/mount/file.go
@@ -62,6 +62,7 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) error {
 			a.Crtime = modTime
 		}
 	}
+	a.Blocks = (a.Size + 511) / 512
 	return nil
 }
 


### PR DESCRIPTION
This fixes the "total" count from `ls` and other size calculating tools like `du -s` or `ncdu`:

Without:
```
$ \ls -ls 
total 0
0 -rw-r--r-- 1 stefan stefan  583076191 Sep 18 15:56 random.bin
0 -rw-r--r-- 1 stefan stefan 1139375223 Sep 18 15:54 random2.bin
```

With:
```
$ \ls -ls 
total 18434355
 569411 -rw-r--r-- 1 stefan stefan  583076191 Sep 18 15:56 random.bin
1112672 -rw-r--r-- 1 stefan stefan 1139375223 Sep 18 15:54 random2.bin
```