### PR TITLE
Add snap install instructions

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -46,6 +46,14 @@ Links
 
 Rclone is a Go program and comes as a single binary file.
 
+## Linux installation from snaps ##
+
+Install rclone in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install rclone
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
 ## Quickstart ##
 
   * [Download](http://rclone.org/downloads/) the relevant binary.


### PR DESCRIPTION
`rclone` is published in the snap store! This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Your software can be installed with a simple `snap install rclone` simplifying the installation instructions for your users.

Please can you also add snap install instructions to [your downloads](https://rclone.org/downloads/) page as well?