### PR TITLE
Initial internal support for DirCopy

### DIFF
--- a/MANUAL.html
+++ b/MANUAL.html
@@ -1067,6 +1067,7 @@ The hashes are used when transferring data as an integrity check and can be spec
 <th align="center">Purge</th>
 <th align="center">Copy</th>
 <th align="center">Move</th>
+<th align="center">DirCopy</th>
 <th align="center">DirMove</th>
 <th align="center">CleanUp</th>
 </tr>
@@ -1171,8 +1172,10 @@ The hashes are used when transferring data as an integrity check and can be spec
 <h3 id="move">Move</h3>
 <p>Used when moving/renaming an object on the same remote. This is known as a server side move of a file. This is used in <code>rclone move</code> if the server doesn't support <code>DirMove</code>.</p>
 <p>If the server isn't capable of <code>Move</code> then rclone simulates it with <code>Copy</code> then delete. If the server doesn't support <code>Copy</code> then rclone will download the file and re-upload it.</p>
+<h3 id="dircopy">DirCopy</h3>
+<p>This is used to implement <code>rclone copy</code> to copy an entire directory if possible. If it isn't then it will use <code>Copy</code> on each file (which falls back to download and upload - see <code>Move</code> section), and Mkdir on each directory (if implemented).</p>
 <h3 id="dirmove">DirMove</h3>
-<p>This is used to implement <code>rclone move</code> to move a directory if possible. If it isn't then it will use <code>Move</code> on each file (which falls back to <code>Copy</code> then download and upload - see <code>Move</code> section).</p>
+<p>This is used to implement <code>rclone move</code> to move a directory if possible. If it isn't then it will use <code>Move</code> on each file (which falls back to <code>Copy</code> then download and upload - see <code>Move</code> section)i, followed by a delete of the original.</p>
 <h3 id="cleanup">CleanUp</h3>
 <p>This is used for emptying the trash for a remote by <code>rclone cleanup</code>.</p>
 <p>If the server can't do <code>CleanUp</code> then <code>rclone cleanup</code> will return an error.</p>

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2120,19 +2120,19 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some
 operations more efficient.
 
-| Name                   | Purge | Copy | Move | DirMove | CleanUp |
-| ---------------------- |:-----:|:----:|:----:|:-------:|:-------:|
-| Google Drive           | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) | 
-| Amazon S3              | No    | Yes  | No   | No      | No      |
-| Openstack Swift        | Yes † | Yes  | No   | No      | No      |
-| Dropbox                | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |
-| Google Cloud Storage   | Yes   | Yes  | No   | No      | No      |
-| Amazon Drive           | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) |
-| Microsoft One Drive    | Yes   | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) |
-| Hubic                  | Yes † | Yes  | No   | No      | No      |
-| Backblaze B2           | No    | No   | No   | No      | Yes     |
-| Yandex Disk            | Yes   | No   | No   | No      | No  [#575](https://github.com/ncw/rclone/issues/575) |
-| The local filesystem   | Yes   | No   | Yes  | Yes     | No      |
+| Name                   | Purge | Copy | Move | DirCopy | DirMove | CleanUp |
+| ---------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-------:|
+| Google Drive           | Yes   | Yes  | Yes  | No      | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |
+| Amazon S3              | No    | Yes  | No   | No      | No      | No      |
+| Openstack Swift        | Yes † | Yes  | No   | No      | No      | No      |
+| Dropbox                | Yes   | Yes  | Yes  | No      | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |
+| Google Cloud Storage   | Yes   | Yes  | No   | No      | No      | No      |
+| Amazon Drive           | Yes   | No   | Yes  | No      | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) |
+| Microsoft One Drive    | Yes   | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No      | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) |
+| Hubic                  | Yes † | Yes  | No   | No      | No      | No      |
+| Backblaze B2           | No    | No   | No   | No      | No      | Yes     |
+| Yandex Disk            | Yes   | No   | No   | No      | No      | No  [#575](https://github.com/ncw/rclone/issues/575) |
+| The local filesystem   | Yes   | No   | Yes  | No      | Yes     | No      |
 
 
 ### Purge ###
@@ -2168,7 +2168,8 @@ will download the file and re-upload it.
 
 This is used to implement `rclone move` to move a directory if
 possible.  If it isn't then it will use `Move` on each file (which
-falls back to `Copy` then download and upload - see `Move` section).
+falls back to `Copy` then download and upload - see `Move` section),
+followed by a delete of the original.
 
 ### CleanUp ###
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2018,19 +2018,19 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some operations
 more efficient.
 
