### PR TITLE
Updated S3 sync permissions

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -252,6 +252,7 @@ permissions are required to be available on the bucket being written to:
 
 * `ListBucket`
 * `DeleteObject`
+* `GetObject`
 * `PutObject`
 * `PutObjectACL`
 
@@ -269,6 +270,7 @@ Example policy:
             "Action": [
                 "s3:ListBucket",
                 "s3:DeleteObject",
+                "s3:GetObject",
                 "s3:PutObject",
                 "s3:PutObjectAcl"
             ],


### PR DESCRIPTION
As it happens, after testing the `GetObject` permission is also required to do `HEAD` requests on a given object.