### PR TITLE
poll for Google Drive changes when mounted

### DIFF
--- a/amazonclouddrive/amazonclouddrive_test.go
+++ b/amazonclouddrive/amazonclouddrive_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/b2/b2_test.go
+++ b/b2/b2_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/cmd/cmount/fs.go
+++ b/cmd/cmount/fs.go
@@ -48,6 +48,9 @@ func NewFS(f fs.Fs) *FS {
 	if readOnly {
 		fsys.FS.ReadOnly()
 	}
+	if pollInterval > 0 {
+		fsys.FS.PollChanges(pollInterval)
+	}
 	return fsys
 }
 

--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -32,6 +32,7 @@ var (
 	debugFUSE    = false
 	noSeek       = false
 	dirCacheTime = 5 * 60 * time.Second
+	pollInterval = time.Minute
 	// mount options
 	readOnly                         = false
 	allowNonEmpty                    = false
@@ -58,6 +59,7 @@ func init() {
 	commandDefintion.Flags().BoolVarP(&debugFUSE, "debug-fuse", "", debugFUSE, "Debug the FUSE internals - needs -v.")
 	commandDefintion.Flags().BoolVarP(&noSeek, "no-seek", "", noSeek, "Don't allow seeking in files.")
 	commandDefintion.Flags().DurationVarP(&dirCacheTime, "dir-cache-time", "", dirCacheTime, "Time to cache directory entries for.")
+	commandDefintion.Flags().DurationVarP(&pollInterval, "poll-interval", "", pollInterval, "Time to wait between polling for changes. Must be smaller than dir-cache-time. Only on supported remotes. Set to 0 to disable.")
 	// mount options
 	commandDefintion.Flags().BoolVarP(&readOnly, "read-only", "", readOnly, "Mount read-only.")
 	commandDefintion.Flags().BoolVarP(&allowNonEmpty, "allow-non-empty", "", allowNonEmpty, "Allow mounting over a non-empty directory.")

--- a/cmd/mount/fs.go
+++ b/cmd/mount/fs.go
@@ -39,6 +39,9 @@ func NewFS(f fs.Fs) *FS {
 	if readOnly {
 		fsys.FS.ReadOnly()
 	}
+	if pollInterval > 0 {
+		fsys.FS.PollChanges(pollInterval)
+	}
 	return fsys
 }
 

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -28,6 +28,7 @@ var (
 	debugFUSE    = false
 	noSeek       = false
 	dirCacheTime = 5 * 60 * time.Second
+	pollInterval = time.Minute
 	// mount options
 	readOnly                         = false
 	allowNonEmpty                    = false
@@ -54,6 +55,7 @@ func init() {
 	commandDefintion.Flags().BoolVarP(&debugFUSE, "debug-fuse", "", debugFUSE, "Debug the FUSE internals - needs -v.")
 	commandDefintion.Flags().BoolVarP(&noSeek, "no-seek", "", noSeek, "Don't allow seeking in files.")
 	commandDefintion.Flags().DurationVarP(&dirCacheTime, "dir-cache-time", "", dirCacheTime, "Time to cache directory entries for.")
+	commandDefintion.Flags().DurationVarP(&pollInterval, "poll-interval", "", pollInterval, "Time to wait between polling for changes. Must be smaller than dir-cache-time. Only on supported remotes. Set to 0 to disable.")
 	// mount options
 	commandDefintion.Flags().BoolVarP(&readOnly, "read-only", "", readOnly, "Mount read-only.")
 	commandDefintion.Flags().BoolVarP(&allowNonEmpty, "allow-non-empty", "", allowNonEmpty, "Allow mounting over a non-empty directory.")

--- a/cmd/mountlib/fs.go
+++ b/cmd/mountlib/fs.go
@@ -51,7 +51,20 @@ func NewFS(f fs.Fs) *FS {
 	fsys := &FS{
 		f: f,
 	}
+
 	fsys.root = newDir(fsys, f, fsDir)
+
+	return fsys
+}
+
+// PollChanges will poll the remote every pollInterval for changes if the remote
+// supports it. If a non-polling option is used, the given time interval can be
+// ignored
+func (fsys *FS) PollChanges(pollInterval time.Duration) *FS {
+	doDirChangeNotify := fsys.f.Features().DirChangeNotify
+	if doDirChangeNotify != nil {
+		doDirChangeNotify(fsys.root.ForgetPath, pollInterval)
+	}
 	return fsys
 }
 

--- a/crypt/crypt2_test.go
+++ b/crypt/crypt2_test.go
@@ -45,6 +45,7 @@ func TestFsMove2(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove2(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull2(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision2(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify2(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString2(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs2(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote2(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/crypt/crypt3_test.go
+++ b/crypt/crypt3_test.go
@@ -45,6 +45,7 @@ func TestFsMove3(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove3(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull3(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision3(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify3(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString3(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs3(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote3(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/crypt/crypt_test.go
+++ b/crypt/crypt_test.go
@@ -45,6 +45,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/drive/drive_test.go
+++ b/drive/drive_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/dropbox/dropbox_test.go
+++ b/dropbox/dropbox_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/ftp/ftp_test.go
+++ b/ftp/ftp_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/googlecloudstorage/googlecloudstorage_test.go
+++ b/googlecloudstorage/googlecloudstorage_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/hubic/hubic_test.go
+++ b/hubic/hubic_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/onedrive/onedrive_test.go
+++ b/onedrive/onedrive_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/swift/swift_test.go
+++ b/swift/swift_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/yandex/yandex_test.go
+++ b/yandex/yandex_test.go
@@ -44,6 +44,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }


### PR DESCRIPTION
With this patch I am the least sure about the actual selection of path to invalidate the cache for. Everything is given as `kind:File` (or type `*File`), even if it's a folder. In some scenarios it appeared as if it would cache invalidate `/`, even though I only had changes within `/subdir/`, but I did not manage to reproduce those. The integration test I added also passes for me.

I'll dogfood the patch in the following days, though, and can always contribute more patches I guess.

Cheers
Stefan