### PR TITLE
Only start bandwidth ticker when necessary.

### DIFF
--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -43,6 +43,12 @@ func startTokenBucket() {
 
 // startTokenTicker creates a ticker to update the bandwidth limiter every minute.
 func startTokenTicker() {
+	// If the timetable has a single entry or was not specified, we don't need
+	// a ticker to update the bandwidth.
+	if len(bwLimit) <= 1 {
+		return
+	}
+
 	ticker := time.NewTicker(time.Minute)
 	go func() {
 		for range ticker.C {


### PR DESCRIPTION
- Only start the token ticker when the timetable entry has more than one
  entry.
- This fixes the "Scheduled bandwidth change" log message when no
  bwlimit is specified.
- Fixes #987