### PR TITLE
Rclone cross compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+
+jobs:
+
+  build:
+    machine: true
+
+    working_directory: ~/.go_workspace/src/github.com/ncw/rclone
+
+    steps:
+    - checkout
+
+    - run:
+        name: Cross-compile rclone
+        command: |
+            docker pull billziss/xgo-cgofuse
+            go get -v github.com/karalabe/xgo
+            xgo \
+                --image=billziss/xgo-cgofuse \
+                --targets=darwin/386,darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 \
+                .
+
+    - run:
+        name: Prepare artifacts
+        command: |
+            mkdir -p /tmp/rclone.dist
+            cp -R rclone-* /tmp/rclone.dist
+
+    - store_artifacts:
+        path: /tmp/rclone.dist

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,8 +33,8 @@ memo = "28c7ca08636da6264c587a36b72ce4f3a45fdf5c32969ffd2092b98456c73685"
 [[projects]]
   name = "github.com/billziss-gh/cgofuse"
   packages = ["fuse"]
-  revision = "b402ef9fb28afcc443348ba2d46b5bfd88867fea"
-  version = "v1.0"
+  revision = "20507c2217acffc7b7d555d337754792e1a9af87"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/cpuguy83/go-md2man"

--- a/vendor/github.com/billziss-gh/cgofuse/.circleci/config.yml
+++ b/vendor/github.com/billziss-gh/cgofuse/.circleci/config.yml
@@ -1,0 +1,69 @@
+version: 2
+
+jobs:
+
+  build:
+    machine: true
+
+    environment:
+      PROJNAME: github.com/billziss-gh/cgofuse
+
+    working_directory: ~/.go_workspace/src/github.com/billziss-gh/cgofuse
+
+    steps:
+    - checkout
+
+    - run:
+        name: Build cgofuse image
+        command: docker build -t cgofuse .
+
+    - run:
+        name: Cross-compile cgofuse
+        command: |
+            go get -v github.com/karalabe/xgo
+            xgo \
+                --image=cgofuse \
+                --targets=darwin/386,darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 \
+                --buildmode=archive \
+                ./fuse
+
+    - run:
+        name: Prepare artifacts
+        command: |
+            mkdir -p /tmp/cgofuse.work/src/$PROJNAME/fuse
+            echo //go:binary-only-package >/tmp/cgofuse.work/src/$PROJNAME/fuse/host.go
+            echo package fuse            >>/tmp/cgofuse.work/src/$PROJNAME/fuse/host.go
+            echo //go:binary-only-package >/tmp/cgofuse.work/src/$PROJNAME/fuse/fsop.go
+            echo package fuse            >>/tmp/cgofuse.work/src/$PROJNAME/fuse/fsop.go
+            for f in fuse-*.[al]*; do
+                d=$(echo "$f" | sed 's/fuse-\([^-.]*\).*-\([^-.]*\)\..*/\1_\2/g')
+                mkdir -p /tmp/cgofuse.work/pkg/$d/$PROJNAME
+                cp "$f" /tmp/cgofuse.work/pkg/$d/$PROJNAME/fuse.a
+            done
+            mkdir -p /tmp/cgofuse.dist
+            GIT_DSC=$(git describe --long)
+            (cd /tmp/cgofuse.work && zip -rv - *) >/tmp/cgofuse.dist/cgofuse-$GIT_DSC.zip
+
+    - store_artifacts:
+        path: /tmp/cgofuse.dist
+
+    - deploy:
+        name: Make github release
+        command: |
+            if git describe --exact-match >/dev/null 2>&1; then
+                GIT_TAG=$(git describe --exact-match)
+                GIT_DSC=$(git describe --long)
+                go get -v github.com/aktau/github-release
+                github-release release \
+                    --user "$CIRCLE_PROJECT_USERNAME" \
+                    --repo "$CIRCLE_PROJECT_REPONAME" \
+                    --tag $GIT_TAG \
+                    --pre-release || true
+                github-release upload \
+                    --user "$CIRCLE_PROJECT_USERNAME" \
+                    --repo "$CIRCLE_PROJECT_REPONAME" \
+                    --tag $GIT_TAG \
+                    --file /tmp/cgofuse.dist/cgofuse-$GIT_DSC.zip \
+                    --name cgofuse-${GIT_TAG:1}.zip \
+                    --replace
+            fi

--- a/vendor/github.com/billziss-gh/cgofuse/Dockerfile
+++ b/vendor/github.com/billziss-gh/cgofuse/Dockerfile
@@ -1,0 +1,40 @@
+FROM \
+    karalabe/xgo-latest
+
+MAINTAINER \
+    Bill Zissimopoulos <billziss at navimatics.com>
+
+# add 32-bit and 64-bit architectures and install 7zip
+RUN \
+    dpkg --add-architecture i386 && \
+    dpkg --add-architecture amd64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends p7zip-full
+
+# install OSXFUSE
+RUN \
+    wget -q -O osxfuse.dmg --no-check-certificate \
+        http://sourceforge.net/projects/osxfuse/files/osxfuse-2.8.3/osxfuse-2.8.3.dmg/download && \
+    7z e osxfuse.dmg 0.hfs &&\
+    7z e 0.hfs "FUSE for OS X/Install OSXFUSE 2.8.pkg" && \
+    7z e "Install OSXFUSE 2.8.pkg" 10.9/OSXFUSECore.pkg/Payload && \
+    7z e Payload && \
+    7z x Payload~ -o/tmp && \
+    cp -R /tmp/usr/local/include/osxfuse /usr/local/include && \
+    cp /tmp/usr/local/lib/libosxfuse_i64.2.dylib /usr/local/lib/libosxfuse.dylib
+
+# install LIBFUSE
+RUN \
+    apt-get install -y --no-install-recommends libfuse-dev:i386 && \
+    apt-get install -y --no-install-recommends libfuse-dev:amd64 && \
+    apt-get download libfuse-dev:i386 && \
+    dpkg -x libfuse-dev*i386*.deb /
+
+# install WinFsp-FUSE
+RUN \
+    wget -q -O winfsp.zip --no-check-certificate \
+        https://github.com/billziss-gh/winfsp/archive/v1.0.zip && \
+    7z e winfsp.zip 'winfsp-1.0/inc/fuse/*' -o/usr/local/include/winfsp
+
+ENV \
+    OSXCROSS_NO_INCLUDE_PATH_WARNINGS 1

