### PR TITLE
Print password prompts to stderr

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -516,15 +516,15 @@ func checkPassword(password string) (string, error) {
 
 // GetPassword asks the user for a password with the prompt given.
 func GetPassword(prompt string) string {
-	fmt.Println(prompt)
+	fmt.Fprintln(os.Stderr, prompt)
 	for {
-		fmt.Print("password:")
+		fmt.Fprint(os.Stderr, "password:")
 		password := ReadPassword()
 		password, err := checkPassword(password)
 		if err == nil {
 			return password
 		}
-		fmt.Printf("Bad password: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Bad password: %v\n", err)
 	}
 }
 
@@ -553,7 +553,7 @@ func getConfigPassword(q string) {
 		if err == nil {
 			return
 		}
-		fmt.Println("Error:", err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
 	}
 }
 

--- a/fs/config_read_password.go
+++ b/fs/config_read_password.go
@@ -18,7 +18,7 @@ import (
 // ReadPassword reads a password without echoing it to the terminal.
 func ReadPassword() string {
 	line, err := terminal.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println("")
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		log.Fatalf("Failed to read password: %v", err)
 	}


### PR DESCRIPTION
This makes rclone with encrypted config better suited for use in
pipelines. E.g.:

    $ rclone lsl mydrive:Some/Dir | sort -k 4

If the password prompt ("Enter configuration password") is printed to
stdout, it will be swallowed by sort. By printing it to stderr, you
still see the prompt, without sacrificing compatibility with the unix
pipeline.

This patch only focuses on password prompts, which may seem a bit haphazard and inconsistent. However, I didn't want to embark on a full code reorg just to change this in your project :P feel free to adapt, of course.