### PR TITLE
implement ModTime via FUSE for remotes that support it (fixes #1197)

### DIFF
--- a/cmd/mount/dir_test.go
+++ b/cmd/mount/dir_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,4 +133,21 @@ func TestDirRenameFullDir(t *testing.T) {
 	run.rmdir(t, "dir/dir3")
 	run.rmdir(t, "dir")
 	run.checkDir(t, "")
+}
+
+func TestDirModTime(t *testing.T) {
+	run.skipIfNoFUSE(t)
+
+	run.mkdir(t, "dir")
+	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	err := os.Chtimes(run.path("dir"), mtime, mtime)
+	require.NoError(t, err)
+
+	info, err := os.Stat(run.path("dir"))
+	require.NoError(t, err)
+
+	// avoid errors because of timezone differences
+	assert.Equal(t, info.ModTime().Unix(), mtime.Unix())
+
+	run.rmdir(t, "dir")
 }

--- a/cmd/mount/file_test.go
+++ b/cmd/mount/file_test.go
@@ -1,0 +1,30 @@
+// +build linux darwin freebsd
+
+package mount
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileModTime(t *testing.T) {
+	run.skipIfNoFUSE(t)
+
+	run.createFile(t, "file", "123")
+
+	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	err := os.Chtimes(run.path("file"), mtime, mtime)
+	require.NoError(t, err)
+
+	info, err := os.Stat(run.path("file"))
+	require.NoError(t, err)
+
+	// avoid errors because of timezone differences
+	assert.Equal(t, info.ModTime().Unix(), mtime.Unix())
+
+	run.rm(t, "file")
+}

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -46,7 +46,7 @@ func init() {
 	umask = unix.Umask(0) // read the umask
 	unix.Umask(umask)     // set it back to what it was
 	cmd.Root.AddCommand(commandDefintion)
-	commandDefintion.Flags().BoolVarP(&noModTime, "no-modtime", "", noModTime, "Don't read the modification time (can speed things up).")
+	commandDefintion.Flags().BoolVarP(&noModTime, "no-modtime", "", noModTime, "Don't read/write the modification time (can speed things up).")
 	commandDefintion.Flags().BoolVarP(&debugFUSE, "debug-fuse", "", debugFUSE, "Debug the FUSE internals - needs -v.")
 	commandDefintion.Flags().BoolVarP(&noSeek, "no-seek", "", noSeek, "Don't allow seeking in files.")
 	commandDefintion.Flags().DurationVarP(&dirCacheTime, "dir-cache-time", "", dirCacheTime, "Time to cache directory entries for.")
@@ -130,8 +130,6 @@ files to be visible in the mount.
 ### TODO ###
 
   * Check hashes on upload/download
-  * Preserve timestamps
-  * Move directories
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)


### PR DESCRIPTION
This patch allows the timestamp to be set for remotes that support it. It stays a no-op for remotes that don't – otherwise it breaks `touch somefile` if the file already exists, which would be a breaking change and is probably unwanted. The alternative would be to fail and ask people to set `--no-modtime`, I guess.

I implemented it for directories, too, even though the timestamp will not be persisted. 

Cheers
Stefan