### PR TITLE
Adds object ID to debug output from ls

### DIFF
--- a/drive/drive.go
+++ b/drive/drive.go
@@ -476,6 +476,7 @@ func (f *Fs) newObjectWithInfo(remote string, info *drive.File) (fs.Object, erro
 			return nil, err
 		}
 	}
+	fs.Debugf(o, "ID = %q", o.id)
 	return o, nil
 }
 


### PR DESCRIPTION
I added the minimum code recommended by @ncw - IMHO a good evolution would be either a "fileinfo" command that returns appropriate information from the current backend (which could then include download URLs and so on) and/or a flag to add (a subset of) this information to the normal output for other commands like sync, copy, move, etc.