### PR TITLE
Added documentation information about Drive server side copies limits

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -275,6 +275,10 @@ limited to transferring about 2 files per second only.  Individual
 files may be transferred much faster at 100s of MBytes/s but lots of
 small files can take a long time.
 
+Server side copies are also subject to a separate rate limit. If
+you see User rate limit exceeded errors, wait at least 24 hours and
+retry.
+
 ### Duplicated files ###
 
 Sometimes, for no reason I've been able to track down, drive will


### PR DESCRIPTION
This information has been gathered from #1339 and confirmed by myself.
This fixes #1552