### PR TITLE
Typo: the the -> the in docs and comments

### DIFF
--- a/MANUAL.html
+++ b/MANUAL.html
@@ -207,14 +207,14 @@ rclone --dry-run --min-size 100M delete remote:path</code></pre>
 <p><code>--size-only</code> may be used to only compare the sizes, not the MD5SUMs.</p>
 <pre><code>rclone check source:path dest:path</code></pre>
 <h2 id="rclone-ls">rclone ls</h2>
-<p>List all the objects in the the path with size and path.</p>
+<p>List all the objects in the path with size and path.</p>
 <h3 id="synopsis-9">Synopsis</h3>
-<p>List all the objects in the the path with size and path.</p>
+<p>List all the objects in the path with size and path.</p>
 <pre><code>rclone ls remote:path</code></pre>
 <h2 id="rclone-lsd">rclone lsd</h2>
-<p>List all directories/containers/buckets in the the path.</p>
+<p>List all directories/containers/buckets in the path.</p>
 <h3 id="synopsis-10">Synopsis</h3>
-<p>List all directories/containers/buckets in the the path.</p>
+<p>List all directories/containers/buckets in the path.</p>
 <pre><code>rclone lsd remote:path</code></pre>
 <h2 id="rclone-lsl">rclone lsl</h2>
 <p>List all the objects path with modification time, size and path.</p>

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -404,12 +404,12 @@ rclone check source:path dest:path
 
 ## rclone ls
 
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 
 ### Synopsis
 
 
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 
 ```
 rclone ls remote:path
@@ -417,12 +417,12 @@ rclone ls remote:path
 
 ## rclone lsd
 
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 
 ### Synopsis
 
 
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 
 ```
 rclone lsd remote:path

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -380,22 +380,22 @@ alter the source or destination.
 
 rclone ls
 
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 
 Synopsis
 
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 
     rclone ls remote:path
 
 
 rclone lsd
 
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 
 Synopsis
 
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 
     rclone lsd remote:path
 

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -14,7 +14,7 @@ func init() {
 
 var commandDefintion = &cobra.Command{
 	Use:   "ls remote:path",
-	Short: `List all the objects in the the path with size and path.`,
+	Short: `List all the objects in the path with size and path.`,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)

--- a/cmd/lsd/lsd.go
+++ b/cmd/lsd/lsd.go
@@ -14,7 +14,7 @@ func init() {
 
 var commandDefintion = &cobra.Command{
 	Use:   "lsd remote:path",
-	Short: `List all directories/containers/buckets in the the path.`,
+	Short: `List all directories/containers/buckets in the path.`,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)

--- a/docs/content/commands/rclone.md
+++ b/docs/content/commands/rclone.md
@@ -131,8 +131,8 @@ rclone
 * [rclone genautocomplete](/commands/rclone_genautocomplete/)	 - Output bash completion script for rclone.
 * [rclone gendocs](/commands/rclone_gendocs/)	 - Output markdown docs for rclone to the directory supplied.
 * [rclone listremotes](/commands/rclone_listremotes/)	 - List all the remotes in the config file.
-* [rclone ls](/commands/rclone_ls/)	 - List all the objects in the the path with size and path.
-* [rclone lsd](/commands/rclone_lsd/)	 - List all directories/containers/buckets in the the path.
+* [rclone ls](/commands/rclone_ls/)	 - List all the objects in the path with size and path.
+* [rclone lsd](/commands/rclone_lsd/)	 - List all directories/containers/buckets in the path.
 * [rclone lsl](/commands/rclone_lsl/)	 - List all the objects path with modification time, size and path.
 * [rclone md5sum](/commands/rclone_md5sum/)	 - Produces an md5sum file for all the objects in the path.
 * [rclone mkdir](/commands/rclone_mkdir/)	 - Make the path if it doesn't already exist.

--- a/docs/content/commands/rclone_ls.md
+++ b/docs/content/commands/rclone_ls.md
@@ -6,12 +6,12 @@ url: /commands/rclone_ls/
 ---
 ## rclone ls
 
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 
 ### Synopsis
 
 
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 
 ```
 rclone ls remote:path

--- a/docs/content/commands/rclone_lsd.md
+++ b/docs/content/commands/rclone_lsd.md
@@ -6,12 +6,12 @@ url: /commands/rclone_lsd/
 ---
 ## rclone lsd
 
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 
 ### Synopsis
 
 
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 
 ```
 rclone lsd remote:path

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -67,8 +67,8 @@ The main rclone commands with most used first
 * [rclone mkdir](/commands/rclone_mkdir/)	 - Make the path if it doesn't already exist.
 * [rclone rmdir](/commands/rclone_rmdir/)	 - Remove the path.
 * [rclone check](/commands/rclone_check/)	 - Checks the files in the source and destination match.
-* [rclone ls](/commands/rclone_ls/)	 - List all the objects in the the path with size and path.
-* [rclone lsd](/commands/rclone_lsd/)	 - List all directories/containers/buckets in the the path.
+* [rclone ls](/commands/rclone_ls/)	 - List all the objects in the path with size and path.
+* [rclone lsd](/commands/rclone_lsd/)	 - List all directories/containers/buckets in the path.
 * [rclone lsl](/commands/rclone_lsl/)	 - List all the objects path with modification time, size and path.
 * [rclone md5sum](/commands/rclone_md5sum/)	 - Produces an md5sum file for all the objects in the path.
 * [rclone sha1sum](/commands/rclone_sha1sum/)	 - Produces an sha1sum file for all the objects in the path.

--- a/rclone.1
+++ b/rclone.1
@@ -511,10 +511,10 @@ rclone\ check\ source:path\ dest:path
 .fi
 .SS rclone ls
 .PP
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 .SS Synopsis
 .PP
-List all the objects in the the path with size and path.
+List all the objects in the path with size and path.
 .IP
 .nf
 \f[C]
@@ -523,10 +523,10 @@ rclone\ ls\ remote:path
 .fi
 .SS rclone lsd
 .PP
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 .SS Synopsis
 .PP
-List all directories/containers/buckets in the the path.
+List all directories/containers/buckets in the path.
 .IP
 .nf
 \f[C]

--- a/vendor/bazil.org/fuse/fuse.go
+++ b/vendor/bazil.org/fuse/fuse.go
@@ -319,7 +319,7 @@ func (h *Header) respond(msg []byte) {
 // Operations may return an error value that implements ErrorNumber to
 // control what specific error number (errno) to return.
 type ErrorNumber interface {
-	// Errno returns the the error number (errno) for this error.
+	// Errno returns the error number (errno) for this error.
 	Errno() Errno
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3iface/interface.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3iface/interface.go
@@ -20,7 +20,7 @@ import (
 //
 // The best way to use this interface is so the SDK's service client's calls
 // can be stubbed out for unit testing your code with the SDK without needing
-// to inject custom request handlers into the the SDK's request pipeline.
+// to inject custom request handlers into the SDK's request pipeline.
 //
 //    // myFunc uses an SDK service client to make a request to
 //    // Amazon Simple Storage Service.

--- a/vendor/github.com/davecgh/go-spew/spew/config.go
+++ b/vendor/github.com/davecgh/go-spew/spew/config.go
@@ -219,7 +219,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), and %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/davecgh/go-spew/spew/doc.go
+++ b/vendor/github.com/davecgh/go-spew/spew/doc.go
@@ -156,7 +156,7 @@ standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/davecgh/go-spew/spew/format.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format.go
@@ -405,7 +405,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/ncw/swift/swift.go
+++ b/vendor/github.com/ncw/swift/swift.go
@@ -94,7 +94,7 @@ type Connection struct {
 	Timeout        time.Duration     // Data channel timeout (default 60s)
 	Region         string            // Region to use eg "LON", "ORD" - default is use first region (v2,v3 auth only)
 	AuthVersion    int               // Set to 1, 2 or 3 or leave at 0 for autodetect
-	Internal       bool              // Set this to true to use the the internal / service network
+	Internal       bool              // Set this to true to use the internal / service network
 	Tenant         string            // Name of the tenant (v2,v3 auth only)
 	TenantId       string            // Id of the tenant (v2,v3 auth only)
 	EndpointType   EndpointType      // Endpoint type (v2,v3 auth only) (default is public URL unless Internal is set)

--- a/vendor/golang.org/x/net/http2/hpack/encode.go
+++ b/vendor/golang.org/x/net/http2/hpack/encode.go
@@ -217,7 +217,7 @@ func appendVarInt(dst []byte, n byte, i uint64) []byte {
 }
 
 // appendHpackString appends s, as encoded in "String Literal"
-// representation, to dst and returns the the extended buffer.
+// representation, to dst and returns the extended buffer.
 //
 // s will be encoded in Huffman codes only when it produces strictly
 // shorter byte string.

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -318,7 +318,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
 			// addresses during development.
 			//
 			// TODO: optionally enforce? Or enforce at the time we receive
-			// a new request, and verify the the ServerName matches the :authority?
+			// a new request, and verify the ServerName matches the :authority?
 			// But that precludes proxy situations, perhaps.
 			//
 			// So for now, do nothing here again.

--- a/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -18,7 +18,7 @@ import (
 
 // ParseKey converts the binary contents of a private key file
 // to an *rsa.PrivateKey. It detects whether the private key is in a
-// PEM container or not. If so, it extracts the the private key
+// PEM container or not. If so, it extracts the private key
 // from PEM container before conversion. It only supports PEM
 // containers with no passphrase.
 func ParseKey(key []byte) (*rsa.PrivateKey, error) {


### PR DESCRIPTION
I noticed that in a lot of places it says `the the` instead of `the`.

So often I wasn't sure if maybe it's actually meant to say e.g. `List all the objects in the the path`. But then there's places with sentences like `If so, it extracts the the private key` which definitely sounds wrong.

I ran a global `s/the the/the/` over all files in the repo. Hope this makes sense.