### PR TITLE
Support for hard deletion of files during b2 sync

### DIFF
--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -138,10 +138,13 @@ used.
 
 When rclone uploads a new version of a file it creates a [new version
 of it](https://www.backblaze.com/b2/docs/file_versions.html).
-Likewise when you delete a file, the old version will still be
-available.
+Likewise when you delete a file, the old version will be marked hidden
+and still be available.  Conversely, you may opt in to a "hard delete"
+of files with the `--b2-hard-delete` flag which would permanently remove
+the file instead of hiding it.
 
-Old versions of files are visible using the `--b2-versions` flag.
+Old versions of files, where available, are visible using the 
+`--b2-versions` flag.
 
 If you wish to remove all the old versions then you can use the
 `rclone cleanup remote:bucket` command which will delete all the old


### PR DESCRIPTION
This PR addresses #1547 with a new option `--b2-soft-delete` that is on by default (i.e. no regression from the present version).  Setting it to `--b2-soft-delete=false` permanently deletes remote files during `sync` instead of hiding them.