### PR TITLE
hand dirCacheTime through again

### DIFF
--- a/cmd/cmount/fs.go
+++ b/cmd/cmount/fs.go
@@ -51,6 +51,7 @@ func NewFS(f fs.Fs) *FS {
 	if pollInterval > 0 {
 		fsys.FS.PollChanges(pollInterval)
 	}
+	fsys.FS.SetDirCacheTime(dirCacheTime)
 	return fsys
 }
 

--- a/cmd/mount/fs.go
+++ b/cmd/mount/fs.go
@@ -42,6 +42,7 @@ func NewFS(f fs.Fs) *FS {
 	if pollInterval > 0 {
 		fsys.FS.PollChanges(pollInterval)
 	}
+	fsys.FS.SetDirCacheTime(dirCacheTime)
 	return fsys
 }
 

--- a/cmd/mountlib/dir.go
+++ b/cmd/mountlib/dir.go
@@ -10,8 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var dirCacheTime = 60 * time.Second // FIXME needs to be settable
-
 // DirEntry describes the contents of a directory entry
 //
 // It can be a file or a directory
@@ -152,7 +150,7 @@ func (d *Dir) readDir() error {
 		// fs.Debugf(d.path, "Reading directory")
 	} else {
 		age := when.Sub(d.read)
-		if age < dirCacheTime {
+		if age < d.fsys.dirCacheTime {
 			return nil
 		}
 		fs.Debugf(d.path, "Re-reading directory (%v old)", age)

--- a/cmd/mountlib/fs.go
+++ b/cmd/mountlib/fs.go
@@ -35,11 +35,12 @@ var (
 
 // FS represents the top level filing system
 type FS struct {
-	f          fs.Fs
-	root       *Dir
-	noSeek     bool // don't allow seeking if set
-	noChecksum bool // don't check checksums if set
-	readOnly   bool // if set FS is read only
+	f            fs.Fs
+	root         *Dir
+	noSeek       bool          // don't allow seeking if set
+	noChecksum   bool          // don't check checksums if set
+	readOnly     bool          // if set FS is read only
+	dirCacheTime time.Duration // how long to consider directory listing cache valid
 }
 
 // NewFS creates a new filing system and root directory
@@ -54,6 +55,13 @@ func NewFS(f fs.Fs) *FS {
 
 	fsys.root = newDir(fsys, f, fsDir)
 
+	return fsys
+}
+
+// SetDirCacheTime allows to set how long a directory listing is considered
+// valid. Set to 0 always request a fresh version from the remote.
+func (fsys *FS) SetDirCacheTime(dirCacheTime time.Duration) *FS {
+	fsys.dirCacheTime = dirCacheTime
 	return fsys
 }
 


### PR DESCRIPTION
I got confused for a moment when testing the google-drive-poll-changes patch why the dir cache was not honored. This is a very simple patch which might not needed depending on how many further changes are planned. In any case, it's a bandaid for people who use HEAD.