### PR TITLE
Updated .pkgr.yml file to use rclone by default.

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,2 +1,2 @@
 default_dependencies: false
-cli: false
+cli: rclone


### PR DESCRIPTION
Hey Nick,

i updated my Packager.io yml file to look for rclone by default,  what i was doing was setting the path but further digging found that pkgr.io already has an golang based apps installed in /opt/.  for example rclone would be installed in /opt/rclone/bin/rclone.

Dedsec1