### PR TITLE
Add time-based bandwidth limits.

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -188,15 +188,34 @@ for bytes, `k` for kBytes, `M` for MBytes and `G` for GBytes may be
 used.  These are the binary units, eg 1, 2\*\*10, 2\*\*20, 2\*\*30
 respectively.
 
-### --bwlimit=SIZE ###
+### --bwlimit=BANDWIDTH_SPEC ###
 
-Bandwidth limit in kBytes/s, or use suffix b|k|M|G.  The default is `0`
-which means to not limit bandwidth.
+This option controls the bandwidth limit. Limits can be specified
+in two ways: As a single limit, or as a timetable.
+
+Single limits last for the duration of the session. To use a single limit,
+specify the desired bandwidth in kBytes/s, or use a suffix b|k|M|G.  The
+default is `0` which means to not limit bandwidth.
 
 For example to limit bandwidth usage to 10 MBytes/s use `--bwlimit 10M`
 
-This only limits the bandwidth of the data transfer, it doesn't limit
-the bandwith of the directory listings etc.
+It is also possible to specify a "timetable" of limits, which will cause
+certain limits to be applied at certain times. To specify a timetable, format your
+entries as "HH:MM,BANDWIDTH HH:MM,BANDWITH...".
+
+An example of a typical timetable to avoid link saturation during daytime
+working hours could be:
+
+`--bwlimit "08:00,512 12:00,10M 13:00,512 18:00,30M 23:00,off"`
+
+In this example, the transfer bandwidth will be set to 512kBytes/sec at 8am.
+At noon, it will raise to 10Mbytes/s, and drop back to 512kBytes/sec at 1pm.
+At 6pm, the bandwidth limit will be set to 30MBytes/s, and at 11pm it will be
+completely disabled (full speed). Anything between 11pm and 8am will remain
+unlimited.
+
+Bandwidth limits only apply to the data transfer. The don't apply to the
+bandwith of the directory listings etc.
 
 Note that the units are Bytes/s not Bits/s.  Typically connections are
 measured in Bits/s - to convert divide by 8.  For example let's say