-  Name                    Purge   Copy    Move     DirMove   CleanUp
-  ---------------------- ------- ------ --------- --------- ---------
-  Google Drive             Yes    Yes      Yes       Yes     No #575
-  Amazon S3                No     Yes      No        No        No
-  Openstack Swift         Yes †   Yes      No        No        No
-  Dropbox                  Yes    Yes      Yes       Yes     No #575
-  Google Cloud Storage     Yes    Yes      No        No        No
-  Amazon Drive             Yes     No      Yes       Yes     No #575
-  Microsoft One Drive      Yes    Yes    No #197   No #197   No #575
-  Hubic                   Yes †   Yes      No        No        No
-  Backblaze B2             No      No      No        No        Yes
-  Yandex Disk              Yes     No      No        No      No #575
-  The local filesystem     Yes     No      Yes       Yes       No
+  Name                    Purge   Copy    Move     DirCopy   DirMove   CleanUp
+  ---------------------- ------- ------ --------- --------- --------- ---------
+  Google Drive             Yes    Yes      Yes       No        Yes     No #575
+  Amazon S3                No     Yes      No        No        No        No
+  Openstack Swift         Yes †   Yes      No        No        No        No
+  Dropbox                  Yes    Yes      Yes       No        Yes     No #575
+  Google Cloud Storage     Yes    Yes      No        No        No        No
+  Amazon Drive             Yes     No      Yes       No        Yes     No #575
+  Microsoft One Drive      Yes    Yes    No #197   No        No #197   No #575
+  Hubic                   Yes †   Yes      No        No        No        No
+  Backblaze B2             No      No      No        No        No        Yes
+  Yandex Disk              Yes     No      No        No        No      No #575
+  The local filesystem     Yes     No      Yes       No        Yes       No
 
 Purge
 
@@ -2061,11 +2061,18 @@ If the server isn't capable of Move then rclone simulates it with Copy
 then delete. If the server doesn't support Copy then rclone will
 download the file and re-upload it.
 
+DirCopy
+
+This is used to implement rclone copy to copy a directory if possible.
+If it isn't then it will use Copy on each file (which falls back to
+download and upload - see Copy section).
+
 DirMove
 
 This is used to implement rclone move to move a directory if possible.
 If it isn't then it will use Move on each file (which falls back to Copy
-then download and upload - see Move section).
+then download and upload - see Move section), followed by a delete of the
+original.
 
 CleanUp
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -101,19 +101,19 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some
 operations more efficient.
 
-| Name                   | Purge | Copy | Move | DirMove | CleanUp |
+| Name                   | Purge | Copy | Move | DirCopy | DirMove | CleanUp |
 | ---------------------- |:-----:|:----:|:----:|:-------:|:-------:|
