### PR TITLE
couple of changes around --stats flag

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -295,7 +295,7 @@ func initConfig() {
 			}
 		}()
 	}
-	
+
 	if m, _ := regexp.MatchString("bits|bytes", *dataRateUnit); m == false {
 		log.Print("Invalid unit passed to --stats-unit. Defaulting to bytes.")
 		fs.Config.DataRateUnit = "bytes"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,10 +11,10 @@ import (
 	"log"
 	"os"
 	"path"
+	"regexp"
 	"runtime"
 	"runtime/pprof"
 	"time"
-	"regexp"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"time"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -27,6 +28,7 @@ var (
 	cpuProfile    = pflag.StringP("cpuprofile", "", "", "Write cpu profile to file")
 	memProfile    = pflag.String("memprofile", "", "Write memory profile to file")
 	statsInterval = pflag.DurationP("stats", "", time.Minute*1, "Interval between printing stats, e.g 500ms, 60s, 5m. (0 to disable)")
+	dataRateUnit  = pflag.StringP("stats-unit", "", "bytes", "Show stats data rate in either bits/s or bytes/s")
 	version       bool
 	logFile       = pflag.StringP("log-file", "", "", "Log everything to this file")
 	retries       = pflag.IntP("retries", "", 3, "Retry operations this many times if they fail")
@@ -292,5 +294,12 @@ func initConfig() {
 				log.Fatal(err)
 			}
 		}()
+	}
+	
+	if m, _ := regexp.MatchString("bits|bytes", *dataRateUnit); m == false {
+		log.Print("Invalid unit passed to --stats-unit. Defaulting to bytes.")
+		fs.Config.DataRateUnit = "bytes"
+	} else {
+		fs.Config.DataRateUnit = *dataRateUnit
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,7 +26,7 @@ var (
 	// Flags
 	cpuProfile    = pflag.StringP("cpuprofile", "", "", "Write cpu profile to file")
 	memProfile    = pflag.String("memprofile", "", "Write memory profile to file")
-	statsInterval = pflag.DurationP("stats", "", time.Minute*1, "Interval to print stats (0 to disable)")
+	statsInterval = pflag.DurationP("stats", "", time.Minute*1, "Interval between printing stats, e.g 500ms, 60s, 5m. (0 to disable)")
 	version       bool
 	logFile       = pflag.StringP("log-file", "", "", "Log everything to this file")
 	retries       = pflag.IntP("retries", "", 3, "Retry operations this many times if they fail")

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -396,6 +396,19 @@ This sets the interval.
 
 The default is `1m`. Use 0 to disable.
 
+### --stats-unit=bits|bytes ###
+
+By default data transfer rates will be printed in bytes/second.  
+
+This option allows the data rate to be printed in bits/second. 
+
+Data transfer volume will still be reported in bytes.
+
+The rate is reported as a binary unit, not SI unit. So 1 Mbit/s 
+equals 1,048,576 bits/s and not 1,000,000 bits/s.
+
+The default is `bytes`.
+
 ### --delete-(before,during,after) ###
 
 This option allows you to specify when files on your destination are

--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -129,11 +129,11 @@ func (s *StatsInfo) String() string {
 	}
 	dtRounded := dt - (dt % (time.Second / 10))
 	buf := &bytes.Buffer{}
-	
+
 	if Config.DataRateUnit == "bits" {
 		speed = speed * 8
 	}
-	
+
 	fmt.Fprintf(buf, `
 %-20s: %-10s (%-s)
 %-20s: %-10d
@@ -448,11 +448,11 @@ func (acc *Account) String() string {
 		where := len(name) - 42
 		name = append([]rune{'.', '.', '.'}, name[where:]...)
 	}
-	
+
 	if Config.DataRateUnit == "bits" {
 		cur, avg = cur*8, avg*8
 	}
-	
+
 	if b <= 0 {
 		return fmt.Sprintf("%-21s %s avg: %s, cur: %s. ETA: %s",
 			"*",

--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -132,12 +132,8 @@ func (s *StatsInfo) String() string {
 	dtRounded := dt - (dt % (time.Second / 10))
 	buf := &bytes.Buffer{}
 	
-	transferVolume, transferSpeed := s.bytes, speed
-	transferVolumeUnit, transferSpeedUnit := "Bytes", "Bytes/s"
-
-	if *statsBps {
-		transferVolume, transferSpeed = s.bytes*8, speed*8
-	  	transferVolumeUnit, transferSpeedUnit = "Bits", "Bits/s"
+	if Config.DataRateUnit == "bits" {
+		speed = speed * 8
 	}
 	
 	fmt.Fprintf(buf, `
@@ -148,7 +144,7 @@ func (s *StatsInfo) String() string {
 %-20s: %-10v
 `,
 		"Transferred",
-		SizeSuffix(transferVolume).Unit(transferVolumeUnit), SizeSuffix(transferSpeed).Unit(transferSpeedUnit),
+		SizeSuffix(s.bytes).Unit("Bytes"), SizeSuffix(speed).Unit(strings.Title(Config.DataRateUnit)+"/s"),
 		"Errors",
 		s.errors,
 		"Checks",
@@ -455,28 +451,24 @@ func (acc *Account) String() string {
 		name = append([]rune{'.', '.', '.'}, name[where:]...)
 	}
 	
-	curSpeed, avgSpeed := cur, avg
-	speedUnit := "Bytes/s"
-
-	if *statsBps {
-		curSpeed, avgSpeed = cur*8, avg*8
-		speedUnit = "Bits/s"
+	if Config.DataRateUnit == "bits" {
+		cur, avg = cur*8, avg*8
 	}
 	
 	if b <= 0 {
 		return fmt.Sprintf("%-21s %s avg: %s, cur: %s. ETA: %s",
 			"*",
 			string(name),
-			SizeSuffix(avgSpeed).Unit(speedUnit),
-			SizeSuffix(curSpeed).Unit(speedUnit),
+			SizeSuffix(avg).Unit(strings.Title(Config.DataRateUnit)+"/s"),
+			SizeSuffix(cur).Unit(strings.Title(Config.DataRateUnit)+"/s"),
 			etas)
 	}
 	return fmt.Sprintf("%-21s %s %2d%% done. avg: %s, cur: %s. ETA: %s",
 		"*",
 		string(name),
 		int(100*float64(a)/float64(b)),
-		SizeSuffix(avgSpeed).Unit(speedUnit),
-		SizeSuffix(curSpeed).Unit(speedUnit),
+		SizeSuffix(avg).Unit(strings.Title(Config.DataRateUnit)+"/s"),
+		SizeSuffix(cur).Unit(strings.Title(Config.DataRateUnit)+"/s"),
 		etas)
 }
 

--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spf13/pflag"
 	"github.com/VividCortex/ewma"
 	"github.com/tsenart/tb"
 )
@@ -22,7 +21,6 @@ var (
 	tokenBucketMu   sync.Mutex // protects the token bucket variables
 	tokenBucket     *tb.Bucket
 	prevTokenBucket = tokenBucket
-	statsBps        = pflag.BoolP("statsbps", "", false, "Show stats output in bits per second")
 )
 
 // Start the token bucket if necessary

--- a/fs/config.go
+++ b/fs/config.go
@@ -301,6 +301,7 @@ type ConfigInfo struct {
 	IgnoreSize         bool
 	NoTraverse         bool
 	NoUpdateModTime    bool
+	DataRateUnit       string
 }
 
 // Find the config directory


### PR DESCRIPTION
- Added example to `--stats` flag to make it more obvious what are syntax for duration is.  

- Added `--statsbps` option to output stats in bits per second. I find this easier to monitor the speed of file transfers and coorelate them to my available bandwidth. e.g. my home broadband is 100Mbit and my VPS uplink is 1000Mbit so viewing output in Bits/s, KBits/s and MBits/s is just easier. 

Example of aligned output

```
2016/11/22 11:45:49
Transferred         : 60.000 MBits (2.683 MBits/s)
Errors              : 0
Checks              : 0
Transferred         : 0
Elapsed time        : 22.3s
Transferring        :
*                     Learning Couchbase.pdf 33% done. avg: 2.000 MBits/s, cur: 1.292 MBits/s. ETA: 49s
*                     Learning Flask Framework.pdf 30% done. avg: 1.805 MBits/s, cur: 1.145 MBits/s. ETA: 55s
```