### PR TITLE
Fix spelling of Unfortunately in Amazon Cloud Drive docs

### DIFF
--- a/docs/content/amazonclouddrive.md
+++ b/docs/content/amazonclouddrive.md
@@ -183,7 +183,7 @@ larger than this will fail.
 At the time of writing (Jan 2016) is in the area of 50GB per file.
 This means that larger files are likely to fail.
 
-Unfortunatly there is no way for rclone to see that this failure is
+Unfortunately there is no way for rclone to see that this failure is
 because of file size, so it will retry the operation, as any other
 failure. To avoid this problem, use `--max-size 50000M` option to limit
 the maximum size of uploaded files. Note that `--max-size` does not split


### PR DESCRIPTION
Noticed on the Amazon Drive page. Grepped and the only other occurrences are in the generated docs.