-| Google Drive           | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) | 
-| Amazon S3              | No    | Yes  | No   | No      | No      |
-| Openstack Swift        | Yes † | Yes  | No   | No      | No      |
-| Dropbox                | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |
-| Google Cloud Storage   | Yes   | Yes  | No   | No      | No      |
-| Amazon Drive           | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) |
-| Microsoft One Drive    | Yes   | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) |
-| Hubic                  | Yes † | Yes  | No   | No      | No      |
-| Backblaze B2           | No    | No   | No   | No      | Yes     |
-| Yandex Disk            | Yes   | No   | No   | No      | No  [#575](https://github.com/ncw/rclone/issues/575) |
-| The local filesystem   | Yes   | No   | Yes  | Yes     | No      |
+| Google Drive           | Yes   | Yes  | Yes  | No      | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |
+| Amazon S3              | No    | Yes  | No   | No      | No      | No      |
+| Openstack Swift        | Yes † | Yes  | No   | No      | No      | No      |
+| Dropbox                | Yes   | Yes  | Yes  | No      | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |
+| Google Cloud Storage   | Yes   | Yes  | No   | No      | No      | No      |
+| Amazon Drive           | Yes   | No   | Yes  | No      | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) |
+| Microsoft One Drive    | Yes   | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No      | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) |
+| Hubic                  | Yes † | Yes  | No   | No      | No      | No      |
+| Backblaze B2           | No    | No   | No   | No      | No      | Yes     |
+| Yandex Disk            | Yes   | No   | No   | No      | No      | No  [#575](https://github.com/ncw/rclone/issues/575) |
+| The local filesystem   | Yes   | No   | Yes  | No      | Yes     | No      |
 
 
 ### Purge ###
@@ -145,11 +145,19 @@ If the server isn't capable of `Move` then rclone simulates it with
 `Copy` then delete.  If the server doesn't support `Copy` then rclone
 will download the file and re-upload it.
 
+### DirCopy ###
+
+This is used to implement `rclone copy` to move a directory if
+possible.  If it isn't then it will use `Copy` on each file (which
+falls back to download and upload - see `Move` section), and Mkdir
+on each directory (if implemented).
+
 ### DirMove ###
 
 This is used to implement `rclone move` to move a directory if
 possible.  If it isn't then it will use `Move` on each file (which