--- a/vendor/github.com/billziss-gh/cgofuse/README.md
+++ b/vendor/github.com/billziss-gh/cgofuse/README.md
@@ -2,6 +2,7 @@
 
 [![Travis CI](https://img.shields.io/travis/billziss-gh/cgofuse.svg?label=osx/linux)](https://travis-ci.org/billziss-gh/cgofuse)
 [![AppVeyor](https://img.shields.io/appveyor/ci/billziss-gh/cgofuse.svg?label=windows)](https://ci.appveyor.com/project/billziss-gh/cgofuse)
+[![CircleCI](https://img.shields.io/circleci/project/github/billziss-gh/cgofuse.svg?label=cross-build)](https://circleci.com/gh/billziss-gh/cgofuse)
 [![GoDoc](https://godoc.org/github.com/billziss-gh/cgofuse/fuse?status.svg)](https://godoc.org/github.com/billziss-gh/cgofuse/fuse)
 
 Cgofuse is a cross-platform FUSE library for Go. It is implemented using [cgo](https://golang.org/cmd/cgo/) and can be ported to any platform that has a FUSE implementation.

--- a/vendor/github.com/billziss-gh/cgofuse/fuse/host.go
+++ b/vendor/github.com/billziss-gh/cgofuse/fuse/host.go
@@ -15,9 +15,13 @@ package fuse
 /*
 #cgo darwin CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64 -I/usr/local/include/osxfuse/fuse
 #cgo darwin LDFLAGS: -L/usr/local/lib -losxfuse
+
 #cgo linux CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse
 #cgo linux LDFLAGS: -lfuse
-#cgo windows CFLAGS: -D_WIN32_WINNT=0x0600 -DFUSE_USE_VERSION=28
+
+// Use `set CPATH=C:\Program Files (x86)\WinFsp\inc\fuse` on Windows.
+// The flag `I/usr/local/include/winfsp` only works on xgo and docker.
+#cgo windows CFLAGS: -D_WIN32_WINNT=0x0600 -DFUSE_USE_VERSION=28 -I/usr/local/include/winfsp
 
 #if !(defined(__APPLE__) || defined(__linux__) || defined(_WIN32))
 #error platform not supported
@@ -907,7 +911,7 @@ func hostInit(conn0 *C.struct_fuse_conn_info) (user_data unsafe.Pointer) {
 		C.bool(host.capCaseInsensitive),
 		C.bool(host.capReaddirPlus))
 	if nil != host.sigc {
-		signal.Notify(host.sigc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+		signal.Notify(host.sigc, syscall.SIGINT, syscall.SIGTERM)
 	}
 	host.fsop.Init()
 	return
@@ -1023,9 +1027,6 @@ func (host *FileSystemHost) SetCapReaddirPlus(value bool) {
 // It is allowed for the mountpoint to be the empty string ("") in which case opts is assumed
 // to contain the mountpoint. It is also allowed for opts to be nil, although in this case the
 // mountpoint must be non-empty.
-//
-// The file system is considered mounted only after its Init() method has been called
-// and before its Destroy() method has been called.
 func (host *FileSystemHost) Mount(mountpoint string, opts []string) bool {
 	if 0 == C.hostInitializeFuse() {
 		panic("cgofuse: cannot find winfsp")


### PR DESCRIPTION
This PR adds cross-compilation for rclone using CircleCI. The PR updates cgofuse to v1.0.1 (necessary to properly cross-compile on Windows) and adds a simple CircleCI configuration file that cross-compiles rclone.

To cross-compile rclone I use the docker image [billziss/xgo-cgofuse](https://hub.docker.com/r/billziss/xgo-cgofuse/) which was produced by this [Dockerfile](https://github.com/billziss-gh/cgofuse/blob/master/Dockerfile). It is basically the xgo docker image with OSXFUSE, LIBFUSE and WinFsp-FUSE added so that cgofuse and rclone can be cross-compiled properly.

The cross-compilation can also be easily done from the command line:

```
$ docker pull billziss/xgo-cgofuse
$ go get -u github.com/karalabe/xgo
$ xgo --image=billziss/xgo-cgofuse --targets=darwin/386,darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 .
```

I have tested the produced executables and their `mount` / `cmount` commands and they run properly. [There is a single exception: the linux/386 architecture does not run on my x64 Linux VM; I think this is normal for Linux installations that do not have the 32-bit standard libraries installed however.] The produced executables have both `mount` and `cmount` commands, except for Windows which has only `mount`.

Because rclone does not currently use CircleCI, I expect that you may be unwilling to accept this PR and that's fine of course. I chose CircleCI, because of its nice artifact support. Since Travis supports docker a similar xgo solution might work there too.

Here is a CircleCI build [log](https://circleci.com/gh/billziss-gh/rclone/7) and a screenshot of the CircleCI artifacts page:

<img width="608" alt="screen shot 2017-05-15 at 11 14 10 pm" src="https://cloud.githubusercontent.com/assets/15330948/26092171/419f6186-39c4-11e7-84d5-d00c9b866081.png">