### PR TITLE
fully write new config file before moving to target location (fixes #1287)

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -650,13 +650,13 @@ func SaveConfig() {
 		Errorf(nil, "Failed to set permissions on config file: %v", err)
 	}
 
-	if err = os.Rename(ConfigPath, ConfigPath+".old"); err != nil {
+	if err = os.Rename(ConfigPath, ConfigPath+".old"); err != nil && !os.IsNotExist(err) {
 		log.Fatalf("Failed to move previous config to backup location: %v", err)
 	}
 	if err = os.Rename(f.Name(), ConfigPath); err != nil {
-		log.Fatalf("Failed to move newly written config to final location: %v", err)
+		log.Fatalf("Failed to move newly written config from %s to final location: %v", f.Name(), err)
 	}
-	if err := os.Remove(ConfigPath + ".old"); err != nil {
+	if err := os.Remove(ConfigPath + ".old"); err != nil && !os.IsNotExist(err) {
 		Errorf(nil, "Failed to remove backup config file: %v", err)
 	}
 }


### PR DESCRIPTION
This should fix the issue described in #1287, or at least fail before destroying the existing config. I chose to delete the temporary backup file so that it is at least not kept around if a user decides to encrypt the config. The old file should probably erased securely when encryption is on, though.