### PR TITLE
Gdrive: partial responses by using explicit fields

### DIFF
--- a/drive/drive.go
+++ b/drive/drive.go
@@ -246,7 +246,6 @@ OUTER:
 			return shouldRetry(err)
 		})
 		if err != nil {
-			fmt.Printf("Error: %d\n", err)
 			return false, errors.Wrap(err, "couldn't list directory")
 		}
 		for _, item := range files.Items {

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -84,7 +84,7 @@ var (
 		"text/tab-separated-values":                                                 "tsv",
 	}
 	extensionToMimeType map[string]string
-	partialFields = googleapi.Field("items(id,downloadUrl,exportLinks,fileExtension,fullFileExtension,fileSize,labels,md5Checksum,modifiedDate,mimeType,title,owners)")
+	partialFields       = googleapi.Field("items(id,downloadUrl,exportLinks,fileExtension,fullFileExtension,fileSize,labels,md5Checksum,modifiedDate,mimeType,title,owners)")
 )
 
 // Register with Fs

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -242,10 +242,11 @@ OUTER:
 	for {
 		var files *drive.FileList
 		err = f.pacer.Call(func() (bool, error) {
-			files, err = list.Do()
+			files, err = list.Fields( "items(id,downloadUrl,parents,md5Checksum,fileSize,fileExtension,fullFileExtension,kind,title,modifiedDate,mimeType)", "kind", "nextPageToken").Do()
 			return shouldRetry(err)
 		})
 		if err != nil {
+			fmt.Printf("Error: %d\n", err)
 			return false, errors.Wrap(err, "couldn't list directory")
 		}
 		for _, item := range files.Items {

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -242,7 +242,7 @@ OUTER:
 	for {
 		var files *drive.FileList
 		err = f.pacer.Call(func() (bool, error) {
-			files, err = list.Fields( "items(id,downloadUrl,parents,md5Checksum,fileSize,fileExtension,fullFileExtension,kind,title,modifiedDate,mimeType)", "kind", "nextPageToken").Do()
+			files, err = list.Fields( "items(id,downloadUrl,parents,md5Checksum,fileSize,fileExtension,fullFileExtension,title,modifiedDate,mimeType)", "nextPageToken").Do()
 			return shouldRetry(err)
 		})
 		if err != nil {

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -84,6 +84,7 @@ var (
 		"text/tab-separated-values":                                                 "tsv",
 	}
 	extensionToMimeType map[string]string
+	partialFields = googleapi.Field("items(id,downloadUrl,exportLinks,fileExtension,fullFileExtension,fileSize,labels,md5Checksum,modifiedDate,mimeType,title,owners)")
 )
 
 // Register with Fs
@@ -242,7 +243,7 @@ OUTER:
 	for {
 		var files *drive.FileList
 		err = f.pacer.Call(func() (bool, error) {
-			files, err = list.Fields( "items(id,downloadUrl,parents,md5Checksum,fileSize,fileExtension,fullFileExtension,title,modifiedDate,mimeType)", "nextPageToken").Do()
+			files, err = list.Fields(partialFields).Do()
 			return shouldRetry(err)
 		})
 		if err != nil {


### PR DESCRIPTION
This solves #1346

The fields I included should be the absolute minimum required to pass the integration tests.

It only seemed to be applicable in listAll()