### PR TITLE
implementation, test case, doc for --check-new option

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -269,6 +269,30 @@ will use this much memory for buffering.
 
 Set to 0 to disable the buffering for the minimum memory use.
 
+### --check-newer ###
+
+Use of a remote that does not support setting the file modification 
+time (such as Amazon Cloud Drive) as the base for an encrytped 
+remote presents some difficulties in determining which files to 
+process when repeating a copy or other command e.g. with the intent
+of keeping a backup up-to-date.  The file modification time is 
+not checked, and --checksum is not effective (as of v1.36) as the 
+crypt filesystem does not provide it. So in general checks for 
+source and dest files being equal amount to comparing file size. 
+Thus files that have been modified on the source since the last copy
+or similar operation but are still the same size will be skipped.
+
+The --check-newer option provides an alternative that may be 
+helpful in this situation.  With this option the source file time is
+compared to the timestamp on the destination file, but only to 
+determine if the source is more recent (more than one minute 
+newer).  "More recent" in this situation indicates that the file 
+was modified more recently than the operation (e.g. copy) that 
+put the file on the destination.
+
+This option takes precedence over --checksum and --size-only so 
+in effect those options are ignored if combined with --check-newer.
+
 ### --checkers=N ###
 
 The number of checkers to run in parallel.  Checkers do the equality

--- a/fs/config.go
+++ b/fs/config.go
@@ -90,8 +90,10 @@ var (
 	noUpdateModTime = BoolP("no-update-modtime", "", false, "Don't update destination mod-time if files identical.")
 	backupDir       = StringP("backup-dir", "", "", "Make backups into hierarchy based in DIR.")
 	suffix          = StringP("suffix", "", "", "Suffix for use with --backup-dir.")
-	bwLimit         BwTimetable
-	bufferSize      SizeSuffix = 16 << 20
+	checkNewer      = BoolP("check-newer", "", false, "On remotes without mod-times, check whether source file is more recent")
+
+	bwLimit    BwTimetable
+	bufferSize SizeSuffix = 16 << 20
 
 	// Key to use for password en/decryption.
 	// When nil, no encryption will be used for saving.
@@ -216,6 +218,7 @@ type ConfigInfo struct {
 	BackupDir          string
 	Suffix             string
 	BufferSize         SizeSuffix
+	CheckNewer         bool
 }
 
 // Return the path to the configuration file
@@ -362,6 +365,7 @@ func LoadConfig() {
 	Config.BackupDir = *backupDir
 	Config.Suffix = *suffix
 	Config.BufferSize = bufferSize
+	Config.CheckNewer = *checkNewer
 
 	ConfigPath = *configFile
 

--- a/fs/operations_test.go
+++ b/fs/operations_test.go
@@ -811,6 +811,46 @@ func TestCopyFile(t *testing.T) {
 	fstest.CheckItems(t, r.fremote, file2)
 }
 
+func TestCheckNewer(t *testing.T) {
+	fs.Config.CheckNewer = true
+	defer func() { fs.Config.CheckNewer = false }()
+	r := NewRun(t)
+	defer r.Finalise()
+
+	item1L := r.WriteFile("file1", "file1 contents", t1)
+	// difference here emphasizes that this option is blind to the CONTENTS
+	item1R := r.WriteObject(item1L.Path, "file1 contentz", t1)
+
+	// Find src object, dst object
+	objL, err := r.flocal.NewObject(item1L.Path)
+	if err != nil {
+		t.Error("did not find local object")
+		return
+	}
+	objR, err := r.fremote.NewObject(item1R.Path)
+	if err != nil {
+		t.Error("did not find remote object")
+		return
+	}
+
+	// ultimately NeedTransfer calls operations.equal() which is where the
+	// CheckNewer flag has its effect
+	need := fs.NeedTransfer(objR, objL)
+	if need {
+		t.Error("Transfer 'needed' when local file is not newer")
+	}
+
+	// non-difference here emphasizes that this option sees the TIMES
+	r.WriteFile("file1", "file1 contents", t1.Add(time.Minute))
+	objL, err = r.flocal.NewObject(item1L.Path)
+
+	need = fs.NeedTransfer(objR, objL)
+	if !need {
+		t.Error("Transfer 'not needed' when local file is newer")
+	}
+
+}
+
 // testFsInfo is for unit testing fs.Info
 type testFsInfo struct {
 	name      string


### PR DESCRIPTION
I'm using crypt on an underlying Amazon Cloud drive, wanting to keep most-recent backup copies of some local directory trees.  Experimenting with the options I saw that a second or later copy operation only picks local files to copy if they are new (never before copied up) or the size is different. I understand this is because ACD does not allow setting the modification time and so it is not checked, and crypt does not support comparing the file hashes.

I wrote a powershell script to extract file names from the output of cryptcheck and for example on a local tree with about 110,000 files it found 300 more files than the copy operation with existing options.  I extended this script to generate a copy command for each file, and it did work but it was slow and made poor use of the available bandwidth due to the overheads of running all those separate commands.

I starting looking at the rclone code for ways that I might improve on this.  I decided that the simplest way to pick out the files I want re-copied is to compare the local timestamp with the remote timestamp: when the local timestamp is more recent it means the local file was altered after its last "backup".

I implemented this as a new option, --check-newer.  The impact on the code is pretty small.  I did update the doc and, while my most extensive testing is using a powershell script, I also was able to work up a test case that exercises the changed logic.  

I suppose there may be "better" ways to deal with the underlying concern, such as maybe hooking in the re-hashing used in cryptcheck to the equal function used to decide if a file needs to be copied from the src to the dest.  This being my first-ever exposure to golang and my second-ever attemtp to make a contribution on github I decided to stick with the simplest change that I thought would serve.