### PR TITLE
mount: umount dir when program ends with SIGINT (Ctrl+C) or SIGTERM

### DIFF
--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -75,20 +75,19 @@ This is **EXPERIMENTAL** - use with care.
 
 First set up your remote using ` + "`rclone config`" + `.  Check it works with ` + "`rclone ls`" + ` etc.
 
-Start the mount like this (note the & on the end to put rclone in the background).
+Start the mount like this
 
-    rclone mount remote:path/to/files /path/to/local/mount &
+    rclone mount remote:path/to/files /path/to/local/mount
 
-Stop the mount with
+When the program ends, either via Ctrl+C or receiving a SIGINT or SIGTERM signal,
+the mount is automatically stopped.
 
+The umount operation can fail, for example when the mountpoint is busy.
+When that happens, it is the user's responsibility to stop the mount manually with
+
+    # Linux
     fusermount -u /path/to/local/mount
-
-Or if that fails try
-
-    fusermount -z -u /path/to/local/mount
-
-Or with OS X
-
+    # OS X
     umount /path/to/local/mount
 
 ### Limitations ###

--- a/rclone.1
+++ b/rclone.1
@@ -916,23 +916,22 @@ Start the mount like this
 .IP
 .nf
 \f[C]
-rclone\ mount\ remote:path/to/files\ /path/to/local/mount\ &
+rclone\ mount\ remote:path/to/files\ /path/to/local/mount
 \f[]
 .fi
 .PP
-Stop the mount with
+When the program ends, either via Ctrl+C or receiving a SIGINT or SIGTERM signal,
+the mount is automatically stopped.
+.PP
+The umount operation can fail, for example when the mountpoint is busy.
+When that happens, it is the user's responsibility to stop the mount manually with
 .IP
 .nf
 \f[C]
+#\ Linux
 fusermount\ \-u\ /path/to/local/mount
-\f[]
-.fi
-.PP
-Or with OS X
-.IP
-.nf
-\f[C]
-umount\ \-u\ /path/to/local/mount
+#\ OS\ X
+umount\ /path/to/local/mount
 \f[]
 .fi
 .SS Limitations


### PR DESCRIPTION
Tested the following scenarios:

* external `fusermount -u`: `rclone` exits properly
* Ctrl+C: `rclone` exits and umount dir
* `killall rclone`: exits and umount dir
* `killall rclone` with busy mountpoint: dir not umounted and the following message is printed
```
2017/03/17 11:23:03 Fatal error: failed to umount FUSE fs: exit status 1: fusermount: failed to unmount /tmp/rclone-mount: Device or resource busy
```

Related issue: #1244 
