### PR TITLE
Add an "obfuscate" option for filename encryption.

### DIFF
--- a/crypt/cipher.go
+++ b/crypt/cipher.go
@@ -50,9 +50,7 @@ var (
 	ErrorNotAnEncryptedFile      = errors.New("not an encrypted file - no \"" + encryptedSuffix + "\" suffix")
 	ErrorBadSeek                 = errors.New("Seek beyond end of file")
 	defaultSalt                  = []byte{0xA8, 0x0D, 0xF4, 0x3A, 0x8F, 0xBD, 0x03, 0x08, 0xA7, 0xCA, 0xB8, 0x3E, 0x58, 0x1F, 0x86, 0xB1}
-	obfuscASCII                  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	obfuscASCIILen               = len(obfuscASCII)
-	obfuscQuote                  = "!"
+	obfuscQuoteRune              = '!'
 )
 
 // Global variables
@@ -294,7 +292,6 @@ func (c *cipher) decryptSegment(ciphertext string) (string, error) {
 }
 
 // Simple obfuscation routines
-
 func (c *cipher) obfuscateSegment(plaintext string) string {
 	if plaintext == "" {
 		return ""
@@ -315,64 +312,71 @@ func (c *cipher) obfuscateSegment(plaintext string) string {
 	dir = dir % 256
 
 	// We'll use this number to store in the result filename...
-	result := strconv.Itoa(dir) + "."
+	var result bytes.Buffer
+	_, _ = result.WriteString(strconv.Itoa(dir) + ".")
 
 	// but we'll augment it with the nameKey for real calculation
 	for i := 0; i < len(c.nameKey); i++ {
 		dir += int(c.nameKey[i])
 	}
-	dir = dir % 127
 
 	// Now for each character, depending on the range it is in
 	// we will actually rotate a different amount
-	var newChar string
-
 	for _, runeValue := range plaintext {
 		switch {
-		case string(runeValue) == obfuscQuote:
+		case runeValue == obfuscQuoteRune:
 			// Quote the Quote character
-			newChar = obfuscQuote + obfuscQuote
+			_, _ = result.WriteRune(obfuscQuoteRune)
+			_, _ = result.WriteRune(obfuscQuoteRune)
 
-		case (runeValue >= 0x30 && runeValue <= 0x39):
+		case runeValue >= '0' && runeValue <= '9':
 			// Number
 			thisdir := (dir % 9) + 1
-			newRune := 0x30 + (int(runeValue)-0x30+thisdir)%10
-			newChar = string(newRune)
+			newRune := '0' + (int(runeValue)-'0'+thisdir)%10
+			_, _ = result.WriteRune(rune(newRune))
 
-		case (runeValue >= 0x41 && runeValue <= 0x5A) ||
-			(runeValue >= 0x61 && runeValue <= 0x7A):
+		case (runeValue >= 'A' && runeValue <= 'Z') ||
+			(runeValue >= 'a' && runeValue <= 'z'):
 			// ASCII letter.  Try to avoid trivial A->a mappings
-			thisdir := dir%(obfuscASCIILen/2-1) + 1
-			pos := strings.Index(obfuscASCII, string(runeValue))
-			pos = (pos + thisdir) % obfuscASCIILen
-			newChar = string(obfuscASCII[pos])
+			thisdir := dir%25 + 1
+			// Calculate the offset of this character in A-Za-z
+			pos := int(runeValue - 'A')
+			if pos >= 26 {
+				pos -= 6 // It's lower case
+			}
+			// Rotate the character to the new location
+			pos = (pos + thisdir) % 52
+			if pos >= 26 {
+				pos += 6 // and handle lower case offset again
+			}
+			_, _ = result.WriteRune(rune('A' + pos))
 
-		case (runeValue >= 0xA0 && runeValue <= 0xFF):
+		case runeValue >= 0xA0 && runeValue <= 0xFF:
 			// Latin 1 supplement
 			thisdir := (dir % 95) + 1
 			newRune := 0xA0 + (int(runeValue)-0xA0+thisdir)%96
-			newChar = string(newRune)
+			_, _ = result.WriteRune(rune(newRune))
 
-		case (runeValue >= 0x100):
+		case runeValue >= 0x100:
 			// Some random Unicode range; we have no good rules here
-			thisdir := dir + 1
+			thisdir := (dir % 127) + 1
 			base := int(runeValue - runeValue%256)
 			newRune := rune(base + (int(runeValue)-base+thisdir)%256)
-			newChar = string(newRune)
 			// If the new character isn't a valid UTF8 char
 			// then don't rotate it.  Quote it instead
-			if !utf8.ValidString(newChar) {
-				newChar = obfuscQuote + string(runeValue)
+			if !utf8.ValidRune(newRune) {
+				_, _ = result.WriteRune(obfuscQuoteRune)
+				_, _ = result.WriteRune(runeValue)
+			} else {
+				_, _ = result.WriteRune(newRune)
 			}
 
 		default:
 			// Leave character untouched
-			newChar = string(runeValue)
+			_, _ = result.WriteRune(runeValue)
 		}
-
-		result += newChar
 	}
-	return result
+	return result.String()
 }
 
 func (c *cipher) deobfuscateSegment(ciphertext string) (string, error) {
@@ -397,67 +401,68 @@ func (c *cipher) deobfuscateSegment(ciphertext string) (string, error) {
 	for i := 0; i < len(c.nameKey); i++ {
 		dir += int(c.nameKey[i])
 	}
-	dir = dir % 127
 
-	var result string
-
-	var newChar string
+	var result bytes.Buffer
 
 	inQuote := false
 	for _, runeValue := range ciphertext[pos+1:] {
 		switch {
 		case inQuote:
-			newChar = string(runeValue)
+			_, _ = result.WriteRune(runeValue)
 			inQuote = false
 
-		case string(runeValue) == obfuscQuote:
-			newChar = ""
+		case runeValue == obfuscQuoteRune:
 			inQuote = true
 
-		case (runeValue >= 0x30 && runeValue <= 0x39):
+		case runeValue >= '0' && runeValue <= '9':
 			// Number
 			thisdir := (dir % 9) + 1
-			newRune := 0x30 + int(runeValue) - 0x30 - thisdir
-			if newRune < 0x30 {
+			newRune := '0' + int(runeValue) - '0' - thisdir
+			if newRune < '0' {
 				newRune += 10
 			}
-			newChar = string(newRune)
+			_, _ = result.WriteRune(rune(newRune))
 
-		case (runeValue >= 0x41 && runeValue <= 0x5A) ||
-			(runeValue >= 0x61 && runeValue <= 0x7A):
-			thisdir := dir%(obfuscASCIILen/2-1) + 1
-			pos := strings.Index(obfuscASCII, string(runeValue))
-			pos = (pos - thisdir) % obfuscASCIILen
-			if pos < 0 {
-				pos += obfuscASCIILen
+		case (runeValue >= 'A' && runeValue <= 'Z') ||
+			(runeValue >= 'a' && runeValue <= 'z'):
+			thisdir := dir%25 + 1
+			pos := int(runeValue - 'A')
+			if pos >= 26 {
+				pos -= 6
 			}
-			newChar = string(obfuscASCII[pos])
+			pos = pos - thisdir
+			if pos < 0 {
+				pos += 52
+			}
+			if pos >= 26 {
+				pos += 6
+			}
+			_, _ = result.WriteRune(rune('A' + pos))
 
-		case (runeValue >= 0xA0 && runeValue <= 0xFF):
+		case runeValue >= 0xA0 && runeValue <= 0xFF:
 			thisdir := (dir % 95) + 1
 			newRune := 0xA0 + int(runeValue) - 0xA0 - thisdir
 			if newRune < 0xA0 {
 				newRune += 96
 			}
-			newChar = string(newRune)
+			_, _ = result.WriteRune(rune(newRune))
 
-		case (runeValue >= 0x100):
-			thisdir := dir + 1
+		case runeValue >= 0x100:
+			thisdir := (dir % 127) + 1
 			base := int(runeValue - runeValue%256)
 			newRune := rune(base + (int(runeValue) - base - thisdir))
 			if int(newRune) < base {
 				newRune += 256
 			}
-			newChar = string(newRune)
+			_, _ = result.WriteRune(rune(newRune))
 
 		default:
-			newChar = string(runeValue)
+			_, _ = result.WriteRune(runeValue)
 
 		}
-		result += newChar
 	}
 
-	return result, nil
+	return result.String(), nil
 }
 
 // encryptFileName encrypts a file path

--- a/crypt/cipher_test.go
+++ b/crypt/cipher_test.go
@@ -223,9 +223,9 @@ func TestEncryptFileName(t *testing.T) {
 	assert.Equal(t, "1/12/123.bin", c.EncryptFileName("1/12/123"))
 	// Obfuscation mode
 	c, _ = newCipher(NameEncryptionObfuscated, "", "")
-	assert.Equal(t, "49.6/99.23/150.789/53.!!lipps", c.EncryptFileName("1/12/123/!hello"))
-	assert.Equal(t, "161."+string(rune(0xc4)), c.EncryptFileName(string(rune(0xa1))))
-	assert.Equal(t, "160."+string(rune(0x3c2)), c.EncryptFileName(string(rune(0x3a0))))
+	assert.Equal(t, "49.6/99.23/150.890/53.!!lipps", c.EncryptFileName("1/12/123/!hello"))
+	assert.Equal(t, "161.\u00e4", c.EncryptFileName("\u00a1"))
+	assert.Equal(t, "160.\u03c2", c.EncryptFileName("\u03a0"))
 }
 
 func TestDecryptFileName(t *testing.T) {
@@ -245,8 +245,8 @@ func TestDecryptFileName(t *testing.T) {
 		{NameEncryptionOff, ".bin", "", ErrorNotAnEncryptedFile},
 		{NameEncryptionObfuscated, "0.hello", "hello", nil},
 		{NameEncryptionObfuscated, "hello", "", ErrorNotAnEncryptedFile},
-		{NameEncryptionObfuscated, "161." + string(rune(0xc4)), string(rune(0xa1)), nil},
-		{NameEncryptionObfuscated, "160." + string(rune(0x3c2)), string(rune(0x3a0)), nil},
+		{NameEncryptionObfuscated, "161.\u00e4", "\u00a1", nil},
+		{NameEncryptionObfuscated, "160.\u03c2", "\u03a0", nil},
 	} {
 		c, _ := newCipher(test.mode, "", "")
 		actual, actualErr := c.DecryptFileName(test.in)
@@ -263,7 +263,7 @@ func TestEncDecMatches(t *testing.T) {
 	}{
 		{NameEncryptionStandard, "1/2/3/4"},
 		{NameEncryptionOff, "1/2/3/4"},
-		{NameEncryptionObfuscated, "1/2/3/4/!hello" + string(rune(0x3a0))},
+		{NameEncryptionObfuscated, "1/2/3/4/!hello\u03a0"},
 	} {
 		c, _ := newCipher(test.mode, "", "")
 		out, err := c.DecryptFileName(c.EncryptFileName(test.in))

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -37,6 +37,9 @@ func init() {
 				}, {
 					Value: "standard",
 					Help:  "Encrypt the filenames see the docs for the details.",
+				}, {
+					Value: "obfuscate",
+					Help:  "Very simple filename obfuscation.",
 				},
 			},
 		}, {

--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -71,6 +71,8 @@ Choose a number from below, or type in your own value
    \ "off"
  2 / Encrypt the filenames see the docs for the details.
    \ "standard"
+ 3 / Very simple filename obfuscation.
+   \ "obfuscate"
 filename_encryption> 2
 Password or pass phrase for encryption.
 y) Yes type in my own password
@@ -224,6 +226,27 @@ Standard
   * directory structure visibile
   * identical files names will have identical uploaded names
   * can use shortcuts to shorten the directory recursion
+
+Obfuscation
+
+This is a simple "rotate" of the filename, with each file having a rot
+distance based on the filename. We store the distance at the beginning
+of the filename. So a file called "hello" may become "53.jgnnq"
+
+This is not a strong encryption of filenames, but it may stop automated
+scanning tools from picking up on filename patterns. As such it's an
+intermediate between "off" and "standard". The advantage is that it
+allows for longer path segment names.
+
+There is a possibility with some unicode based filenames that the
+obfuscation is weak and may map lower case characters to upper case
+equivalents.  You can not rely on this for strong protection.
+
+  * file names very lightly obfuscated
+  * file names can be longer than standard encryption
+  * can use sub paths and copy single files
+  * directory structure visibile
+  * identical files names will have identical uploaded names
 
 Cloud storage systems have various limits on file name length and
 total path length which you are more likely to hit using "Standard"


### PR DESCRIPTION
This is a simple "rotate" of the filename, with each file having a rot
distance based on the filename.  We store the distance at the beginning
of the filename.  So a file called "go" would become "37.KS".

This is not a strong encryption of filenames, but it should stop automated
scanning tools from picking up on filename patterns.  As such it's an
intermediate between "off" and "standard".  The advantage is that it
allows for longer path segment names.