### PR TITLE
make moveto/copyto no-ops when source and destination are the same (fixes #1261)

### DIFF
--- a/fs/operations.go
+++ b/fs/operations.go
@@ -1487,6 +1487,11 @@ func Rmdirs(f Fs, dir string) error {
 
 // moveOrCopyFile moves or copies a single file possibly to a new name
 func moveOrCopyFile(fdst Fs, fsrc Fs, dstFileName string, srcFileName string, cp bool) (err error) {
+	if fdst.Name() == fsrc.Name() && dstFileName == srcFileName {
+		Debugf(fdst, "don't need to copy/move %s, it is already at target location", dstFileName)
+		return nil
+	}
+
 	// Choose operations
 	Op := Move
 	if cp {

--- a/fs/operations_test.go
+++ b/fs/operations_test.go
@@ -788,6 +788,11 @@ func TestMoveFile(t *testing.T) {
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.flocal)
 	fstest.CheckItems(t, r.fremote, file2)
+
+	err = fs.MoveFile(r.fremote, r.flocal, file2.Path, file2.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.flocal)
+	fstest.CheckItems(t, r.fremote, file2)
 }
 
 func TestCopyFile(t *testing.T) {
@@ -806,6 +811,11 @@ func TestCopyFile(t *testing.T) {
 	fstest.CheckItems(t, r.fremote, file2)
 
 	err = fs.CopyFile(r.fremote, r.flocal, file2.Path, file1.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.flocal, file1)
+	fstest.CheckItems(t, r.fremote, file2)
+
+	err = fs.CopyFile(r.fremote, r.flocal, file2.Path, file2.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.flocal, file1)
 	fstest.CheckItems(t, r.fremote, file2)


### PR DESCRIPTION
#1261 is only about moving and copying from/to the same destination works for me on Google Drive even without the patch. I guess it might safe an operation in an edge case, though, so why not…

Cheers
Stefan