### PR TITLE
For encrypted drives, report the name:root specified by the user

### DIFF
--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -140,7 +140,7 @@ func (f *Fs) Features() *fs.Features {
 
 // String returns a description of the FS
 func (f *Fs) String() string {
-	return fmt.Sprintf("Encrypted %s", f.Fs.String())
+	return fmt.Sprintf("Encrypted drive '%s:%s'", f.name, f.root)
 }
 
 // List the Fs into a channel


### PR DESCRIPTION
For encrypted drives, report the name:root specified by the user,
rather then the underlying Fs root (which may be unreadable
when filename_encryption is set).  See enhancement issue #1305