### PR TITLE
Fix issue #1315 where filenames calculated with a base distance of zero

### DIFF
--- a/crypt/cipher.go
+++ b/crypt/cipher.go
@@ -298,9 +298,9 @@ func (c *cipher) obfuscateSegment(plaintext string) string {
 	}
 
 	// If the string isn't valid UTF8 then don't rotate; just
-	// prepend a 0.
+	// prepend a !.
 	if !utf8.ValidString(plaintext) {
-		return "0." + plaintext
+		return "!." + plaintext
 	}
 
 	// Calculate a simple rotation based on the filename and
@@ -388,7 +388,7 @@ func (c *cipher) deobfuscateSegment(ciphertext string) (string, error) {
 		return "", ErrorNotAnEncryptedFile
 	} // No .
 	num := ciphertext[:pos]
-	if num == "0" {
+	if num == "!" {
 		// No rotation; probably original was not valid unicode
 		return ciphertext[pos+1:], nil
 	}

--- a/crypt/cipher_test.go
+++ b/crypt/cipher_test.go
@@ -243,7 +243,7 @@ func TestDecryptFileName(t *testing.T) {
 		{NameEncryptionOff, "1/12/123.bin", "1/12/123", nil},
 		{NameEncryptionOff, "1/12/123.bix", "", ErrorNotAnEncryptedFile},
 		{NameEncryptionOff, ".bin", "", ErrorNotAnEncryptedFile},
-		{NameEncryptionObfuscated, "0.hello", "hello", nil},
+		{NameEncryptionObfuscated, "!.hello", "hello", nil},
 		{NameEncryptionObfuscated, "hello", "", ErrorNotAnEncryptedFile},
 		{NameEncryptionObfuscated, "161.\u00e4", "\u00a1", nil},
 		{NameEncryptionObfuscated, "160.\u03c2", "\u03a0", nil},
@@ -264,6 +264,7 @@ func TestEncDecMatches(t *testing.T) {
 		{NameEncryptionStandard, "1/2/3/4"},
 		{NameEncryptionOff, "1/2/3/4"},
 		{NameEncryptionObfuscated, "1/2/3/4/!hello\u03a0"},
+		{NameEncryptionObfuscated, "Avatar The Last Airbender"},
 	} {
 		c, _ := newCipher(test.mode, "", "")
 		out, err := c.DecryptFileName(c.EncryptFileName(test.in))


### PR DESCRIPTION
Fix issue #1315 where filenames calculated with a base distance of zero
(ie the characters add up to 0(mod 256) aren't de-obfuscated on reading.
This was due to overloading of "0" to also mean "invalid UTF8; no rotation",
so we remove that double meaning