--- a/fs/config.go
+++ b/fs/config.go
@@ -50,6 +50,15 @@ const (
 // SizeSuffix is parsed by flag with k/M/G suffixes
 type SizeSuffix int64
 
+// BwTimeSlot represents a bandwidth configuration at a point in time.
+type BwTimeSlot struct {
+	hhmm      int
+	bandwidth SizeSuffix
+}
+
+// BwTimetable contains all configured time slots.
+type BwTimetable []BwTimeSlot
+
 // Global
 var (
 	// ConfigFile is the config file data structure
@@ -89,7 +98,7 @@ var (
 	ignoreSize      = pflag.BoolP("ignore-size", "", false, "Ignore size when skipping use mod-time or checksum.")
 	noTraverse      = pflag.BoolP("no-traverse", "", false, "Don't traverse destination file system on copy.")
 	noUpdateModTime = pflag.BoolP("no-update-modtime", "", false, "Don't update destination mod-time if files identical.")
-	bwLimit         SizeSuffix
+	bwLimit         BwTimetable
 
 	// Key to use for password en/decryption.
 	// When nil, no encryption will be used for saving.
@@ -97,7 +106,7 @@ var (
 )
 
 func init() {
-	pflag.VarP(&bwLimit, "bwlimit", "", "Bandwidth limit in kBytes/s, or use suffix b|k|M|G")
+	pflag.VarP(&bwLimit, "bwlimit", "", "Bandwidth limit in kBytes/s, or use suffix b|k|M|G or a full timetable.")
 }
 
 // Turn SizeSuffix into a string and a suffix
@@ -190,6 +199,122 @@ func (x *SizeSuffix) Type() string {
 
 // Check it satisfies the interface
 var _ pflag.Value = (*SizeSuffix)(nil)
+
+// String returns a printable representation of BwTimetable.
+func (x BwTimetable) String() string {
+	ret := []string{}
+	for _, ts := range x {
+		ret = append(ret, fmt.Sprintf("%04.4d,%s", ts.hhmm, ts.bandwidth.String()))
+	}
+	return strings.Join(ret, " ")
+}
+
+// Set the bandwidth timetable.
+func (x *BwTimetable) Set(s string) error {
+	// The timetable is formatted as:
+	// "hh:mm,bandwidth hh:mm,banwidth..." ex: "10:00,10G 11:30,1G 18:00,off"
+	// If only a single bandwidth identifier is provided, we assume constant bandwidth.
+
+	if len(s) == 0 {
+		return errors.New("empty string")
+	}
+	// Single value without time specification.
+	if !strings.Contains(s, " ") && !strings.Contains(s, ",") {
+		ts := BwTimeSlot{}
+		if err := ts.bandwidth.Set(s); err != nil {
+			return err
+		}
+		ts.hhmm = 0
+		*x = BwTimetable{ts}
+		return nil
+	}
+
+	for _, tok := range strings.Split(s, " ") {
+		tv := strings.Split(tok, ",")
+
+		// Format must be HH:MM,BW
+		if len(tv) != 2 {
+			return errors.Errorf("invalid time/bandwidth specification: %q", tok)
+		}
+
+		// Basic timespec sanity checking
+		hhmm := tv[0]
+		if len(hhmm) != 5 {
+			return errors.Errorf("invalid time specification (hh:mm): %q", hhmm)
+		}
+		hh, err := strconv.Atoi(hhmm[0:2])
+		if err != nil {
+			return errors.Errorf("invalid hour in time specification %q: %v", hhmm, err)
+		}
+		if hh < 0 || hh > 23 {
+			return errors.Errorf("invalid hour (must be between 00 and 23): %q", hh)
+		}
+		mm, err := strconv.Atoi(hhmm[3:])
+		if err != nil {
+			return errors.Errorf("invalid minute in time specification: %q: %v", hhmm, err)
+		}
+		if mm < 0 || mm > 59 {
+			return errors.Errorf("invalid minute (must be between 00 and 59): %q", hh)
+		}
+
+		ts := BwTimeSlot{
+			hhmm: (hh * 100) + mm,
+		}
+		// Bandwidth limit for this time slot.
+		if err := ts.bandwidth.Set(tv[1]); err != nil {
+			return err
+		}
+		*x = append(*x, ts)
+	}
+	return nil
+}
+
+// LimitAt returns a BwTimeSlot for the time requested.
+func (x BwTimetable) LimitAt(tt time.Time) BwTimeSlot {
+	// If the timetable is empty, we return an unlimited BwTimeSlot starting at midnight.
+	if len(x) == 0 {
+		return BwTimeSlot{hhmm: 0, bandwidth: -1}
+	}
+
+	hhmm := tt.Hour()*100 + tt.Minute()
+
+	// By default, we return the last element in the timetable. This
+	// satisfies two conditions: 1) If there's only one element it
+	// will always be selected, and 2) The last element of the table
+	// will "wrap around" until overriden by an earlier time slot.
+	// there's only one time slot in the timetable.
+	ret := x[len(x)-1]
+
+	mindif := 0
+	first := true
+
+	// Look for most recent time slot.
+	for _, ts := range x {
+		// Ignore the past
+		if hhmm < ts.hhmm {
+			continue
+		}
+		dif := ((hhmm / 100 * 60) + (hhmm % 100)) - ((ts.hhmm / 100 * 60) + (ts.hhmm % 100))
+		if first {
+			mindif = dif
+			first = false
+		}
+		if dif <= mindif {
+			mindif = dif
+			ret = ts
+		}
+	}
+
+	return ret
+}
+
+// Type of the value
+func (x BwTimetable) Type() string {
+	return "BwTimetable"
+}
+
+// Check it satisfies the interface
+var _ pflag.Value = (*BwTimetable)(nil)
 
 // crypt internals
 var (
@@ -392,6 +517,9 @@ func LoadConfig() {
 
 	// Start the token bucket limiter
 	startTokenBucket()
+
+	// Start the bandwidth update ticker
+	startTokenTicker()
 }
 
 var errorConfigFileNotFound = errors.New("config file not found")


### PR DESCRIPTION
- Change the --bwlimit command line parameter to accept both a limit (as
  before) or a full timetable (formatted as "hh:mm,limit
  hh:mm,limit...")
- The timetable is checked once a minute by a ticker function. A new
  tokenBucket is created every time a bandwidth change is necessary.
- This change is compatible with the SIGUSR2 change to toggle bandwidth
  limits.