### PR TITLE
Update Onedrive doc to reflect file size limit

### DIFF
--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -147,3 +147,5 @@ names.  These can't occur on Windows platforms, but on non-Windows
 platforms they are common.  Rclone will map these names to and from an
 identical looking unicode equivalent.  For example if a file has a `?`
 in it will be mapped to `？` instead.
+
+The largest allowed file size is 10GiB (10,737,418,240 bytes).


### PR DESCRIPTION
I was uploading a 12GB file to Onedrive and got this error: `Failed to copy: invalidRequest: maxFileSizeExceeded: Declared file size too large. The largest allowed file size is 10737418240 bytes`. Didn't see it anywhere in the docs, so I thought I'd add it.