### PR TITLE
clarification added in amazonclouddrive.md and filtering.md

### DIFF
--- a/docs/content/amazonclouddrive.md
+++ b/docs/content/amazonclouddrive.md
@@ -175,4 +175,5 @@ This means that larger files are likely to fail.
 Unfortunatly there is no way for rclone to see that this failure is 
 because of file size, so it will retry the operation, as any other
 failure. To avoid this problem, use `--max-size 50000M` option to limit
-the maximum size of uploaded files.
+the maximum size of uploaded files. Note that `--max-size` does not split
+files into segments, it only ignores files over this size.

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -29,9 +29,10 @@ The patterns used to match files for inclusion or exclusion are based
 on "file globs" as used by the unix shell.
 
 If the pattern starts with a `/` then it only matches at the top level
-of the directory tree, relative to the root of the remote.
-If it doesn't start with `/` then it is matched starting at the
-**end of the path**, but it will only match a complete path element:
+of the directory tree, **relative to the root of the remote** (not 
+necessarily the root of the local drive). If it doesn't start with `/` 
+then it is matched starting at the **end of the path**, but it will 
+only match a complete path element:
 
     file.jpg  - matches "file.jpg"
               - matches "directory/file.jpg"


### PR DESCRIPTION
Added some clarification about `--max-size` in amazoncloudrive.md and `/` in filtering.md