### PR TITLE
local: add --skip-links to suppress symlink warnings

### DIFF
--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -172,3 +172,8 @@ filesystem.
 **NB** This flag is only available on Unix based systems.  On systems
 where it isn't supported (eg Windows) it will not appear as an valid
 flag.
+
+#### --skip-links ####
+
+This flag disables warning messages on skipped symlinks or junction
+points, as you explicitly acknowledge that they should be skipped.

--- a/local/local.go
+++ b/local/local.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	followSymlinks = fs.BoolP("copy-links", "L", false, "Follow symlinks and copy the pointed to item.")
+	skipSymlinks   = fs.BoolP("skip-links", "", false, "Don't warn about skipped symlinks.")
 	noUTFNorm      = fs.BoolP("local-no-unicode-normalization", "", false, "Don't apply unicode normalization to paths and filenames")
 )
 
@@ -606,7 +607,9 @@ func (o *Object) Storable() bool {
 		mode &^= os.ModeSymlink
 	}
 	if mode&os.ModeSymlink != 0 {
-		fs.Logf(o, "Can't follow symlink without -L/--copy-links")
+		if !*skipSymlinks {
+			fs.Logf(o, "Can't follow symlink without -L/--copy-links")
+		}
 		return false
 	} else if mode&(os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
 		fs.Logf(o, "Can't transfer non file/directory")


### PR DESCRIPTION
Give users a way to explicitly acknowledge that symlinks are to be skipped without warnings.

I want an option like this because I sync a drive with tons of symlinks to Google Drive and don't want to be flooded with "Can't follow symlink without -L/--copy-links" messages every single time, which may even bury actually useful/actionable messages.