### PR TITLE
allow to manually flush the mount cache (fixes #803)

### DIFF
--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -5,6 +5,7 @@ package mount
 import (
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,14 +44,58 @@ func newDir(f fs.Fs, fsDir *fs.Dir) *Dir {
 	}
 }
 
+// ForgetAll ensures the directory and all its children are purged
+// from the cache.
+func (d *Dir) ForgetAll() {
+	d.ForgetPath("")
+}
+
+// ForgetPath clears the cache for itself and all subdirectories if
+// they match the given path. The path is specified relative from the
+// directory it is called from.
+// It is not possible to traverse the directory tree upwards, i.e.
+// you cannot clear the cache for the Dir's ancestors or siblings.
+func (d *Dir) ForgetPath(relativePath string) {
+	absPath := path.Join(d.path, relativePath)
+	if absPath == "." {
+		absPath = ""
+	}
+
+	d.walk(absPath, func(dir *Dir) {
+		fs.Debugf(dir.path, "forgetting directory cache")
+		dir.read = time.Time{}
+		dir.items = nil
+	})
+}
+
+// walk runs a function on all directories whose path matches
+// the given absolute one. It will be called on a directory's
+// children first. It will not apply the function to parent
+// nodes, regardless of the given path.
+func (d *Dir) walk(absPath string, fun func(*Dir)) {
+	if d.items != nil {
+		for _, entry := range d.items {
+			if dir, ok := entry.node.(*Dir); ok {
+				dir.walk(absPath, fun)
+			}
+		}
+	}
+
+	if d.path == absPath || absPath == "" || strings.HasPrefix(d.path, absPath+"/") {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		fun(d)
+	}
+}
+
 // rename should be called after the directory is renamed
 //
 // Reset the directory to new state, discarding all the objects and
 // reading everything again
 func (d *Dir) rename(newParent *Dir, fsDir *fs.Dir) {
+	d.ForgetAll()
 	d.path = fsDir.Name
 	d.modTime = fsDir.When
-	d.items = nil
 	d.read = time.Time{}
 }
 

--- a/cmd/mount/fs_test.go
+++ b/cmd/mount/fs_test.go
@@ -49,6 +49,7 @@ type Run struct {
 	fremoteName  string
 	cleanRemote  func()
 	umountResult <-chan error
+	mountFS      *FS
 	skip         bool
 }
 
@@ -102,7 +103,7 @@ func newRun() *Run {
 func (r *Run) mount() {
 	log.Printf("mount %q %q", r.fremote, r.mountPath)
 	var err error
-	r.umountResult, err = mount(r.fremote, r.mountPath)
+	r.mountFS, r.umountResult, err = mount(r.fremote, r.mountPath)
 	if err != nil {
 		log.Printf("mount failed: %v", err)
 		r.skip = true

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -122,6 +122,21 @@ mount won't do that, so will be less reliable than the rclone command.
 Note that all the rclone filters can be used to select a subset of the
 files to be visible in the mount.
 
+### Directory Cache ###
+
+Using the ` + "`--dir-cache-time`" + ` flag, you can set how long a
+directory should be considered up to date and not refreshed from the
+backend. Changes made locally in the mount may appear immediately or
+invalidate the cache. However, changes done on the remote will only
+be picked up once the cache expires.
+
+Alternatively, you can send a ` + "`SIGHUP`" + ` signal to rclone for
+it to flush all directory caches, regardless of how old they are.
+Assuming only one rlcone instance is running, you can reset the cache
+like this:
+
+    kill -SIGHUP $(pidof rclone)
+
 ### Bugs ###
 
   * All the remotes should work for read, but some may not for write
@@ -160,7 +175,7 @@ func Mount(f fs.Fs, mountpoint string) error {
 	}
 
 	// Mount it
-	errChan, err := mount(f, mountpoint)
+	_, errChan, err := mount(f, mountpoint)
 	if err != nil {
 		return errors.Wrap(err, "failed to mount FUSE fs")
 	}


### PR DESCRIPTION
some comments on this PR:
* I will rebase/squash when this is ready. I expect your review will yield some more changes :)
* fixes #803, and allows fine grained eviction if needed
* I did not need to modify bazil/fuse after all: It already offers a callback through `NodeForgetter` when it discards something on its side. Together with the already implemented rename/remove, this should cover all cases.
* the extra code in `func (d *Dir) rename(…)` is to fix #1375. I experience it when I test manually with GDrive mounted, but I didn't manage to write a failing test case. I'll have to see in #1375 if this is just a bug in GDrive, just not present in the local backend used in test cases or maybe a timing related issue…
* I wonder if SIGHUP is a good signal choice. I would prefer something like SIGUSR1, but if I read [correctly this is not available on Windows](https://github.com/golang/sys/blob/ff24cb3cd86e67842e0d078a5e0cb92d9ffcf8b4/windows/ztypes_windows.go#L51-L84). What about SIGALRM? If not, rclone should probably ignore SIGHUP in other modes, because users might otherwise accidentally kill a running sync if they pass the wrong PID.
