### PR TITLE
Return error on not found from ListFn

### DIFF
--- a/fs/operations.go
+++ b/fs/operations.go
@@ -654,7 +654,10 @@ func ListFn(f Fs, fn func(Object)) error {
 			for {
 				o, err := list.GetObject()
 				if err != nil {
-					log.Fatal(err)
+					// The error will be persisted within the Lister object and
+					// we'll get an opportunity to return it as we leave this
+					// function.
+					return
 				}
 				// check if we are finished
 				if o == nil {
@@ -667,7 +670,7 @@ func ListFn(f Fs, fn func(Object)) error {
 		}()
 	}
 	wg.Wait()
-	return nil
+	return list.Error()
 }
 
 // mutex for synchronized output


### PR DESCRIPTION
This changes `ListFn`'s implementation so that if it encounters a not
found error, instead of sending a fatal error to log, it coordinates the
return of the error between checker goroutines and sends it back to the
caller.

The main impotus here is that it allows an external program compiling
against rclone as a package to handle a not found, where it currently it
cannot. I'm sure that using rclone's API is not recommended, but I've
found it useful for some personal projects, and I think this change
makes thing strictly less surprising and more consistent.

This does change error output on a not found a little bit, we go from
this:

    2017/01/09 21:14:03 directory not found

To this:

    2017/01/09 21:13:44 Failed to ls: directory not found

This seems okay to me, but I'd defer to more expert opinions.