### PR TITLE
allow modTime to be changed even before all writers are closed (fixes #1197 -- again)

### DIFF
--- a/cmd/mount/file_test.go
+++ b/cmd/mount/file_test.go
@@ -28,3 +28,30 @@ func TestFileModTime(t *testing.T) {
 
 	run.rm(t, "file")
 }
+
+func TestFileModTimeWithOpenWriters(t *testing.T) {
+	run.skipIfNoFUSE(t)
+
+	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	filepath := run.path("cp-archive-test")
+
+	f, err := os.Create(filepath)
+	require.NoError(t, err)
+
+	_, err = f.Write([]byte{104, 105})
+	require.NoError(t, err)
+
+	err = os.Chtimes(filepath, mtime, mtime)
+	require.NoError(t, err)
+
+	err = f.Close()
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath)
+	require.NoError(t, err)
+
+	// avoid errors because of timezone differences
+	assert.Equal(t, info.ModTime().Unix(), mtime.Unix())
+
+	run.rm(t, "cp-archive-test")
+}


### PR DESCRIPTION
This is "proposal 3" from my [previous comment](https://github.com/ncw/rclone/issues/1197#issuecomment-289964080). I decided not to hand down error until there's an actual bug reported that warrants complicating the error handling in `WriteFileHandle.close`. 

It fixes not only the `cp -a` issue, but also the stale cache issue that would result in the dir listing showing a wrong timestamp for some time directly after copying. 

Cheers
Stefan