### PR TITLE
Use RedirectLocalhostURL for OneDrive.

### DIFF
--- a/onedrive/onedrive.go
+++ b/onedrive/onedrive.go
@@ -48,7 +48,7 @@ var (
 		},
 		ClientID:     rcloneClientID,
 		ClientSecret: fs.MustReveal(rcloneEncryptedClientSecret),
-		RedirectURL:  oauthutil.RedirectPublicURL,
+		RedirectURL:  oauthutil.RedirectLocalhostURL,
 	}
 	chunkSize    = fs.SizeSuffix(10 * 1024 * 1024)
 	uploadCutoff = fs.SizeSuffix(10 * 1024 * 1024)


### PR DESCRIPTION
Microsoft Application Registration Portal requires redirect URI to be either http://localhost or SSL enabled host (url must start with "https"). 