### PR TITLE
"OneDrive" instread of "One Drive"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Rclone is a command line program to sync files and directories to and from
   * Dropbox
   * Google Cloud Storage
   * Amazon Drive
-  * Microsoft One Drive
+  * Microsoft OneDrive
   * Hubic
   * Backblaze B2
   * Yandex Disk


### PR DESCRIPTION
It's better to call this service as it's officially named.