### PR TITLE
Created Packager.io file for Rclone

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,6 @@
+default_dependencies: false
+dependencies:
+  - git
+  - fuse
+user: "$USERNAME"  
+cli: rclone

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@ grade: stable
 apps:
   rclone:
     command: bin/rclone
-    plugs: [home, network, network-bind]
+    plugs: [home, network, network-bind,fuse-support]
 
 parts:
   rclone:
@@ -18,4 +18,4 @@ parts:
     source-tag: v1.35
     source-type: git
     go-importpath: github.com/ncw/rclone
-    build-packages: [gcc, libgudev-1.0-dev]
+    build-packages: [gcc, libgudev-1.0-dev,fuse]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,4 +18,4 @@ parts:
     source-tag: v1.35
     source-type: git
     go-importpath: github.com/ncw/rclone
-    build-packages: [gcc, libgudev-1.0-dev,fusermount]
+    build-packages: [gcc, libgudev-1.0-dev]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@ grade: stable
 apps:
   rclone:
     command: bin/rclone
-    plugs: [home, network, network-bind]
+    plugs: [home, network, network-bind,fuse-support]
 
 parts:
   rclone:
@@ -18,4 +18,4 @@ parts:
     source-tag: v1.35
     source-type: git
     go-importpath: github.com/ncw/rclone
-    build-packages: [gcc, libgudev-1.0-dev]
+    build-packages: [gcc, libgudev-1.0-dev,fusermount]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@ grade: stable
 apps:
   rclone:
     command: bin/rclone
-    plugs: [home, network, network-bind,fuse-support]
+    plugs: [home, network, network-bind]
 
 parts:
   rclone:


### PR DESCRIPTION
Hey ncw,

i figured i would ahead and create a automated apt-get option for rclone using packager.io, all you would need to do is go to https://packager.io and just sign in from your github account, select the rclone repo once you add my .pkgr.yml file and the system will start building the rest of the apps each time you push out an new release.