### PR TITLE
fix --ignore-checksum

### DIFF
--- a/fs/operations.go
+++ b/fs/operations.go
@@ -336,7 +336,7 @@ func Copy(f Fs, dst Object, remote string, src Object) (err error) {
 			if err != nil {
 				Stats.Error()
 				Errorf(dst, "Failed to read hash: %v", err)
-			} else if !Config.IgnoreSize && !HashEquals(srcSum, dstSum) {
+			} else if !Config.IgnoreChecksum && !HashEquals(srcSum, dstSum) {
 				Stats.Error()
 				err = errors.Errorf("corrupted on transfer: %v hash differ %q vs %q", hashType, srcSum, dstSum)
 				Errorf(dst, "%v", err)


### PR DESCRIPTION
The code to ignore checksum accidentally checks for the IgnoreSize flag rather than IgnoreChecksum. 

Original commit:
https://github.com/ncw/rclone/commit/9d331ce04b000ea1d284ee5b251fbc142ad8f623
