### PR TITLE
Add support for checksums/hashes with SFTP

### DIFF
--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -27,7 +27,7 @@ Here is an overview of the major features of each cloud storage system.
 | Google Drive                 | MD5         | Yes     | No               | Yes             | R/W       |
 | HTTP                         | -           | No      | No               | No              | R         |
 | Hubic                        | MD5         | Yes     | No               | No              | R/W       |
-| Microsoft Azure Blob Storage | MD5         | Yes     | No               | No              |
+| Microsoft Azure Blob Storage | MD5         | Yes     | No               | No              | R/W
 | Microsoft OneDrive           | SHA1        | Yes     | Yes              | No              | R         |
 | Openstack Swift              | MD5         | Yes     | No               | No              | R/W       |
 | QingStor                     | -           | No      | No               | No              | R/W       |

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -48,6 +48,9 @@ systems they must support a common hash type.
 hash](https://www.dropbox.com/developers/reference/content-hash).
 This is an SHA256 sum of all the 4MB block SHA256s.
 
+* SFTP supports checksums if the same login has shell access and `md5sum`
+or `sha1sum` as well as `echo` are in the remote's PATH.
+
 ### ModTime ###
 
 The cloud storage system supports setting modification times on

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -15,25 +15,24 @@ show through.
 
 Here is an overview of the major features of each cloud storage system.
 
-| Name                         | Hash    | ModTime | Case Insensitive | Duplicate Files | MIME Type |
-| ---------------------------- |:-------:|:-------:|:----------------:|:---------------:|:---------:|
-| Amazon Drive                 | MD5     | No      | Yes              | No              | R         |
-| Amazon S3                    | MD5     | Yes     | No               | No              | R/W       |
-| Backblaze B2                 | SHA1    | Yes     | No               | No              | R/W       |
-| Box                          | SHA1    | Yes     | Yes              | No              | -         |
-| Dropbox                      | DBHASH †| Yes     | Yes              | No              | -         |
-| FTP                          | -       | No      | No               | No              | -         |
-| Google Cloud Storage         | MD5     | Yes     | No               | No              | R/W       |
-| Google Drive                 | MD5     | Yes     | No               | Yes             | R/W       |
-| HTTP                         | -       | No      | No               | No              | R         |
-| Hubic                        | MD5     | Yes     | No               | No              | R/W       |
-| Microsoft Azure Blob Storage | MD5     | Yes     | No               | No              | R/W       |
-| Microsoft OneDrive           | SHA1    | Yes     | Yes              | No              | R         |
-| Openstack Swift              | MD5     | Yes     | No               | No              | R/W       |
-| QingStor                     | -       | No      | No               | No              | R/W       |
-| SFTP                         | -       | Yes     | Depends          | No              | -         |
-| Yandex Disk                  | MD5     | Yes     | No               | No              | R/W       |
-| The local filesystem         | All     | Yes     | Depends          | No              | -         |
+| Name                   | Hash        | ModTime | Case Insensitive | Duplicate Files | MIME Type |
+| ---------------------- |:-----------:|:-------:|:----------------:|:---------------:|:---------:|
+| Amazon Drive           | MD5         | No      | Yes              | No              | R         |
+| Amazon S3              | MD5         | Yes     | No               | No              | R/W       |
+| Backblaze B2           | SHA1        | Yes     | No               | No              | R/W       |
+| Box                    | SHA1        | Yes     | Yes              | No              | -         |
+| Dropbox                | DBHASH †    | Yes     | Yes              | No              | -         |
+| FTP                    | -           | No      | No               | No              | -         |
+| Google Cloud Storage   | MD5         | Yes     | No               | No              | R/W       |
+| Google Drive           | MD5         | Yes     | No               | Yes             | R/W       |
+| HTTP                   | -           | No      | No               | No              | R         |
+| Hubic                  | MD5         | Yes     | No               | No              | R/W       |
+| Microsoft OneDrive     | SHA1        | Yes     | Yes              | No              | R         |
+| Openstack Swift        | MD5         | Yes     | No               | No              | R/W       |
+| QingStor               | -           | No      | No               | No              | R/W       |
+| SFTP                   | MD5, SHA1 * | Yes     | Depends          | No              | -         |
+| Yandex Disk            | MD5         | Yes     | No               | No              | R/W       |
+| The local filesystem   | All         | Yes     | Depends          | No              | -         |
 
 ### Hash ###
 
@@ -112,25 +111,24 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some
 operations more efficient.
 
-| Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR |
-| ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|
-| Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| Amazon S3                    | No    | Yes  | No   | No      | No      | Yes   |
-| Backblaze B2                 | No    | No   | No   | No      | Yes     | Yes   |
-| Box                          | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| Dropbox                      | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| FTP                          | No    | No   | Yes  | Yes     | No      | No    |
-| Google Cloud Storage         | Yes   | Yes  | No   | No      | No      | Yes   |
-| Google Drive                 | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |  No    |
-| HTTP                         | No    | No   | No   | No      | No      | No    |
-| Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   |
-| Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   |
-| Microsoft OneDrive           | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| Openstack Swift              | Yes † | Yes  | No   | No      | No      | Yes   |
-| QingStor                     | No    | Yes  | No   | No      | No      | Yes   |
-| SFTP                         | No    | No   | Yes  | Yes     | No      | No    |
-| Yandex Disk                  | Yes   | No   | No   | No      | No  [#575](https://github.com/ncw/rclone/issues/575) | Yes   |
-| The local filesystem         | Yes   | No   | Yes  | Yes     | No      | No    |
+| Name                   | Purge | Copy | Move | DirMove | CleanUp | ListR |
+| ---------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|
+| Amazon Drive           | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| Amazon S3              | No    | Yes  | No   | No      | No      | Yes   |
+| Backblaze B2           | No    | No   | No   | No      | Yes     | Yes   |
+| Box                    | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| Dropbox                | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| FTP                    | No    | No   | Yes  | Yes     | No      | No    |
+| Google Cloud Storage   | Yes   | Yes  | No   | No      | No      | Yes   |
+| Google Drive           | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |  No    |
+| HTTP                   | No    | No   | No   | No      | No      | No    |
+| Hubic                  | Yes † | Yes  | No   | No      | No      | Yes   |
+| Microsoft OneDrive     | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| Openstack Swift        | Yes † | Yes  | No   | No      | No      | Yes   |
+| QingStor               | No    | Yes  | No   | No      | No      | Yes   |
+| SFTP                   | No    | No   | Yes  | Yes     | No      | No    |
+| Yandex Disk            | Yes   | No   | No   | No      | No  [#575](https://github.com/ncw/rclone/issues/575) | Yes   |
+| The local filesystem   | Yes   | No   | Yes  | Yes     | No      | No    |
 
 
 ### Purge ###

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -27,7 +27,7 @@ Here is an overview of the major features of each cloud storage system.
 | Google Drive                 | MD5         | Yes     | No               | Yes             | R/W       |
 | HTTP                         | -           | No      | No               | No              | R         |
 | Hubic                        | MD5         | Yes     | No               | No              | R/W       |
-| Microsoft Azure Blob Storage | MD5         | Yes     | No               | No              | R/W
+| Microsoft Azure Blob Storage | MD5         | Yes     | No               | No              | R/W       |
 | Microsoft OneDrive           | SHA1        | Yes     | Yes              | No              | R         |
 | Openstack Swift              | MD5         | Yes     | No               | No              | R/W       |
 | QingStor                     | -           | No      | No               | No              | R/W       |

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -15,24 +15,25 @@ show through.
 
 Here is an overview of the major features of each cloud storage system.
 
-| Name                   | Hash        | ModTime | Case Insensitive | Duplicate Files | MIME Type |
-| ---------------------- |:-----------:|:-------:|:----------------:|:---------------:|:---------:|
-| Amazon Drive           | MD5         | No      | Yes              | No              | R         |
-| Amazon S3              | MD5         | Yes     | No               | No              | R/W       |
-| Backblaze B2           | SHA1        | Yes     | No               | No              | R/W       |
-| Box                    | SHA1        | Yes     | Yes              | No              | -         |
-| Dropbox                | DBHASH †    | Yes     | Yes              | No              | -         |
-| FTP                    | -           | No      | No               | No              | -         |
-| Google Cloud Storage   | MD5         | Yes     | No               | No              | R/W       |
-| Google Drive           | MD5         | Yes     | No               | Yes             | R/W       |
-| HTTP                   | -           | No      | No               | No              | R         |
-| Hubic                  | MD5         | Yes     | No               | No              | R/W       |
-| Microsoft OneDrive     | SHA1        | Yes     | Yes              | No              | R         |
-| Openstack Swift        | MD5         | Yes     | No               | No              | R/W       |
-| QingStor               | -           | No      | No               | No              | R/W       |
-| SFTP                   | MD5, SHA1 * | Yes     | Depends          | No              | -         |
-| Yandex Disk            | MD5         | Yes     | No               | No              | R/W       |
-| The local filesystem   | All         | Yes     | Depends          | No              | -         |
+| Name                         | Hash        | ModTime | Case Insensitive | Duplicate Files | MIME Type |
+| ----------------------------:|:-----------:|:-------:|:----------------:|:---------------:|:---------:|
+| Amazon Drive                 | MD5         | No      | Yes              | No              | R         |
+| Amazon S3                    | MD5         | Yes     | No               | No              | R/W       |
+| Backblaze B2                 | SHA1        | Yes     | No               | No              | R/W       |
+| Box                          | SHA1        | Yes     | Yes              | No              | -         |
+| Dropbox                      | DBHASH †    | Yes     | Yes              | No              | -         |
+| FTP                          | -           | No      | No               | No              | -         |
+| Google Cloud Storage         | MD5         | Yes     | No               | No              | R/W       |
+| Google Drive                 | MD5         | Yes     | No               | Yes             | R/W       |
+| HTTP                         | -           | No      | No               | No              | R         |
+| Hubic                        | MD5         | Yes     | No               | No              | R/W       |
+| Microsoft Azure Blob Storage | MD5         | Yes     | No               | No              |
+| Microsoft OneDrive           | SHA1        | Yes     | Yes              | No              | R         |
+| Openstack Swift              | MD5         | Yes     | No               | No              | R/W       |
+| QingStor                     | -           | No      | No               | No              | R/W       |
+| SFTP                         | MD5, SHA1 * | Yes     | Depends          | No              | -         |
+| Yandex Disk                  | MD5         | Yes     | No               | No              | R/W       |
+| The local filesystem         | All         | Yes     | Depends          | No              | -         |
 
 ### Hash ###
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -16,7 +16,7 @@ show through.
 Here is an overview of the major features of each cloud storage system.
 
 | Name                         | Hash        | ModTime | Case Insensitive | Duplicate Files | MIME Type |
-| ----------------------------:|:-----------:|:-------:|:----------------:|:---------------:|:---------:|
+| ---------------------------- |:-----------:|:-------:|:----------------:|:---------------:|:---------:|
 | Amazon Drive                 | MD5         | No      | Yes              | No              | R         |
 | Amazon S3                    | MD5         | Yes     | No               | No              | R/W       |
 | Backblaze B2                 | SHA1        | Yes     | No               | No              | R/W       |
@@ -115,24 +115,25 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some
 operations more efficient.
 
-| Name                   | Purge | Copy | Move | DirMove | CleanUp | ListR |
-| ---------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|
-| Amazon Drive           | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| Amazon S3              | No    | Yes  | No   | No      | No      | Yes   |
-| Backblaze B2           | No    | No   | No   | No      | Yes     | Yes   |
-| Box                    | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| Dropbox                | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| FTP                    | No    | No   | Yes  | Yes     | No      | No    |
-| Google Cloud Storage   | Yes   | Yes  | No   | No      | No      | Yes   |
-| Google Drive           | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |  No    |
-| HTTP                   | No    | No   | No   | No      | No      | No    |
-| Hubic                  | Yes † | Yes  | No   | No      | No      | Yes   |
-| Microsoft OneDrive     | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
-| Openstack Swift        | Yes † | Yes  | No   | No      | No      | Yes   |
-| QingStor               | No    | Yes  | No   | No      | No      | Yes   |
-| SFTP                   | No    | No   | Yes  | Yes     | No      | No    |
-| Yandex Disk            | Yes   | No   | No   | No      | No  [#575](https://github.com/ncw/rclone/issues/575) | Yes   |
-| The local filesystem   | Yes   | No   | Yes  | Yes     | No      | No    |
+| Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR |
+| ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|
+| Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| Amazon S3                    | No    | Yes  | No   | No      | No      | Yes   |
+| Backblaze B2                 | No    | No   | No   | No      | Yes     | Yes   |
+| Box                          | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| Dropbox                      | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| FTP                          | No    | No   | Yes  | Yes     | No      | No    |
+| Google Cloud Storage         | Yes   | Yes  | No   | No      | No      | Yes   |
+| Google Drive                 | Yes   | Yes  | Yes  | Yes     | No  [#575](https://github.com/ncw/rclone/issues/575) |  No    |
+| HTTP                         | No    | No   | No   | No      | No      | No    |
+| Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   |
+| Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   |
+| Microsoft OneDrive           | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197)    | No [#575](https://github.com/ncw/rclone/issues/575) | No    |
+| Openstack Swift              | Yes † | Yes  | No   | No      | No      | Yes   |
+| QingStor                     | No    | Yes  | No   | No      | No      | Yes   |
+| SFTP                         | No    | No   | Yes  | Yes     | No      | No    |
+| Yandex Disk                  | Yes   | No   | No   | No      | No  [#575](https://github.com/ncw/rclone/issues/575) | Yes   |
+| The local filesystem         | Yes   | No   | Yes  | Yes     | No      | No    |
 
 
 ### Purge ###

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -149,7 +149,8 @@ Modified times are used in syncing and are fully supported.
 
 ### Limitations ###
 
-SFTP supports checksums if the same login has shell access and md5sum or sha1sum are in the remote's PATH.
+SFTP supports checksums if the same login has shell access and `md5sum`
+or `sha1sum` as well as `awk` are in the remote's PATH.
 
 The only ssh agent supported under Windows is Putty's pagent.
 

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -150,7 +150,7 @@ Modified times are used in syncing and are fully supported.
 ### Limitations ###
 
 SFTP supports checksums if the same login has shell access and `md5sum`
-or `sha1sum` as well as `awk` are in the remote's PATH.
+or `sha1sum` as well as `echo` are in the remote's PATH.
 
 The only ssh agent supported under Windows is Putty's pagent.
 

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -149,7 +149,7 @@ Modified times are used in syncing and are fully supported.
 
 ### Limitations ###
 
-SFTP does not support any checksums.
+SFTP supports checksums if the same login has shell access and md5sum or sha1sum are in the remote's PATH.
 
 The only ssh agent supported under Windows is Putty's pagent.
 

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -461,8 +461,8 @@ func (f *Fs) Hashes() fs.HashSet {
 		return fs.HashSet(fs.HashNone)
 	}
 
-	sha1Works := StdoutToHashStr(sha1Output) == expectedSha1
-	md5Works := StdoutToHashStr(md5Output) == expectedMd5
+	sha1Works := parseHash(sha1Output) == expectedSha1
+	md5Works := parseHash(md5Output) == expectedMd5
 
 	var set fs.HashSet = fs.NewHashSet()
 	if !sha1Works && !md5Works {
@@ -520,14 +520,14 @@ func (o *Object) Hash(r fs.HashType) (string, error) {
 	}
 
 	_ = session.Close()
-	str := StdoutToHashStr(outputBytes)
+	str := parseHash(outputBytes)
 	return str, nil
 }
 
 // Converts a byte array from the SSH session returned by
 // an invocation of md5sum/sha1sum to a hash string
 // as expected by the rest of this application
-func StdoutToHashStr(bytes []byte) string {
+func parseHash(bytes []byte) string {
 	return strings.Split(string(bytes), "\n")[0]
 }
 

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -445,8 +445,8 @@ func (f *Fs) Hashes() fs.HashSet {
 	}
 	sha1Output, err := session.Output("echo 'abc' | sha1sum | awk '{ print $1 }'")
 	expectedSha1 := "03cfd743661f07975fa2f1220c5194cbaff48451"
+	_ = session.Close()
 	if err != nil {
-		_ = session.Close()
 		return fs.HashSet(fs.HashNone)
 	}
 

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -508,9 +508,9 @@ func (o *Object) Hash(r fs.HashType) (string, error) {
 	err = fs.ErrHashUnsupported
 	var outputBytes []byte
 	if r == fs.HashMD5 {
-		outputBytes, err = session.Output("md5sum " + o.path() + " | awk '{ print $1 }'")
+		outputBytes, err = session.Output("md5sum \"" + o.path() + "\" | awk '{ print $1 }'")
 	} else if r == fs.HashSHA1 {
-		outputBytes, err = session.Output("sha1sum " + o.path() + " | awk '{ print $1 }'")
+		outputBytes, err = session.Output("sha1sum \"" + o.path() + "\" | awk '{ print $1 }'")
 	}
 
 	if err != nil {

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -443,7 +443,7 @@ func (f *Fs) Hashes() fs.HashSet {
 	if err != nil {
 		return fs.HashSet(fs.HashNone)
 	}
-	sha1Output, err := session.Output("echo 'abc' | sha1sum | awk '{ print $1 }'")
+	sha1Output, err := session.Output("echo 'abc' | sha1sum")
 	expectedSha1 := "03cfd743661f07975fa2f1220c5194cbaff48451"
 	_ = session.Close()
 	if err != nil {
@@ -454,7 +454,7 @@ func (f *Fs) Hashes() fs.HashSet {
 	if err != nil {
 		return fs.HashSet(fs.HashNone)
 	}
-	md5Output, err := session.Output("echo 'abc' | md5sum | awk '{ print $1 }'")
+	md5Output, err := session.Output("echo 'abc' | md5sum")
 	expectedMd5 := "0bee89b07a248e27c83fc3d5951213c1"
 	if err != nil {
 		_ = session.Close()
@@ -508,9 +508,9 @@ func (o *Object) Hash(r fs.HashType) (string, error) {
 	err = fs.ErrHashUnsupported
 	var outputBytes []byte
 	if r == fs.HashMD5 {
-		outputBytes, err = session.Output("md5sum \"" + o.path() + "\" | awk '{ print $1 }'")
+		outputBytes, err = session.Output("md5sum \"" + o.path() + "\"")
 	} else if r == fs.HashSHA1 {
-		outputBytes, err = session.Output("sha1sum \"" + o.path() + "\" | awk '{ print $1 }'")
+		outputBytes, err = session.Output("sha1sum \"" + o.path() + "\"")
 	}
 
 	if err != nil {
@@ -528,7 +528,7 @@ func (o *Object) Hash(r fs.HashType) (string, error) {
 // an invocation of md5sum/sha1sum to a hash string
 // as expected by the rest of this application
 func parseHash(bytes []byte) string {
-	return strings.Split(string(bytes), "\n")[0]
+	return strings.Split(string(bytes), " ")[0] // Split at hash / filename separator
 }
 
 // Size returns the size in bytes of the remote sftp file

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -443,23 +443,17 @@ func (f *Fs) Hashes() fs.HashSet {
 	if err != nil {
 		return fs.HashSet(fs.HashNone)
 	}
-	sha1Output, err := session.Output("echo 'abc' | sha1sum")
+	sha1Output, _ := session.Output("echo 'abc' | sha1sum")
 	expectedSha1 := "03cfd743661f07975fa2f1220c5194cbaff48451"
 	_ = session.Close()
-	if err != nil {
-		return fs.HashSet(fs.HashNone)
-	}
 
 	session, err = f.sshClient.NewSession()
 	if err != nil {
 		return fs.HashSet(fs.HashNone)
 	}
-	md5Output, err := session.Output("echo 'abc' | md5sum")
+	md5Output, _ := session.Output("echo 'abc' | md5sum")
 	expectedMd5 := "0bee89b07a248e27c83fc3d5951213c1"
-	if err != nil {
-		_ = session.Close()
-		return fs.HashSet(fs.HashNone)
-	}
+	_ = session.Close()
 
 	sha1Works := parseHash(sha1Output) == expectedSha1
 	md5Works := parseHash(md5Output) == expectedMd5

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -504,9 +504,9 @@ func (o *Object) Hash(r fs.HashType) (string, error) {
 	var outputBytes []byte
 	escapedPath := shellEscape(o.path())
 	if r == fs.HashMD5 {
-		outputBytes, err = session.Output("md5sum \"" + escapedPath + "\"")
+		outputBytes, err = session.Output("md5sum " + escapedPath)
 	} else if r == fs.HashSHA1 {
-		outputBytes, err = session.Output("sha1sum \"" + escapedPath + "\"")
+		outputBytes, err = session.Output("sha1sum " + escapedPath)
 	}
 
 	if err != nil {

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -464,15 +464,15 @@ func (f *Fs) Hashes() fs.HashSet {
 	sha1Works := StdoutToHashStr(sha1Output) == expectedSha1
 	md5Works := StdoutToHashStr(md5Output) == expectedMd5
 
-	var set fs.HashSet
-	if sha1Works && md5Works {
-		set = fs.NewHashSet(fs.HashSHA1, fs.HashMD5)
-	} else if sha1Works {
-		set = fs.HashSet(fs.HashSHA1)
-	} else if md5Works {
-		set = fs.HashSet(fs.HashMD5)
-	} else {
-		set = fs.HashSet(fs.HashNone)
+	var set fs.HashSet = fs.NewHashSet()
+	if !sha1Works && !md5Works {
+		set.Add(fs.HashNone)
+	}
+	if sha1Works {
+		set.Add(fs.HashSHA1)
+	}
+	if md5Works {
+		set.Add(fs.HashMD5)
 	}
 
 	_ = session.Close()

--- a/sftp/sftp_internal_test.go
+++ b/sftp/sftp_internal_test.go
@@ -1,0 +1,34 @@
+package sftp
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"fmt"
+)
+
+func TestShellEscape(t *testing.T) {
+	for i, test := range []struct {
+		unescaped, escaped string
+	}{
+		{"", ""},
+		{"/this/is/harmless", "/this/is/harmless"},
+		{"$(rm -rf /)", "\\$\\(rm\\ -rf\\ /\\)"},
+		{"/test/\n", "/test/'\n'"},
+		{":\"'", ":\\\"\\'"},
+	} {
+		got := shellEscape(test.unescaped)
+		assert.Equal(t, test.escaped, got, fmt.Sprintf("Test %d unescaped = %q", i, test.unescaped))
+	}
+}
+
+func TestParseHash(t *testing.T) {
+	for i, test := range []struct {
+		sshOutput, checksum string
+	}{
+		{"8dbc7733dbd10d2efc5c0a0d8dad90f958581821  RELEASE.md\n", "8dbc7733dbd10d2efc5c0a0d8dad90f958581821"},
+		{"03cfd743661f07975fa2f1220c5194cbaff48451  -\n", "03cfd743661f07975fa2f1220c5194cbaff48451"},
+	} {
+		got := parseHash([]byte(test.sshOutput))
+		assert.Equal(t, test.checksum, got, fmt.Sprintf("Test %d sshOutput = %q", i, test.sshOutput))
+	}
+}


### PR DESCRIPTION
This change adds support for checksums/hashes when using SFTP remotes. While SFTP doesn't directly support hashing, appropriate programs can be called using SSH, at least if shell access is available.
Since the function that determines which hash functions are available on the remote system is called frequently, it caches its result.

It's my first time writing Go code, so if there's anything I can or will need to improve, I'd be glad to be told. Thanks!