-falls back to `Copy` then download and upload - see `Move` section).
+falls back to `Copy` then download and upload - see `Move` section),
+followed by a delete of the original.
 
 ### CleanUp ###
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -267,7 +267,7 @@ type Features struct {
 	// If it isn't possible then return fs.ErrorCantDirCopy
 	//
 	// If destination exists then return fs.ErrorDirExists
-	DirCopy func(src Object, remote string) (Object, error)
+	DirCopy func(src Fs) error
 
 	// DirMove moves src to this remote using server side move
 	// operations.
@@ -440,7 +440,7 @@ type DirCopier interface {
 	// Will only be called if src.Fs().Name() == f.Name()
 	//
 	// If it isn't possible then return fs.ErrorCantCopy
-	DirCopy(src Object, remote string) (Object, error)
+	DirCopy(src Fs) error
 }
 
 // DirMover is an optional interface for Fs

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -1299,7 +1299,7 @@ func MoveFile(fdst Fs, fsrc Fs, dstFileName string, srcFileName string) (err err
 	return moveOrCopyFile(fdst, fsrc, dstFileName, srcFileName, false)
 }
 
-// CopyFile moves a single file possibly to a new name
+// CopyFile copies a single file possibly to a new name
 func CopyFile(fdst Fs, fsrc Fs, dstFileName string, srcFileName string) (err error) {
 	return moveOrCopyFile(fdst, fsrc, dstFileName, srcFileName, true)
 }

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -471,6 +471,51 @@ func TestFsMove(t *testing.T) {
 	// 2: hello sausage?/../z.txt
 }
 
+// Copy src to this remote using server side move operations.
+//
+// Will only be called if src.Fs().Name() == f.Name()
+//
+// If it isn't possible then return fs.ErrorCantDirCopy
+//
+// If destination exists then return fs.ErrorDirExists
+
+// TestFsDirCopy tests DirCopy
+func TestFsDirCopy(t *testing.T) {
+	skipIfNotOk(t)
+
+	// Check have DirCopy
+	doDirCopy := remote.Features().DirCopy
+	if doDirCopy == nil {
+		t.Skip("FS has no DirCopier interface")
+	}
+
+	// Check it can't copy onto itself
+	err := doDirCopy(remote)
+	require.Equal(t, fs.ErrorDirExists, err)
+
+	// new remote
+	newRemote, _, removeNewRemote, err := fstest.RandomRemote(RemoteName, false)
+	require.NoError(t, err)
+	defer removeNewRemote()
+
+	// try the move
+	err = newRemote.Features().DirCopy(remote)
+	require.NoError(t, err)
+
+	// check remotes
+	// FIXME: Prints errors.
+	fstest.CheckListing(t, remote, []fstest.Item{})
+	fstest.CheckListing(t, newRemote, []fstest.Item{file2, file1})
+
+	// Delete copy
+	err = dst.Purge()
+	require.NoError(t, err)
+
+	// check remotes
+	fstest.CheckListing(t, remote, []fstest.Item{file2, file1})
+	fstest.CheckListing(t, newRemote, []fstest.Item{})
+}
+
 // Move src to this remote using server side move operations.
 //
 // Will only be called if src.Fs().Name() == f.Name()

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -498,7 +498,7 @@ func TestFsDirCopy(t *testing.T) {
 	require.NoError(t, err)
 	defer removeNewRemote()
 
-	// try the move
+	// try the copy
 	err = newRemote.Features().DirCopy(remote)
 	require.NoError(t, err)
 
@@ -508,7 +508,7 @@ func TestFsDirCopy(t *testing.T) {
 	fstest.CheckListing(t, newRemote, []fstest.Item{file2, file1})
 
 	// Delete copy
-	err = dst.Purge()
+	err = fs.Purge(newRemote)
 	require.NoError(t, err)
 
 	// check remotes

--- a/local/local.go
+++ b/local/local.go
@@ -493,6 +493,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirCopy
 //
 // If destination exists then return fs.ErrorDirExists
+/*
 func (f *Fs) DirCopy(src fs.Fs) error {
 	srcFs, ok := src.(*Fs)
 	if !ok {
@@ -516,9 +517,10 @@ func (f *Fs) DirCopy(src fs.Fs) error {
 	}
 
 	// Do the local copy
-	// FIXME - Intentional compile error
-	//return errors.New("DirCopy not fully implemented")
+	// FIXME
+	return errors.New("DirCopy not fully implemented")
 }
+*/
 
 // DirMove moves src directory to this remote using server side move
 // operations.

--- a/local/local.go
+++ b/local/local.go
@@ -485,6 +485,41 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 	return dstObj, nil
 }
 
+// DirCopy copies src directory to this remote using server side copy
+// operations.
+//
+// Will only be called if src.Fs().Name() == f.Name()
+//
+// If it isn't possible then return fs.ErrorCantDirCopy
+//
+// If destination exists then return fs.ErrorDirExists
+func (f *Fs) DirCopy(src fs.Fs) error {
+	srcFs, ok := src.(*Fs)
+	if !ok {
+		fs.Debug(srcFs, "Can't copy directory - not same remote type")
+		return fs.ErrorCantDirCopy
+	}
+	// Check if source exists
+	sstat, err := os.Lstat(srcFs.root)
+	if err != nil {
+		return err
+	}
+	// And is a directory
+	if !sstat.IsDir() {
+		return fs.ErrorCantDirCopy
+	}
+
+	// Check if destination exists
+	_, err = os.Lstat(f.root)
+	if !os.IsNotExist(err) {
+		return fs.ErrorDirExists
+	}
+
+	// Do the local copy
+	// FIXME - Intentional compile error
+	//return errors.New("DirCopy not fully implemented")
+}
+
 // DirMove moves src directory to this remote using server side move
 // operations.
 //

--- a/rclone.1
+++ b/rclone.1
@@ -2624,6 +2624,8 @@ Copy
 T}@T{
 Move
 T}@T{
+DirCopy
+T}@T{
 DirMove
 T}@T{
 CleanUp
@@ -2802,6 +2804,13 @@ If the server isn\[aq]t capable of \f[C]Move\f[] then rclone simulates
 it with \f[C]Copy\f[] then delete.
 If the server doesn\[aq]t support \f[C]Copy\f[] then rclone will
 download the file and re\-upload it.
+.SS DirCopy
+.PP
+This is used to implement \f[C]rclone\ copy\f[] to copy an entire
+directory tree if possible.
+If it isn\[aq]t then it will use \f[C]Copy\f[] on each file (which falls
+back to download and upload \- see \f[C]Copy\f[]
+section), and Mkdir on each directory (if implemented).
 .SS DirMove
 .PP
 This is used to implement \f[C]rclone\ move\f[] to move a directory if


### PR DESCRIPTION
First pass at DirCopy support.  Since we have no remotes (yet) that implement this, I can't be sure that I did everything correct.  Please check `TestFsDirCopy`.  Comments and corrections invited.

You may want to exclude the changes to `local/local.go` as that was just a stab at testing.