### PR TITLE
compare checksums on upload/download via FUSE

### DIFF
--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -22,6 +22,7 @@ import (
 // Globals
 var (
 	noModTime    = false
+	noChecksum   = false
 	debugFUSE    = false
 	noSeek       = false
 	dirCacheTime = 5 * 60 * time.Second
@@ -47,6 +48,7 @@ func init() {
 	unix.Umask(umask)     // set it back to what it was
 	cmd.Root.AddCommand(commandDefintion)
 	commandDefintion.Flags().BoolVarP(&noModTime, "no-modtime", "", noModTime, "Don't read/write the modification time (can speed things up).")
+	commandDefintion.Flags().BoolVarP(&noChecksum, "no-checksum", "", noChecksum, "Don't compare checksums on up/download.")
 	commandDefintion.Flags().BoolVarP(&debugFUSE, "debug-fuse", "", debugFUSE, "Debug the FUSE internals - needs -v.")
 	commandDefintion.Flags().BoolVarP(&noSeek, "no-seek", "", noSeek, "Don't allow seeking in files.")
 	commandDefintion.Flags().DurationVarP(&dirCacheTime, "dir-cache-time", "", dirCacheTime, "Time to cache directory entries for.")
@@ -126,10 +128,6 @@ files to be visible in the mount.
     * those which need to know the size in advance won't - eg B2
     * maybe should pass in size as -1 to mean work it out
     * Or put in an an upload cache to cache the files on disk first
-
-### TODO ###
-
-  * Check hashes on upload/download
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)

--- a/cmd/mount/read_test.go
+++ b/cmd/mount/read_test.go
@@ -37,6 +37,45 @@ func TestReadByByte(t *testing.T) {
 	run.rm(t, "testfile")
 }
 
+func TestReadChecksum(t *testing.T) {
+	run.skipIfNoFUSE(t)
+
+	// create file big enough so we exceed any single FUSE read
+	// request
+	b := make([]rune, 3*128*1024)
+	for i := range b {
+		b[i] = 'r'
+	}
+	run.createFile(t, "bigfile", string(b))
+
+	// The hash comparison would fail in Flush, if we did not
+	// ensure we read the whole file
+	fd, err := os.Open(run.path("bigfile"))
+	assert.NoError(t, err)
+	buf := make([]byte, 10)
+	_, err = io.ReadFull(fd, buf)
+	assert.NoError(t, err)
+	err = fd.Close()
+	assert.NoError(t, err)
+
+	// The hash comparison would fail, because we only read parts
+	// of the file
+	fd, err = os.Open(run.path("bigfile"))
+	assert.NoError(t, err)
+	// read at start
+	_, err = io.ReadFull(fd, buf)
+	assert.NoError(t, err)
+	// read at end
+	_, err = fd.Seek(int64(len(b)-len(buf)), 0)
+	assert.NoError(t, err)
+	_, err = io.ReadFull(fd, buf)
+	// ensure we don't compare hashes
+	err = fd.Close()
+	assert.NoError(t, err)
+
+	run.rm(t, "bigfile")
+}
+
 // Test double close
 func TestReadFileDoubleClose(t *testing.T) {
 	run.skipIfNoFUSE(t)


### PR DESCRIPTION
I'm not sure how to write decent tests for the error cases, i.e. when comparing the hash sum fails. The only thing I can think of would be meddle with the internal state of some of the objects. When I edit the code so that hash comparison always fails, we get the desired behaviour: input/output errors both during reads and writes.