### PR TITLE
Backend cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _junk/
 rclone
 build
 docs/public
+rclone.iml
+.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,6 +56,12 @@
   version = "v1.0.3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/coreos/bbolt"
+  packages = ["."]
+  revision = "a148de800f91fe6cbd8b2a472bbfdc09c4b6568f"
+
+[[projects]]
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
   revision = "1d903dcb749992f3741d744c0f8376b4bd7eb3e1"
@@ -149,6 +155,12 @@
   packages = ["check","convert","json","yaml"]
   revision = "454950d6a0782c34427d4f29b46c6bf447256f20"
   version = "v0.0.8"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/patrickmn/go-cache"
+  packages = ["."]
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -136,3 +136,11 @@
 [[constraint]]
   branch = "master"
   name = "github.com/yunify/qingstor-sdk-go"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/coreos/bbolt"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/patrickmn/go-cache"

--- a/bin/make_manual.py
+++ b/bin/make_manual.py
@@ -25,6 +25,7 @@ docs = [
     "s3.md",
     "b2.md",
     "box.md",
+    "cache.md",
     "crypt.md",
     "dropbox.md",
     "ftp.md",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,949 @@
+// +build !plan9
+
+package cache
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"os"
+
+	"github.com/ncw/rclone/fs"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"golang.org/x/time/rate"
+)
+
+const (
+	// DefCacheChunkSize is the default value for chunk size
+	DefCacheChunkSize = "5M"
+	// DefCacheInfoAge is the default value for object info age
+	DefCacheInfoAge = "6h"
+	// DefCacheChunkAge is the default value for chunk age duration
+	DefCacheChunkAge = "3h"
+	// DefCacheMetaAge is the default value for chunk age duration
+	DefCacheMetaAge = "3h"
+	// DefCacheReadRetries is the default value for read retries
+	DefCacheReadRetries = 3
+	// DefCacheTotalWorkers is how many workers run in parallel to download chunks
+	DefCacheTotalWorkers = 4
+	// DefCacheChunkNoMemory will enable or disable in-memory storage for chunks
+	DefCacheChunkNoMemory = false
+	// DefCacheRps limits the number of requests per second to the source FS
+	DefCacheRps = -1
+	// DefWarmUpRatePerSeconds will apply a special config for warming up the cache
+	DefWarmUpRatePerSeconds = "3/20"
+	// DefCacheWrites will cache file data on writes through the cache
+	DefCacheWrites = false
+)
+
+// Globals
+var (
+	// Flags
+	cacheDbPath        = fs.StringP("cache-db-path", "", path.Join(path.Dir(fs.ConfigPath), "cache"), "Directory to cache DB")
+	cacheDbPurge       = fs.BoolP("cache-db-purge", "", false, "Purge the cache DB before")
+	cacheChunkSize     = fs.StringP("cache-chunk-size", "", DefCacheChunkSize, "The size of a chunk")
+	cacheInfoAge       = fs.StringP("cache-info-age", "", DefCacheInfoAge, "How much time should object info be stored in cache")
+	cacheChunkAge      = fs.StringP("cache-chunk-age", "", DefCacheChunkAge, "How much time should a chunk be in cache before cleanup")
+	cacheMetaAge       = fs.StringP("cache-warm-up-age", "", DefCacheMetaAge, "How much time should data be cached during warm up")
+	cacheReadRetries   = fs.IntP("cache-read-retries", "", DefCacheReadRetries, "How many times to retry a read from a cache storage")
+	cacheTotalWorkers  = fs.IntP("cache-workers", "", DefCacheTotalWorkers, "How many workers should run in parallel to download chunks")
+	cacheChunkNoMemory = fs.BoolP("cache-chunk-no-memory", "", DefCacheChunkNoMemory, "Disable the in-memory cache for storing chunks during streaming")
+	cacheRps           = fs.IntP("cache-rps", "", int(DefCacheRps), "Limits the number of requests per second to the source FS. -1 disables the rate limiter")
+	cacheWarmUp        = fs.StringP("cache-warm-up-rps", "", DefWarmUpRatePerSeconds, "Format is X/Y = how many X opens per Y seconds should trigger the warm up mode. See the docs")
+	cacheStoreWrites   = fs.BoolP("cache-writes", "", DefCacheWrites, "Will cache file data on writes through the FS")
+)
+
+// Register with Fs
+func init() {
+	fs.Register(&fs.RegInfo{
+		Name:        "cache",
+		Description: "Cache a remote",
+		NewFs:       NewFs,
+		Options: []fs.Option{{
+			Name: "remote",
+			Help: "Remote to cache.\nNormally should contain a ':' and a path, eg \"myremote:path/to/dir\",\n\"myremote:bucket\" or maybe \"myremote:\" (not recommended).",
+		}, {
+			Name: "chunk_size",
+			Help: "The size of a chunk. Lower value good for slow connections but can affect seamless reading. \nDefault: " + DefCacheChunkSize,
+			Examples: []fs.OptionExample{
+				{
+					Value: "1m",
+					Help:  "1MB",
+				}, {
+					Value: "5M",
+					Help:  "5 MB",
+				}, {
+					Value: "10M",
+					Help:  "10 MB",
+				},
+			},
+			Optional: true,
+		}, {
+			Name: "info_age",
+			Help: "How much time should object info (file size, file hashes etc) be stored in cache. Use a very high value if you don't plan on changing the source FS from outside the cache. \nAccepted units are: \"s\", \"m\", \"h\".\nDefault: " + DefCacheInfoAge,
+			Examples: []fs.OptionExample{
+				{
+					Value: "1h",
+					Help:  "1 hour",
+				}, {
+					Value: "24h",
+					Help:  "24 hours",
+				}, {
+					Value: "48h",
+					Help:  "24 hours",
+				},
+			},
+			Optional: true,
+		}, {
+			Name: "chunk_age",
+			Help: "How much time should a chunk (file data) be stored in cache. \nAccepted units are: \"s\", \"m\", \"h\".\nDefault: " + DefCacheChunkAge,
+			Examples: []fs.OptionExample{
+				{
+					Value: "30s",
+					Help:  "30 seconds",
+				}, {
+					Value: "1m",
+					Help:  "1 minute",
+				}, {
+					Value: "1h30m",
+					Help:  "1 hour and 30 minutes",
+				},
+			},
+			Optional: true,
+		}, {
+			Name: "warmup_age",
+			Help: "How much time should data be cached during warm up. \nAccepted units are: \"s\", \"m\", \"h\".\nDefault: " + DefCacheMetaAge,
+			Examples: []fs.OptionExample{
+				{
+					Value: "3h",
+					Help:  "3 hours",
+				}, {
+					Value: "6h",
+					Help:  "6 hours",
+				}, {
+					Value: "24h",
+					Help:  "24 hours",
+				},
+			},
+			Optional: true,
+		}},
+	})
+}
+
+// ChunkStorage is a storage type that supports only chunk operations (i.e in RAM)
+type ChunkStorage interface {
+	// will check if the chunk is in storage. should be fast and not read the chunk itself if possible
+	HasChunk(cachedObject *Object, offset int64) bool
+
+	// returns the chunk in storage. return an error if it's not
+	GetChunk(cachedObject *Object, offset int64) ([]byte, error)
+
+	// add a new chunk
+	AddChunk(cachedObject *Object, data []byte, offset int64) error
+
+	// AddChunkAhead adds a new chunk before caching an Object for it
+	AddChunkAhead(fp string, data []byte, offset int64, t time.Duration) error
+
+	// if the storage can cleanup on a cron basis
+	// otherwise it can do a noop operation
+	CleanChunksByAge(chunkAge time.Duration)
+
+	// if the storage can cleanup chunks after we no longer need them
+	// otherwise it can do a noop operation
+	CleanChunksByNeed(offset int64)
+}
+
+// Storage is a storage type (Bolt) which needs to support both chunk and file based operations
+type Storage interface {
+	ChunkStorage
+
+	// will update/create a directory or an error if it's not found
+	AddDir(cachedDir *Directory) error
+
+	// will return a directory with all the entries in it or an error if it's not found
+	GetDirEntries(cachedDir *Directory) (fs.DirEntries, error)
+
+	// remove a directory and all the objects and chunks in it
+	RemoveDir(fp string) error
+
+	// remove a directory and all the objects and chunks in it
+	ExpireDir(fp string) error
+
+	// will return an object (file) or error if it doesn't find it
+	GetObject(cachedObject *Object) (err error)
+
+	// add a new object to its parent directory
+	// the directory structure (all the parents of this object) is created if its not found
+	AddObject(cachedObject *Object) error
+
+	// remove an object and all its chunks
+	RemoveObject(fp string) error
+
+	// Stats returns stats about the cache storage
+	Stats() (map[string]map[string]interface{}, error)
+
+	// if the storage can cleanup on a cron basis
+	// otherwise it can do a noop operation
+	CleanEntriesByAge(entryAge time.Duration)
+
+	// Purge will flush the entire cache
+	Purge()
+}
+
+// Fs represents a wrapped fs.Fs
+type Fs struct {
+	fs.Fs
+
+	name     string
+	root     string
+	features *fs.Features // optional features
+	cache    Storage
+
+	fileAge              time.Duration
+	chunkSize            int64
+	chunkAge             time.Duration
+	metaAge              time.Duration
+	readRetries          int
+	totalWorkers         int
+	chunkMemory          bool
+	warmUp               bool
+	warmUpRate           int
+	warmUpSec            int
+	cacheWrites          bool
+	originalTotalWorkers int
+	originalChunkMemory  bool
+
+	lastChunkCleanup  time.Time
+	lastRootCleanup   time.Time
+	lastOpenedEntries map[string]time.Time
+	cleanupMu         sync.Mutex
+	warmupMu          sync.Mutex
+	rateLimiter       *rate.Limiter
+}
+
+// NewFs contstructs an Fs from the path, container:path
+func NewFs(name, rpath string) (fs.Fs, error) {
+	remote := fs.ConfigFileGet(name, "remote")
+	if strings.HasPrefix(remote, name+":") {
+		return nil, errors.New("can't point cache remote at itself - check the value of the remote setting")
+	}
+
+	// Look for a file first
+	remotePath := path.Join(remote, rpath)
+	wrappedFs, wrapErr := fs.NewFs(remotePath)
+
+	if wrapErr != fs.ErrorIsFile && wrapErr != nil {
+		return nil, errors.Wrapf(wrapErr, "failed to make remote %q to wrap", remotePath)
+	}
+	fs.Debugf(name, "wrapped %v:%v at root %v", wrappedFs.Name(), wrappedFs.Root(), rpath)
+
+	var chunkSize fs.SizeSuffix
+	chunkSizeString := fs.ConfigFileGet(name, "chunk_size", DefCacheChunkSize)
+	if *cacheChunkSize != DefCacheChunkSize {
+		chunkSizeString = *cacheChunkSize
+	}
+	err := chunkSize.Set(chunkSizeString)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to understand chunk size", chunkSizeString)
+	}
+	infoAge := fs.ConfigFileGet(name, "info_age", DefCacheInfoAge)
+	if *cacheInfoAge != DefCacheInfoAge {
+		infoAge = *cacheInfoAge
+	}
+	infoDuration, err := time.ParseDuration(infoAge)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to understand duration", infoAge)
+	}
+	chunkAge := fs.ConfigFileGet(name, "chunk_age", DefCacheChunkAge)
+	if *cacheChunkAge != DefCacheChunkAge {
+		chunkAge = *cacheChunkAge
+	}
+	chunkDuration, err := time.ParseDuration(chunkAge)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to understand duration", chunkAge)
+	}
+	metaAge := fs.ConfigFileGet(name, "warmup_age", DefCacheChunkAge)
+	if *cacheMetaAge != DefCacheMetaAge {
+		metaAge = *cacheMetaAge
+	}
+	metaDuration, err := time.ParseDuration(metaAge)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to understand duration", metaAge)
+	}
+	warmupRps := strings.Split(*cacheWarmUp, "/")
+	warmupRate, err := strconv.Atoi(warmupRps[0])
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to understand warm up rate", *cacheWarmUp)
+	}
+	warmupSec, err := strconv.Atoi(warmupRps[1])
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to understand warm up seconds", *cacheWarmUp)
+	}
+	// configure cache backend
+	if *cacheDbPurge {
+		fs.Debugf(name, "Purging the DB")
+	}
+	f := &Fs{
+		Fs:                   wrappedFs,
+		name:                 name,
+		root:                 rpath,
+		fileAge:              infoDuration,
+		chunkSize:            int64(chunkSize),
+		chunkAge:             chunkDuration,
+		metaAge:              metaDuration,
+		readRetries:          *cacheReadRetries,
+		totalWorkers:         *cacheTotalWorkers,
+		originalTotalWorkers: *cacheTotalWorkers,
+		chunkMemory:          !*cacheChunkNoMemory,
+		originalChunkMemory:  !*cacheChunkNoMemory,
+		warmUp:               false,
+		warmUpRate:           warmupRate,
+		warmUpSec:            warmupSec,
+		cacheWrites:          *cacheStoreWrites,
+		lastChunkCleanup:     time.Now().Truncate(time.Hour * 24 * 30),
+		lastRootCleanup:      time.Now().Truncate(time.Hour * 24 * 30),
+		lastOpenedEntries:    make(map[string]time.Time),
+	}
+	f.rateLimiter = rate.NewLimiter(rate.Limit(float64(*cacheRps)), f.totalWorkers)
+
+	dbPath := *cacheDbPath
+	if path.Ext(dbPath) != "" {
+		dbPath = path.Dir(dbPath)
+	}
+	err = os.MkdirAll(dbPath, os.ModePerm)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create cache directory %v", dbPath)
+	}
+
+	dbPath = path.Join(dbPath, name+".db")
+	fs.Infof(name, "Storage DB path: %v", dbPath)
+	f.cache = GetPersistent(dbPath, *cacheDbPurge)
+	if err != nil {
+		return nil, err
+	}
+
+	fs.Infof(name, "Chunk Memory: %v", f.chunkMemory)
+	fs.Infof(name, "Chunk Size: %v", fs.SizeSuffix(f.chunkSize))
+	fs.Infof(name, "Workers: %v", f.totalWorkers)
+	fs.Infof(name, "File Age: %v", f.fileAge.String())
+	fs.Infof(name, "Chunk Age: %v", f.chunkAge.String())
+	fs.Infof(name, "Cache Writes: %v", f.cacheWrites)
+
+	go f.CleanUpCache(false)
+
+	// TODO: Explore something here but now it's not something we want
+	// when writing from cache, source FS will send a notification and clear it out immediately
+	//setup dir notification
+	//doDirChangeNotify := wrappedFs.Features().DirChangeNotify
+	//if doDirChangeNotify != nil {
+	//	doDirChangeNotify(func(dir string) {
+	//		d := NewAbsDirectory(f, dir)
+	//		d.Flush()
+	//		fs.Infof(dir, "updated from notification")
+	//	}, time.Second * 10)
+	//}
+
+	f.features = (&fs.Features{
+		CanHaveEmptyDirectories: true,
+		DuplicateFiles:          false, // storage doesn't permit this
+		Purge:                   f.Purge,
+		Copy:                    f.Copy,
+		Move:                    f.Move,
+		DirMove:                 f.DirMove,
+		DirChangeNotify:         nil,
+		DirCacheFlush:           f.DirCacheFlush,
+		PutUnchecked:            f.PutUnchecked,
+		CleanUp:                 f.CleanUp,
+		UnWrap:                  f.UnWrap,
+	}).Fill(f).Mask(wrappedFs)
+
+	return f, wrapErr
+}
+
+// Name of the remote (as passed into NewFs)
+func (f *Fs) Name() string {
+	return f.name
+}
+
+// Root of the remote (as passed into NewFs)
+func (f *Fs) Root() string {
+	return f.root
+}
+
+// Features returns the optional features of this Fs
+func (f *Fs) Features() *fs.Features {
+	return f.features
+}
+
+// String returns a description of the FS
+func (f *Fs) String() string {
+	return fmt.Sprintf("%s:%s", f.name, f.root)
+}
+
+// ChunkSize returns the configured chunk size
+func (f *Fs) ChunkSize() int64 {
+	return f.chunkSize
+}
+
+// originalSettingWorkers will return the original value of this config
+func (f *Fs) originalSettingWorkers() int {
+	return f.originalTotalWorkers
+}
+
+// originalSettingChunkNoMemory will return the original value of this config
+func (f *Fs) originalSettingChunkNoMemory() bool {
+	return f.originalChunkMemory
+}
+
+// InWarmUp says if cache warm up is active
+func (f *Fs) InWarmUp() bool {
+	return f.warmUp
+}
+
+// enableWarmUp will enable the warm up state of this cache along with the relevant settings
+func (f *Fs) enableWarmUp() {
+	f.totalWorkers = 1
+	f.chunkMemory = false
+	f.warmUp = true
+}
+
+// disableWarmUp will disable the warm up state of this cache along with the relevant settings
+func (f *Fs) disableWarmUp() {
+	f.totalWorkers = f.originalSettingWorkers()
+	f.chunkMemory = !f.originalSettingChunkNoMemory()
+	f.warmUp = false
+}
+
+// NewObject finds the Object at remote.
+func (f *Fs) NewObject(remote string) (fs.Object, error) {
+	co := NewObject(f, remote)
+	err := f.cache.GetObject(co)
+	if err == nil {
+		return co, nil
+	}
+	obj, err := f.Fs.NewObject(remote)
+	if err != nil {
+		return nil, err
+	}
+	co = ObjectFromOriginal(f, obj)
+	co.persist()
+	return co, nil
+}
+
+// List the objects and directories in dir into entries
+func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+	// clean cache
+	go f.CleanUpCache(false)
+
+	cd := NewDirectory(f, dir)
+	entries, err = f.cache.GetDirEntries(cd)
+	if err != nil {
+		fs.Debugf(dir, "no dir entries in cache: %v", err)
+	} else if len(entries) == 0 {
+		// TODO: read empty dirs from source?
+	} else {
+		return entries, nil
+	}
+
+	entries, err = f.Fs.List(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var cachedEntries fs.DirEntries
+	for _, entry := range entries {
+		switch o := entry.(type) {
+		case fs.Object:
+			co := ObjectFromOriginal(f, o)
+			co.persist()
+			cachedEntries = append(cachedEntries, co)
+		case fs.Directory:
+			cd := DirectoryFromOriginal(f, o)
+			err = f.cache.AddDir(cd)
+			cachedEntries = append(cachedEntries, cd)
+		default:
+			err = errors.Errorf("Unknown object type %T", entry)
+		}
+	}
+	if err != nil {
+		fs.Errorf(dir, "err caching listing: %v", err)
+	}
+
+	return cachedEntries, nil
+}
+
+func (f *Fs) recurse(dir string, list *fs.ListRHelper) error {
+	entries, err := f.List(dir)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(entries); i++ {
+		innerDir, ok := entries[i].(fs.Directory)
+		if ok {
+			err := f.recurse(innerDir.Remote(), list)
+			if err != nil {
+				return err
+			}
+		}
+
+		err := list.Add(entries[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ListR lists the objects and directories of the Fs starting
+// from dir recursively into out.
+func (f *Fs) ListR(dir string, callback fs.ListRCallback) (err error) {
+	fs.Debugf(f, "list recursively from '%s'", dir)
+
+	// we check if the source FS supports ListR
+	// if it does, we'll use that to get all the entries, cache them and return
+	do := f.Fs.Features().ListR
+	if do != nil {
+		return do(dir, func(entries fs.DirEntries) error {
+			// we got called back with a set of entries so let's cache them and call the original callback
+			for _, entry := range entries {
+				switch o := entry.(type) {
+				case fs.Object:
+					_ = f.cache.AddObject(ObjectFromOriginal(f, o))
+				case fs.Directory:
+					_ = f.cache.AddDir(DirectoryFromOriginal(f, o))
+				default:
+					return errors.Errorf("Unknown object type %T", entry)
+				}
+			}
+
+			// call the original callback
+			return callback(entries)
+		})
+	}
+
+	// if we're here, we're gonna do a standard recursive traversal and cache everything
+	list := fs.NewListRHelper(callback)
+	err = f.recurse(dir, list)
+	if err != nil {
+		return err
+	}
+
+	return list.Flush()
+}
+
+// Mkdir makes the directory (container, bucket)
+func (f *Fs) Mkdir(dir string) error {
+	err := f.Fs.Mkdir(dir)
+	if err != nil {
+		return err
+	}
+	if dir == "" && f.Root() == "" { // creating the root is possible but we don't need that cached as we have it already
+		fs.Debugf(dir, "skipping empty dir in cache")
+		return nil
+	}
+	fs.Infof(f, "create dir '%s'", dir)
+
+	// make an empty dir
+	_ = f.cache.AddDir(NewDirectory(f, dir))
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return nil
+}
+
+// Rmdir removes the directory (container, bucket) if empty
+func (f *Fs) Rmdir(dir string) error {
+	err := f.Fs.Rmdir(dir)
+	if err != nil {
+		return err
+	}
+
+	_ = f.cache.RemoveDir(NewDirectory(f, dir).abs())
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return nil
+}
+
+// DirMove moves src, srcRemote to this remote at dstRemote
+// using server side move operations.
+func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+	do := f.Fs.Features().DirMove
+	if do == nil {
+		return fs.ErrorCantDirMove
+	}
+	srcFs, ok := src.(*Fs)
+	if !ok {
+		fs.Errorf(srcFs, "can't move directory - not same remote type")
+		return fs.ErrorCantDirMove
+	}
+	if srcFs.Fs.Name() != f.Fs.Name() {
+		fs.Errorf(srcFs, "can't move directory - not wrapping same remotes")
+		return fs.ErrorCantDirMove
+	}
+	fs.Infof(f, "move dir '%s'/'%s' -> '%s'", srcRemote, srcFs.Root(), dstRemote)
+
+	err := do(src.Features().UnWrap(), srcRemote, dstRemote)
+	if err != nil {
+		return err
+	}
+
+	srcDir := NewDirectory(srcFs, srcRemote)
+	// clear any likely dir cached
+	_ = f.cache.ExpireDir(srcDir.parentRemote())
+	_ = f.cache.ExpireDir(NewDirectory(srcFs, dstRemote).parentRemote())
+	// delete src dir
+	_ = f.cache.RemoveDir(srcDir.abs())
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return nil
+}
+
+// cacheReader will split the stream of a reader to be cached at the same time it is read by the original source
+func (f *Fs) cacheReader(u io.Reader, src fs.ObjectInfo, originalRead func(inn io.Reader)) {
+	// create the pipe and tee reader
+	pr, pw := io.Pipe()
+	tr := io.TeeReader(u, pw)
+
+	// create channel to synchronize
+	done := make(chan bool)
+	defer close(done)
+
+	go func() {
+		// notify the cache reader that we're complete after the source FS finishes
+		defer func() {
+			_ = pw.Close()
+		}()
+		// process original reading
+		originalRead(tr)
+		// signal complete
+		done <- true
+	}()
+
+	go func() {
+		var offset int64
+		for {
+			chunk := make([]byte, f.chunkSize)
+			readSize, err := io.ReadFull(pr, chunk)
+			// we ignore 3 failures which are ok:
+			// 1. EOF - original reading finished and we got a full buffer too
+			// 2. ErrUnexpectedEOF - original reading finished and partial buffer
+			// 3. ErrClosedPipe - source remote reader was closed (usually means it reached the end) and we need to stop too
+			// if we have a different error: we're going to error out the original reading too and stop this
+			if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF && err != io.ErrClosedPipe {
+				fs.Errorf(src, "error saving new data in cache. offset: %v, err: %v", offset, err)
+				_ = pr.CloseWithError(err)
+				break
+			}
+			// if we have some bytes we cache them
+			if readSize > 0 {
+				chunk = chunk[:readSize]
+				err2 := f.cache.AddChunkAhead(cleanPath(path.Join(f.root, src.Remote())), chunk, offset, f.metaAge)
+				if err2 != nil {
+					fs.Errorf(src, "error saving new data in cache '%v'", err2)
+					_ = pr.CloseWithError(err2)
+					break
+				}
+				offset += int64(readSize)
+			}
+			// stuff should be closed but let's be sure
+			if err == io.EOF || err == io.ErrUnexpectedEOF || err == io.ErrClosedPipe {
+				_ = pr.Close()
+				break
+			}
+		}
+
+		// signal complete
+		done <- true
+	}()
+
+	// wait until both are done
+	for c := 0; c < 2; c++ {
+		<-done
+	}
+}
+
+// Put in to the remote path with the modTime given of the given size
+func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	fs.Debugf(f, "put data at '%s'", src.Remote())
+
+	var err error
+	var obj fs.Object
+	if f.cacheWrites {
+		f.cacheReader(in, src, func(inn io.Reader) {
+			obj, err = f.Fs.Put(inn, src, options...)
+		})
+	} else {
+		obj, err = f.Fs.Put(in, src, options...)
+	}
+
+	if err != nil {
+		fs.Errorf(src, "error saving in cache: %v", err)
+		return nil, err
+	}
+	cachedObj := ObjectFromOriginal(f, obj).persist()
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return cachedObj, nil
+}
+
+// PutUnchecked uploads the object
+func (f *Fs) PutUnchecked(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	do := f.Fs.Features().PutUnchecked
+	if do == nil {
+		return nil, errors.New("can't PutUnchecked")
+	}
+	fs.Infof(f, "put data unchecked in '%s'", src.Remote())
+
+	var err error
+	var obj fs.Object
+	if f.cacheWrites {
+		f.cacheReader(in, src, func(inn io.Reader) {
+			obj, err = f.Fs.Put(inn, src, options...)
+		})
+	} else {
+		obj, err = f.Fs.Put(in, src, options...)
+	}
+
+	if err != nil {
+		fs.Errorf(src, "error saving in cache: %v", err)
+		return nil, err
+	}
+	cachedObj := ObjectFromOriginal(f, obj).persist()
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return cachedObj, nil
+}
+
+// Copy src to this remote using server side copy operations.
+func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+	do := f.Fs.Features().Copy
+	if do == nil {
+		return nil, fs.ErrorCantCopy
+	}
+
+	srcObj, ok := src.(*Object)
+	if !ok {
+		fs.Errorf(srcObj, "can't copy - not same remote type")
+		return nil, fs.ErrorCantCopy
+	}
+	if srcObj.CacheFs.Fs.Name() != f.Fs.Name() {
+		fs.Errorf(srcObj, "can't copy - not wrapping same remote types")
+		return nil, fs.ErrorCantCopy
+	}
+
+	fs.Infof(f, "copy obj '%s' -> '%s'", srcObj.abs(), remote)
+
+	// store in cache
+	if err := srcObj.refreshFromSource(); err != nil {
+		fs.Errorf(f, "can't move %v - %v", src, err)
+		return nil, fs.ErrorCantCopy
+	}
+	obj, err := do(srcObj.Object, remote)
+	if err != nil {
+		fs.Errorf(srcObj, "error moving in cache: %v", err)
+		return nil, err
+	}
+
+	// persist new
+	cachedObj := ObjectFromOriginal(f, obj).persist()
+	_ = f.cache.ExpireDir(cachedObj.parentRemote())
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return cachedObj, nil
+}
+
+// Move src to this remote using server side move operations.
+func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+	do := f.Fs.Features().Move
+	if do == nil {
+		return nil, fs.ErrorCantMove
+	}
+
+	srcObj, ok := src.(*Object)
+	if !ok {
+		fs.Errorf(srcObj, "can't move - not same remote type")
+		return nil, fs.ErrorCantMove
+	}
+
+	if srcObj.CacheFs.Fs.Name() != f.Fs.Name() {
+		fs.Errorf(srcObj, "can't move - not wrapping same remote types")
+		return nil, fs.ErrorCantMove
+	}
+
+	fs.Infof(f, "moving obj '%s' -> %s", srcObj.abs(), remote)
+
+	// save in cache
+	if err := srcObj.refreshFromSource(); err != nil {
+		fs.Errorf(f, "can't move %v - %v", src, err)
+		return nil, fs.ErrorCantMove
+	}
+	obj, err := do(srcObj.Object, remote)
+	if err != nil {
+		fs.Errorf(srcObj, "error moving in cache: %v", err)
+		return nil, err
+	}
+
+	// remove old
+	_ = f.cache.ExpireDir(srcObj.parentRemote())
+	_ = f.cache.RemoveObject(srcObj.abs())
+
+	// persist new
+	cachedObj := ObjectFromOriginal(f, obj)
+	cachedObj.persist()
+	_ = f.cache.ExpireDir(cachedObj.parentRemote())
+
+	// clean cache
+	go f.CleanUpCache(false)
+	return cachedObj, nil
+}
+
+// Hashes returns the supported hash sets.
+func (f *Fs) Hashes() fs.HashSet {
+	return f.Fs.Hashes()
+}
+
+// Purge all files in the root and the root directory
+func (f *Fs) Purge() error {
+	fs.Infof(f, "purging cache")
+	f.cache.Purge()
+
+	f.warmupMu.Lock()
+	defer f.warmupMu.Unlock()
+	f.lastOpenedEntries = make(map[string]time.Time)
+
+	do := f.Fs.Features().Purge
+	if do == nil {
+		return nil
+	}
+
+	err := do()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CleanUp the trash in the Fs
+func (f *Fs) CleanUp() error {
+	f.CleanUpCache(false)
+
+	do := f.Fs.Features().CleanUp
+	if do == nil {
+		return nil
+	}
+
+	return do()
+}
+
+// Stats returns stats about the cache storage
+func (f *Fs) Stats() (map[string]map[string]interface{}, error) {
+	return f.cache.Stats()
+}
+
+// OpenRateLimited will execute a closure under a rate limiter watch
+func (f *Fs) OpenRateLimited(fn func() (io.ReadCloser, error)) (io.ReadCloser, error) {
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	start := time.Now()
+
+	if err = f.rateLimiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	elapsed := time.Since(start)
+	if elapsed > time.Second*2 {
+		fs.Debugf(f, "rate limited: %s", elapsed)
+	}
+	return fn()
+}
+
+// CheckIfWarmupNeeded changes the FS settings during warmups
+func (f *Fs) CheckIfWarmupNeeded(remote string) {
+	f.warmupMu.Lock()
+	defer f.warmupMu.Unlock()
+
+	secondCount := time.Duration(f.warmUpSec)
+	rate := f.warmUpRate
+
+	// clean up entries older than the needed time frame needed
+	for k, v := range f.lastOpenedEntries {
+		if time.Now().After(v.Add(time.Second * secondCount)) {
+			delete(f.lastOpenedEntries, k)
+		}
+	}
+	f.lastOpenedEntries[remote] = time.Now()
+
+	// simple check for the current load
+	if len(f.lastOpenedEntries) >= rate && !f.warmUp {
+		fs.Infof(f, "turning on cache warmup")
+		f.enableWarmUp()
+	} else if len(f.lastOpenedEntries) < rate && f.warmUp {
+		fs.Infof(f, "turning off cache warmup")
+		f.disableWarmUp()
+	}
+}
+
+// CleanUpCache will cleanup only the cache data that is expired
+func (f *Fs) CleanUpCache(ignoreLastTs bool) {
+	f.cleanupMu.Lock()
+	defer f.cleanupMu.Unlock()
+
+	if ignoreLastTs || time.Now().After(f.lastChunkCleanup.Add(f.chunkAge/4)) {
+		fs.Infof("cache", "running chunks cleanup")
+		f.cache.CleanChunksByAge(f.chunkAge)
+		f.lastChunkCleanup = time.Now()
+	}
+
+	if ignoreLastTs || time.Now().After(f.lastRootCleanup.Add(f.fileAge/4)) {
+		fs.Infof("cache", "running root cleanup")
+		f.cache.CleanEntriesByAge(f.fileAge)
+		f.lastRootCleanup = time.Now()
+	}
+}
+
+// UnWrap returns the Fs that this Fs is wrapping
+func (f *Fs) UnWrap() fs.Fs {
+	return f.Fs
+}
+
+// DirCacheFlush flushes the dir cache
+func (f *Fs) DirCacheFlush() {
+	_ = f.cache.RemoveDir("")
+}
+
+func cleanPath(p string) string {
+	p = path.Clean(p)
+	if p == "." || p == "/" {
+		p = ""
+	}
+
+	return p
+}
+
+// Check the interfaces are satisfied
+var (
+	_ fs.Fs             = (*Fs)(nil)
+	_ fs.Purger         = (*Fs)(nil)
+	_ fs.Copier         = (*Fs)(nil)
+	_ fs.Mover          = (*Fs)(nil)
+	_ fs.DirMover       = (*Fs)(nil)
+	_ fs.PutUncheckeder = (*Fs)(nil)
+	_ fs.CleanUpper     = (*Fs)(nil)
+	_ fs.UnWrapper      = (*Fs)(nil)
+	_ fs.ListRer        = (*Fs)(nil)
+)

--- a/cache/cache_internal_test.go
+++ b/cache/cache_internal_test.go
@@ -1,0 +1,653 @@
+// +build !plan9
+
+package cache_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"path"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ncw/rclone/cache"
+	"github.com/ncw/rclone/fs"
+	"github.com/ncw/rclone/fstest"
+	"github.com/ncw/rclone/local"
+	flag "github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	WrapRemote   = flag.String("wrap-remote", "", "Remote to wrap")
+	RemoteName   = flag.String("remote-name", "TestCacheInternal", "Root remote")
+	SkipTimeouts = flag.Bool("skip-waits", false, "To skip tests that have wait times")
+	rootFs       fs.Fs
+	boltDb       *cache.Persistent
+	metaAge      = time.Second * 30
+	infoAge      = time.Second * 10
+	chunkAge     = time.Second * 10
+	okDiff       = time.Second * 9 // really big diff here but the build machines seem to be slow. need a different way for this
+	workers      = 2
+	warmupRate   = 3
+	warmupSec    = 10
+)
+
+// prepare the test server and return a function to tidy it up afterwards
+func TestInternalInit(t *testing.T) {
+	var err error
+
+	// delete the default path
+	dbPath := path.Join(path.Dir(fs.ConfigPath), "cache", *RemoteName+".db")
+	boltDb = cache.GetPersistent(dbPath, true)
+	fstest.Initialise()
+
+	if len(*WrapRemote) == 0 {
+		*WrapRemote = "localInternal:/var/tmp/rclone-cache"
+		fs.ConfigFileSet("localInternal", "type", "local")
+		fs.ConfigFileSet("localInternal", "nounc", "true")
+	}
+
+	remoteExists := false
+	for _, s := range fs.ConfigFileSections() {
+		if s == *RemoteName {
+			remoteExists = true
+		}
+	}
+
+	if !remoteExists {
+		fs.ConfigFileSet(*RemoteName, "type", "cache")
+		fs.ConfigFileSet(*RemoteName, "remote", *WrapRemote)
+		fs.ConfigFileSet(*RemoteName, "chunk_size", "1024")
+		fs.ConfigFileSet(*RemoteName, "chunk_age", chunkAge.String())
+		fs.ConfigFileSet(*RemoteName, "info_age", infoAge.String())
+	}
+
+	_ = flag.Set("cache-warm-up-age", metaAge.String())
+	_ = flag.Set("cache-warm-up-rps", fmt.Sprintf("%v/%v", warmupRate, warmupSec))
+	_ = flag.Set("cache-chunk-no-memory", "true")
+	_ = flag.Set("cache-workers", strconv.Itoa(workers))
+
+	// Instantiate root
+	rootFs, err = fs.NewFs(*RemoteName + ":")
+	_ = rootFs.Features().Purge()
+	require.NoError(t, err)
+	err = rootFs.Mkdir("")
+	require.NoError(t, err)
+
+	// flush cache
+	_, err = getCacheFs(rootFs)
+	require.NoError(t, err)
+}
+
+func TestInternalListRootAndInnerRemotes(t *testing.T) {
+	// Instantiate inner fs
+	innerFolder := "inner"
+	err := rootFs.Mkdir(innerFolder)
+	require.NoError(t, err)
+	innerFs, err := fs.NewFs(*RemoteName + ":" + innerFolder)
+	require.NoError(t, err)
+
+	obj := writeObjectString(t, innerFs, "one", "content")
+
+	listRoot, err := rootFs.List("")
+	require.NoError(t, err)
+	listRootInner, err := rootFs.List(innerFolder)
+	require.NoError(t, err)
+	listInner, err := innerFs.List("")
+	require.NoError(t, err)
+
+	require.Lenf(t, listRoot, 1, "remote %v should have 1 entry", rootFs.Root())
+	require.Lenf(t, listRootInner, 1, "remote %v should have 1 entry in %v", rootFs.Root(), innerFolder)
+	require.Lenf(t, listInner, 1, "remote %v should have 1 entry", innerFs.Root())
+
+	err = obj.Remove()
+	require.NoError(t, err)
+
+	err = innerFs.Features().Purge()
+	require.NoError(t, err)
+	innerFs = nil
+}
+
+func TestInternalObjWrapFsFound(t *testing.T) {
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	wrappedFs := cfs.UnWrap()
+	data := "content"
+	writeObjectString(t, wrappedFs, "second", data)
+
+	listRoot, err := rootFs.List("")
+	require.NoError(t, err)
+	require.Lenf(t, listRoot, 1, "remote %v should have 1 entry", rootFs.Root())
+
+	co, err := rootFs.NewObject("second")
+	require.NoError(t, err)
+	r, err := co.Open()
+	require.NoError(t, err)
+	cachedData, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	err = r.Close()
+	require.NoError(t, err)
+
+	strCached := string(cachedData)
+	require.Equal(t, data, strCached)
+
+	err = co.Remove()
+	require.NoError(t, err)
+
+	listRoot, err = wrappedFs.List("")
+	require.NoError(t, err)
+	require.Lenf(t, listRoot, 0, "remote %v should have 0 entries: %v", wrappedFs.Root(), listRoot)
+}
+
+func TestInternalObjNotFound(t *testing.T) {
+	reset(t)
+	obj, err := rootFs.NewObject("404")
+	require.Error(t, err)
+	require.Nil(t, obj)
+}
+
+func TestInternalCachedWrittenContentMatches(t *testing.T) {
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	// create some rand test data
+	testData := make([]byte, (chunkSize*4 + chunkSize/2))
+	testSize, err := rand.Read(testData)
+	require.Equal(t, len(testData), testSize, "data size doesn't match")
+	require.NoError(t, err)
+
+	// write the object
+	o := writeObjectBytes(t, rootFs, "data.bin", testData)
+	require.Equal(t, o.Size(), int64(testSize))
+
+	// check sample of data from in-file
+	sampleStart := chunkSize / 2
+	sampleEnd := chunkSize
+	testSample := testData[sampleStart:sampleEnd]
+	checkSample := readDataFromObj(t, o, sampleStart, sampleEnd, false)
+	require.Equal(t, int64(len(checkSample)), sampleEnd-sampleStart)
+	require.Equal(t, checkSample, testSample)
+}
+
+func TestInternalCachedUpdatedContentMatches(t *testing.T) {
+	reset(t)
+
+	// create some rand test data
+	testData1 := []byte(fstest.RandomString(100))
+	testData2 := []byte(fstest.RandomString(200))
+
+	// write the object
+	o := updateObjectBytes(t, rootFs, "data.bin", testData1, testData2)
+	require.Equal(t, o.Size(), int64(len(testData2)))
+
+	// check data from in-file
+	reader, err := o.Open()
+	require.NoError(t, err)
+	checkSample, err := ioutil.ReadAll(reader)
+	_ = reader.Close()
+	require.NoError(t, err)
+	require.Equal(t, checkSample, testData2)
+}
+
+func TestInternalWrappedWrittenContentMatches(t *testing.T) {
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	reset(t)
+
+	// create some rand test data
+	testData := make([]byte, (chunkSize*4 + chunkSize/2))
+	testSize, err := rand.Read(testData)
+	require.Equal(t, len(testData), testSize)
+	require.NoError(t, err)
+
+	// write the object
+	o := writeObjectBytes(t, cfs.UnWrap(), "data.bin", testData)
+	require.Equal(t, o.Size(), int64(testSize))
+
+	o2, err := rootFs.NewObject("data.bin")
+	require.NoError(t, err)
+	require.Equal(t, o2.Size(), o.Size())
+
+	// check sample of data from in-file
+	sampleStart := chunkSize / 2
+	sampleEnd := chunkSize
+	testSample := testData[sampleStart:sampleEnd]
+	checkSample := readDataFromObj(t, o2, sampleStart, sampleEnd, false)
+	require.Equal(t, len(checkSample), len(testSample))
+
+	for i := 0; i < len(checkSample); i++ {
+		require.Equal(t, testSample[i], checkSample[i])
+	}
+}
+
+func TestInternalLargeWrittenContentMatches(t *testing.T) {
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	reset(t)
+
+	// create some rand test data
+	testData := make([]byte, (chunkSize*10 + chunkSize/2))
+	testSize, err := rand.Read(testData)
+	require.Equal(t, len(testData), testSize)
+	require.NoError(t, err)
+
+	// write the object
+	o := writeObjectBytes(t, cfs.UnWrap(), "data.bin", testData)
+	require.Equal(t, o.Size(), int64(testSize))
+
+	o2, err := rootFs.NewObject("data.bin")
+	require.NoError(t, err)
+	require.Equal(t, o2.Size(), o.Size())
+
+	// check data from in-file
+	checkSample := readDataFromObj(t, o2, int64(0), int64(testSize), false)
+	require.Equal(t, len(checkSample), len(testData))
+
+	for i := 0; i < len(checkSample); i++ {
+		require.Equal(t, testData[i], checkSample[i], "byte: %d (%d), chunk: %d", int64(i)%chunkSize, i, int64(i)/chunkSize)
+	}
+}
+
+func TestInternalWrappedFsChangeNotSeen(t *testing.T) {
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	// create some rand test data
+	co := writeObjectRandomBytes(t, rootFs, (chunkSize*4 + chunkSize/2))
+
+	// update in the wrapped fs
+	o, err := cfs.UnWrap().NewObject(co.Remote())
+	require.NoError(t, err)
+	err = o.SetModTime(co.ModTime().Truncate(time.Hour))
+	require.NoError(t, err)
+
+	// get a new instance from the cache
+	co2, err := rootFs.NewObject(o.Remote())
+	require.NoError(t, err)
+
+	require.NotEqual(t, o.ModTime(), co.ModTime())
+	require.NotEqual(t, o.ModTime(), co2.ModTime())
+	require.Equal(t, co.ModTime(), co2.ModTime())
+}
+
+func TestInternalChangeSeenAfterDirCacheFlush(t *testing.T) {
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+
+	cfs.DirCacheFlush() // flush the cache
+
+	l, err := cfs.UnWrap().List("")
+	require.NoError(t, err)
+	require.Len(t, l, 1)
+	o := l[0]
+
+	// get a new instance from the cache
+	co, err := rootFs.NewObject(o.Remote())
+	require.NoError(t, err)
+	require.Equal(t, o.ModTime(), co.ModTime())
+}
+
+func TestInternalWarmUp(t *testing.T) {
+	if *SkipTimeouts {
+		t.Skip("--skip-waits set")
+	}
+
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	o1 := writeObjectRandomBytes(t, rootFs, (chunkSize * 3))
+	o2 := writeObjectRandomBytes(t, rootFs, (chunkSize * 4))
+	o3 := writeObjectRandomBytes(t, rootFs, (chunkSize * 6))
+
+	_ = readDataFromObj(t, o1, 0, chunkSize, false)
+	_ = readDataFromObj(t, o2, 0, chunkSize, false)
+
+	// validate a fresh chunk
+	expectedExpiry := time.Now().Add(chunkAge)
+	ts, err := boltDb.GetChunkTs(path.Join(rootFs.Root(), o2.Remote()), 0)
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+
+	// validate that we entered a warm up state
+	_ = readDataFromObj(t, o3, 0, chunkSize, false)
+	require.True(t, cfs.InWarmUp())
+	expectedExpiry = time.Now().Add(metaAge)
+	ts, err = boltDb.GetChunkTs(path.Join(rootFs.Root(), o3.Remote()), 0)
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+
+	// validate that we cooled down and exit warm up
+	// we wait for the cache to expire
+	t.Logf("Waiting 10 seconds for warm up to expire\n")
+	time.Sleep(time.Second * 10)
+
+	_ = readDataFromObj(t, o3, chunkSize, chunkSize*2, false)
+	require.False(t, cfs.InWarmUp())
+	expectedExpiry = time.Now().Add(chunkAge)
+	ts, err = boltDb.GetChunkTs(path.Join(rootFs.Root(), o3.Remote()), chunkSize)
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+}
+
+func TestInternalWarmUpInFlight(t *testing.T) {
+	if *SkipTimeouts {
+		t.Skip("--skip-waits set")
+	}
+
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	o1 := writeObjectRandomBytes(t, rootFs, (chunkSize * 3))
+	o2 := writeObjectRandomBytes(t, rootFs, (chunkSize * 4))
+	o3 := writeObjectRandomBytes(t, rootFs, (chunkSize * int64(workers) * int64(2)))
+
+	_ = readDataFromObj(t, o1, 0, chunkSize, false)
+	_ = readDataFromObj(t, o2, 0, chunkSize, false)
+	require.False(t, cfs.InWarmUp())
+
+	// validate that we entered a warm up state
+	_ = readDataFromObj(t, o3, 0, chunkSize, false)
+	require.True(t, cfs.InWarmUp())
+	expectedExpiry := time.Now().Add(metaAge)
+	ts, err := boltDb.GetChunkTs(path.Join(rootFs.Root(), o3.Remote()), 0)
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+
+	checkSample := make([]byte, chunkSize)
+	reader, err := o3.Open(&fs.SeekOption{Offset: 0})
+	require.NoError(t, err)
+	rs, ok := reader.(*cache.Handle)
+	require.True(t, ok)
+
+	for i := 0; i <= workers; i++ {
+		_, _ = rs.Seek(int64(i)*chunkSize, 0)
+		_, err = io.ReadFull(reader, checkSample)
+		require.NoError(t, err)
+
+		if i == workers {
+			require.False(t, rs.InWarmUp(), "iteration %v", i)
+		} else {
+			require.True(t, rs.InWarmUp(), "iteration %v", i)
+		}
+	}
+	_ = reader.Close()
+	require.True(t, cfs.InWarmUp())
+	expectedExpiry = time.Now().Add(chunkAge)
+	ts, err = boltDb.GetChunkTs(path.Join(rootFs.Root(), o3.Remote()), chunkSize*int64(workers+1))
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+
+	// validate that we cooled down and exit warm up
+	// we wait for the cache to expire
+	t.Logf("Waiting 10 seconds for warm up to expire\n")
+	time.Sleep(time.Second * 10)
+
+	_ = readDataFromObj(t, o2, chunkSize, chunkSize*2, false)
+	require.False(t, cfs.InWarmUp())
+	expectedExpiry = time.Now().Add(chunkAge)
+	ts, err = boltDb.GetChunkTs(path.Join(rootFs.Root(), o2.Remote()), chunkSize)
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+}
+
+// TODO: this is bugged
+//func TestInternalRateLimiter(t *testing.T) {
+//	reset(t)
+//	_ = flag.Set("cache-rps", "2")
+//	rootFs, err := fs.NewFs(*RemoteName + ":")
+//	require.NoError(t, err)
+//	defer func() {
+//		_ = flag.Set("cache-rps", "-1")
+//		rootFs, err = fs.NewFs(*RemoteName + ":")
+//		require.NoError(t, err)
+//	}()
+//	cfs, err := getCacheFs(rootFs)
+//	require.NoError(t, err)
+//	chunkSize := cfs.ChunkSize()
+//
+//	// create some rand test data
+//	co := writeObjectRandomBytes(t, rootFs, (chunkSize*4 + chunkSize/2))
+//
+//	doStuff(t, 5, time.Second, func() {
+//		r, err := co.Open(&fs.SeekOption{Offset: chunkSize + 1})
+//		require.NoError(t, err)
+//
+//		buf := make([]byte, chunkSize)
+//		totalRead, err := io.ReadFull(r, buf)
+//		require.NoError(t, err)
+//		require.Equal(t, len(buf), totalRead)
+//		_ = r.Close()
+//	})
+//}
+
+func TestInternalCacheWrites(t *testing.T) {
+	reset(t)
+	_ = flag.Set("cache-writes", "true")
+	rootFs, err := fs.NewFs(*RemoteName + ":")
+	require.NoError(t, err)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+
+	// create some rand test data
+	co := writeObjectRandomBytes(t, rootFs, (chunkSize*4 + chunkSize/2))
+	expectedExpiry := time.Now().Add(metaAge)
+	ts, err := boltDb.GetChunkTs(path.Join(rootFs.Root(), co.Remote()), 0)
+	require.NoError(t, err)
+	require.WithinDuration(t, expectedExpiry, ts, okDiff)
+
+	// reset fs
+	_ = flag.Set("cache-writes", "false")
+	rootFs, err = fs.NewFs(*RemoteName + ":")
+	require.NoError(t, err)
+}
+
+func TestInternalExpiredChunkRemoved(t *testing.T) {
+	if *SkipTimeouts {
+		t.Skip("--skip-waits set")
+	}
+
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+	chunkSize := cfs.ChunkSize()
+	totalChunks := 20
+
+	// create some rand test data
+	co := writeObjectRandomBytes(t, cfs, (int64(totalChunks-1)*chunkSize + chunkSize/2))
+	remote := co.Remote()
+	// cache all the chunks
+	_ = readDataFromObj(t, co, 0, co.Size(), false)
+
+	// we wait for the cache to expire
+	t.Logf("Waiting %v for cache to expire\n", chunkAge.String())
+	time.Sleep(chunkAge)
+	_, _ = cfs.List("")
+	time.Sleep(time.Second * 2)
+
+	o, err := cfs.NewObject(remote)
+	require.NoError(t, err)
+	co2, ok := o.(*cache.Object)
+	require.True(t, ok)
+	require.False(t, boltDb.HasChunk(co2, 0))
+}
+
+func TestInternalExpiredEntriesRemoved(t *testing.T) {
+	if *SkipTimeouts {
+		t.Skip("--skip-waits set")
+	}
+
+	reset(t)
+	cfs, err := getCacheFs(rootFs)
+	require.NoError(t, err)
+
+	// create some rand test data
+	_ = writeObjectString(t, cfs, "one", "one content")
+	err = cfs.Mkdir("test")
+	require.NoError(t, err)
+	_ = writeObjectString(t, cfs, "test/second", "second content")
+
+	objOne, err := cfs.NewObject("one")
+	require.NoError(t, err)
+	require.Equal(t, int64(len([]byte("one content"))), objOne.Size())
+
+	waitTime := infoAge + time.Second*2
+	t.Logf("Waiting %v seconds for cache to expire\n", waitTime)
+	time.Sleep(infoAge)
+
+	_, err = cfs.List("test")
+	require.NoError(t, err)
+	time.Sleep(time.Second * 2)
+	require.False(t, boltDb.HasEntry("one"))
+}
+
+func TestInternalFinalise(t *testing.T) {
+	var err error
+
+	err = rootFs.Features().Purge()
+	require.NoError(t, err)
+}
+
+func writeObjectRandomBytes(t *testing.T, f fs.Fs, size int64) fs.Object {
+	remote := strconv.Itoa(rand.Int()) + ".bin"
+	// create some rand test data
+	testData := make([]byte, size)
+	testSize, err := rand.Read(testData)
+	require.Equal(t, size, int64(len(testData)))
+	require.Equal(t, size, int64(testSize))
+	require.NoError(t, err)
+
+	o := writeObjectBytes(t, f, remote, testData)
+	require.Equal(t, size, o.Size())
+
+	return o
+}
+
+func writeObjectString(t *testing.T, f fs.Fs, remote, content string) fs.Object {
+	return writeObjectBytes(t, f, remote, []byte(content))
+}
+
+func writeObjectBytes(t *testing.T, f fs.Fs, remote string, data []byte) fs.Object {
+	in := bytes.NewReader(data)
+	modTime := time.Now()
+	objInfo := fs.NewStaticObjectInfo(remote, modTime, int64(len(data)), true, nil, f)
+
+	obj, err := f.Put(in, objInfo)
+	require.NoError(t, err)
+
+	return obj
+}
+
+func updateObjectBytes(t *testing.T, f fs.Fs, remote string, data1 []byte, data2 []byte) fs.Object {
+	in1 := bytes.NewReader(data1)
+	in2 := bytes.NewReader(data2)
+	objInfo1 := fs.NewStaticObjectInfo(remote, time.Now(), int64(len(data1)), true, nil, f)
+	objInfo2 := fs.NewStaticObjectInfo(remote, time.Now(), int64(len(data2)), true, nil, f)
+
+	obj, err := f.Put(in1, objInfo1)
+	require.NoError(t, err)
+	obj, err = f.NewObject(remote)
+	require.NoError(t, err)
+	err = obj.Update(in2, objInfo2)
+
+	return obj
+}
+
+func readDataFromObj(t *testing.T, co fs.Object, offset, end int64, useSeek bool) []byte {
+	var reader io.ReadCloser
+	var err error
+	size := end - offset
+	checkSample := make([]byte, size)
+
+	reader, err = co.Open(&fs.SeekOption{Offset: offset})
+	require.NoError(t, err)
+
+	totalRead, err := io.ReadFull(reader, checkSample)
+	require.NoError(t, err)
+	_ = reader.Close()
+	require.Equal(t, int64(totalRead), size, "wrong data read size from file")
+
+	return checkSample
+}
+
+func doStuff(t *testing.T, times int, maxDuration time.Duration, stuff func()) {
+	var wg sync.WaitGroup
+
+	for i := 0; i < times; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(maxDuration / 2)
+			stuff()
+			time.Sleep(maxDuration / 2)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func reset(t *testing.T) {
+	var err error
+
+	err = rootFs.Features().Purge()
+	require.NoError(t, err)
+
+	// Instantiate root
+	rootFs, err = fs.NewFs(*RemoteName + ":")
+	require.NoError(t, err)
+	err = rootFs.Mkdir("")
+	require.NoError(t, err)
+}
+
+func getCacheFs(f fs.Fs) (*cache.Fs, error) {
+	cfs, ok := f.(*cache.Fs)
+	if ok {
+		return cfs, nil
+	} else {
+		if f.Features().UnWrap != nil {
+			cfs, ok := f.Features().UnWrap().(*cache.Fs)
+			if ok {
+				return cfs, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("didn't found a cache fs")
+}
+
+func getSourceFs(f fs.Fs) (fs.Fs, error) {
+	if f.Features().UnWrap != nil {
+		sfs := f.Features().UnWrap()
+		_, ok := sfs.(*cache.Fs)
+		if !ok {
+			return sfs, nil
+		}
+
+		return getSourceFs(sfs)
+	}
+
+	return nil, fmt.Errorf("didn't found a source fs")
+}
+
+var (
+	_ fs.Fs = (*cache.Fs)(nil)
+	_ fs.Fs = (*local.Fs)(nil)
+)

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,77 @@
+// Test Cache filesystem interface
+//
+// Automatically generated - DO NOT EDIT
+// Regenerate with: make gen_tests
+
+// +build !plan9
+
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/ncw/rclone/cache"
+	"github.com/ncw/rclone/fs"
+	"github.com/ncw/rclone/fstest/fstests"
+	_ "github.com/ncw/rclone/local"
+)
+
+func TestSetup(t *testing.T) {
+	fstests.NilObject = fs.Object((*cache.Object)(nil))
+	fstests.RemoteName = "TestCache:"
+}
+
+// Generic tests for the Fs
+func TestInit(t *testing.T)                { fstests.TestInit(t) }
+func TestFsString(t *testing.T)            { fstests.TestFsString(t) }
+func TestFsName(t *testing.T)              { fstests.TestFsName(t) }
+func TestFsRoot(t *testing.T)              { fstests.TestFsRoot(t) }
+func TestFsRmdirEmpty(t *testing.T)        { fstests.TestFsRmdirEmpty(t) }
+func TestFsRmdirNotFound(t *testing.T)     { fstests.TestFsRmdirNotFound(t) }
+func TestFsMkdir(t *testing.T)             { fstests.TestFsMkdir(t) }
+func TestFsMkdirRmdirSubdir(t *testing.T)  { fstests.TestFsMkdirRmdirSubdir(t) }
+func TestFsListEmpty(t *testing.T)         { fstests.TestFsListEmpty(t) }
+func TestFsListDirEmpty(t *testing.T)      { fstests.TestFsListDirEmpty(t) }
+func TestFsListRDirEmpty(t *testing.T)     { fstests.TestFsListRDirEmpty(t) }
+func TestFsNewObjectNotFound(t *testing.T) { fstests.TestFsNewObjectNotFound(t) }
+func TestFsPutFile1(t *testing.T)          { fstests.TestFsPutFile1(t) }
+func TestFsPutError(t *testing.T)          { fstests.TestFsPutError(t) }
+func TestFsPutFile2(t *testing.T)          { fstests.TestFsPutFile2(t) }
+func TestFsUpdateFile1(t *testing.T)       { fstests.TestFsUpdateFile1(t) }
+func TestFsListDirFile2(t *testing.T)      { fstests.TestFsListDirFile2(t) }
+func TestFsListRDirFile2(t *testing.T)     { fstests.TestFsListRDirFile2(t) }
+func TestFsListDirRoot(t *testing.T)       { fstests.TestFsListDirRoot(t) }
+func TestFsListRDirRoot(t *testing.T)      { fstests.TestFsListRDirRoot(t) }
+func TestFsListSubdir(t *testing.T)        { fstests.TestFsListSubdir(t) }
+func TestFsListRSubdir(t *testing.T)       { fstests.TestFsListRSubdir(t) }
+func TestFsListLevel2(t *testing.T)        { fstests.TestFsListLevel2(t) }
+func TestFsListRLevel2(t *testing.T)       { fstests.TestFsListRLevel2(t) }
+func TestFsListFile1(t *testing.T)         { fstests.TestFsListFile1(t) }
+func TestFsNewObject(t *testing.T)         { fstests.TestFsNewObject(t) }
+func TestFsListFile1and2(t *testing.T)     { fstests.TestFsListFile1and2(t) }
+func TestFsNewObjectDir(t *testing.T)      { fstests.TestFsNewObjectDir(t) }
+func TestFsCopy(t *testing.T)              { fstests.TestFsCopy(t) }
+func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
+func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
+func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
+func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
+func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
+func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
+func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }
+func TestObjectHashes(t *testing.T)        { fstests.TestObjectHashes(t) }
+func TestObjectModTime(t *testing.T)       { fstests.TestObjectModTime(t) }
+func TestObjectMimeType(t *testing.T)      { fstests.TestObjectMimeType(t) }
+func TestObjectSetModTime(t *testing.T)    { fstests.TestObjectSetModTime(t) }
+func TestObjectSize(t *testing.T)          { fstests.TestObjectSize(t) }
+func TestObjectOpen(t *testing.T)          { fstests.TestObjectOpen(t) }
+func TestObjectOpenSeek(t *testing.T)      { fstests.TestObjectOpenSeek(t) }
+func TestObjectPartialRead(t *testing.T)   { fstests.TestObjectPartialRead(t) }
+func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
+func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
+func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
+func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
+func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
+func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/cache/cache_unsupported.go
+++ b/cache/cache_unsupported.go
@@ -1,0 +1,6 @@
+// Build for cache for unsupported platforms to stop go complaining
+// about "no buildable Go source files "
+
+// +build plan9
+
+package cache

--- a/cache/directory.go
+++ b/cache/directory.go
@@ -1,0 +1,126 @@
+// +build !plan9
+
+package cache
+
+import (
+	"time"
+
+	"os"
+	"path"
+	"strings"
+
+	"github.com/ncw/rclone/fs"
+)
+
+// Directory is a generic dir that stores basic information about it
+type Directory struct {
+	fs.Directory `json:"-"`
+
+	CacheFs      *Fs    `json:"-"`       // cache fs
+	Name         string `json:"name"`    // name of the directory
+	Dir          string `json:"dir"`     // abs path of the directory
+	CacheModTime int64  `json:"modTime"` // modification or creation time - IsZero for unknown
+	CacheSize    int64  `json:"size"`    // size of directory and contents or -1 if unknown
+
+	CacheItems int64  `json:"items"`     // number of objects or -1 for unknown
+	CacheType  string `json:"cacheType"` // object type
+}
+
+// NewDirectory builds an empty dir which will be used to unmarshal data in it
+func NewDirectory(f *Fs, remote string) *Directory {
+	var cd *Directory
+	fullRemote := cleanPath(path.Join(f.Root(), remote))
+
+	// build a new one
+	dir := cleanPath(path.Dir(fullRemote))
+	name := cleanPath(path.Base(fullRemote))
+	cd = &Directory{
+		CacheFs:      f,
+		Name:         name,
+		Dir:          dir,
+		CacheModTime: time.Now().UnixNano(),
+		CacheSize:    0,
+		CacheItems:   0,
+		CacheType:    "Directory",
+	}
+
+	return cd
+}
+
+// DirectoryFromOriginal builds one from a generic fs.Directory
+func DirectoryFromOriginal(f *Fs, d fs.Directory) *Directory {
+	var cd *Directory
+	fullRemote := path.Join(f.Root(), d.Remote())
+
+	dir := cleanPath(path.Dir(fullRemote))
+	name := cleanPath(path.Base(fullRemote))
+	cd = &Directory{
+		Directory:    d,
+		CacheFs:      f,
+		Name:         name,
+		Dir:          dir,
+		CacheModTime: d.ModTime().UnixNano(),
+		CacheSize:    d.Size(),
+		CacheItems:   d.Items(),
+		CacheType:    "Directory",
+	}
+
+	return cd
+}
+
+// Fs returns its FS info
+func (d *Directory) Fs() fs.Info {
+	return d.CacheFs
+}
+
+// String returns a human friendly name for this object
+func (d *Directory) String() string {
+	if d == nil {
+		return "<nil>"
+	}
+	return d.Remote()
+}
+
+// Remote returns the remote path
+func (d *Directory) Remote() string {
+	p := cleanPath(path.Join(d.Dir, d.Name))
+	if d.CacheFs.Root() != "" {
+		p = strings.Replace(p, d.CacheFs.Root(), "", 1)
+		p = strings.TrimPrefix(p, string(os.PathSeparator))
+	}
+
+	return p
+}
+
+// abs returns the absolute path to the dir
+func (d *Directory) abs() string {
+	return cleanPath(path.Join(d.Dir, d.Name))
+}
+
+// parentRemote returns the absolute path parent remote
+func (d *Directory) parentRemote() string {
+	absPath := d.abs()
+	if absPath == "" {
+		return ""
+	}
+	return cleanPath(path.Dir(absPath))
+}
+
+// ModTime returns the cached ModTime
+func (d *Directory) ModTime() time.Time {
+	return time.Unix(0, d.CacheModTime)
+}
+
+// Size returns the cached Size
+func (d *Directory) Size() int64 {
+	return d.CacheSize
+}
+
+// Items returns the cached Items
+func (d *Directory) Items() int64 {
+	return d.CacheItems
+}
+
+var (
+	_ fs.Directory = (*Directory)(nil)
+)

--- a/cache/handle.go
+++ b/cache/handle.go
@@ -1,0 +1,436 @@
+// +build !plan9
+
+package cache
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/ncw/rclone/fs"
+	"github.com/pkg/errors"
+)
+
+// Handle is managing the read/write/seek operations on an open handle
+type Handle struct {
+	cachedObject  *Object
+	memory        ChunkStorage
+	preloadQueue  chan int64
+	preloadOffset int64
+	offset        int64
+	seenOffsets   map[int64]bool
+	mu            sync.Mutex
+
+	ReadRetries  int
+	TotalWorkers int
+	UseMemory    bool
+	workers      []*worker
+	chunkAge     time.Duration
+	warmup       bool
+	closed       bool
+}
+
+// NewObjectHandle returns a new Handle for an existing Object
+func NewObjectHandle(o *Object) *Handle {
+	r := &Handle{
+		cachedObject:  o,
+		offset:        0,
+		preloadOffset: -1, // -1 to trigger the first preload
+
+		ReadRetries:  o.CacheFs.readRetries,
+		TotalWorkers: o.CacheFs.totalWorkers,
+		UseMemory:    o.CacheFs.chunkMemory,
+		chunkAge:     o.CacheFs.chunkAge,
+		warmup:       o.CacheFs.InWarmUp(),
+	}
+	r.seenOffsets = make(map[int64]bool)
+	r.memory = NewMemory(o.CacheFs.chunkAge)
+	if o.CacheFs.InWarmUp() {
+		r.chunkAge = o.CacheFs.metaAge
+	}
+
+	// create a larger buffer to queue up requests
+	r.preloadQueue = make(chan int64, r.TotalWorkers*10)
+	r.startReadWorkers()
+	return r
+}
+
+// cacheFs is a convenience method to get the parent cache FS of the object's manager
+func (r *Handle) cacheFs() *Fs {
+	return r.cachedObject.CacheFs
+}
+
+// storage is a convenience method to get the persistent storage of the object's manager
+func (r *Handle) storage() Storage {
+	return r.cacheFs().cache
+}
+
+// String representation of this reader
+func (r *Handle) String() string {
+	return r.cachedObject.abs()
+}
+
+// InWarmUp says if this handle is in warmup mode
+func (r *Handle) InWarmUp() bool {
+	return r.warmup
+}
+
+// startReadWorkers will start the worker pool
+func (r *Handle) startReadWorkers() {
+	if r.hasAtLeastOneWorker() {
+		return
+	}
+	for i := 0; i < r.TotalWorkers; i++ {
+		w := &worker{
+			r:  r,
+			ch: r.preloadQueue,
+			id: i,
+		}
+		go w.run()
+
+		r.workers = append(r.workers, w)
+	}
+}
+
+// queueOffset will send an offset to the workers if it's different from the last one
+func (r *Handle) queueOffset(offset int64) {
+	if offset != r.preloadOffset {
+		r.preloadOffset = offset
+		previousChunksCounter := 0
+		maxOffset := r.cacheFs().chunkSize * int64(r.cacheFs().originalSettingWorkers())
+
+		// clear the past seen chunks
+		// they will remain in our persistent storage but will be removed from transient
+		// so they need to be picked up by a worker
+		for k := range r.seenOffsets {
+			if k < offset {
+				r.seenOffsets[k] = false
+
+				// we count how many continuous chunks were seen before
+				if offset >= maxOffset && k >= offset-maxOffset {
+					previousChunksCounter++
+				}
+			}
+		}
+
+		// if we read all the previous chunks that could have been preloaded
+		// we should then disable warm up setting for this handle
+		if r.warmup && previousChunksCounter >= r.cacheFs().originalSettingWorkers() {
+			r.TotalWorkers = r.cacheFs().originalSettingWorkers()
+			r.UseMemory = !r.cacheFs().originalSettingChunkNoMemory()
+			r.chunkAge = r.cacheFs().chunkAge
+			r.warmup = false
+			fs.Infof(r, "disabling warm up")
+		}
+
+		for i := 0; i < r.TotalWorkers; i++ {
+			o := r.preloadOffset + r.cacheFs().chunkSize*int64(i)
+			if o < 0 || o >= r.cachedObject.Size() {
+				continue
+			}
+			if v, ok := r.seenOffsets[o]; ok && v {
+				continue
+			}
+
+			r.seenOffsets[o] = true
+			r.preloadQueue <- o
+		}
+	}
+}
+
+func (r *Handle) hasAtLeastOneWorker() bool {
+	oneWorker := false
+	for i := 0; i < len(r.workers); i++ {
+		if r.workers[i].isRunning() {
+			oneWorker = true
+		}
+	}
+	return oneWorker
+}
+
+// getChunk is called by the FS to retrieve a specific chunk of known start and size from where it can find it
+// it can be from transient or persistent cache
+// it will also build the chunk from the cache's specific chunk boundaries and build the final desired chunk in a buffer
+func (r *Handle) getChunk(chunkStart int64) ([]byte, error) {
+	var data []byte
+	var err error
+
+	// we reached the end of the file
+	if chunkStart >= r.cachedObject.Size() {
+		fs.Debugf(r, "reached EOF %v", chunkStart)
+		return nil, io.EOF
+	}
+
+	// we calculate the modulus of the requested offset with the size of a chunk
+	offset := chunkStart % r.cacheFs().chunkSize
+
+	// we align the start offset of the first chunk to a likely chunk in the storage
+	chunkStart = chunkStart - offset
+	r.queueOffset(chunkStart)
+	found := false
+
+	// delete old chunks from memory
+	if r.UseMemory {
+		go r.memory.CleanChunksByNeed(chunkStart)
+
+		data, err = r.memory.GetChunk(r.cachedObject, chunkStart)
+		if err == nil {
+			found = true
+		}
+	}
+
+	if !found {
+		// we're gonna give the workers a chance to pickup the chunk
+		// and retry a couple of times
+		for i := 0; i < r.ReadRetries; i++ {
+			data, err = r.storage().GetChunk(r.cachedObject, chunkStart)
+
+			if err == nil {
+				found = true
+				break
+			}
+
+			fs.Debugf(r, "%v: chunk retry storage: %v", chunkStart, i)
+			time.Sleep(time.Second)
+		}
+	}
+
+	// not found in ram or
+	// the worker didn't managed to download the chunk in time so we abort and close the stream
+	if err != nil || len(data) == 0 || !found {
+		if !r.hasAtLeastOneWorker() {
+			fs.Errorf(r, "out of workers")
+			return nil, io.ErrUnexpectedEOF
+		}
+
+		return nil, errors.Errorf("chunk not found %v", chunkStart)
+	}
+
+	// first chunk will be aligned with the start
+	if offset > 0 {
+		data = data[int(offset):]
+	}
+
+	return data, nil
+}
+
+// Read a chunk from storage or len(p)
+func (r *Handle) Read(p []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var buf []byte
+
+	currentOffset := r.offset
+	buf, err = r.getChunk(currentOffset)
+	if err != nil && len(buf) == 0 {
+		return 0, io.EOF
+	}
+	readSize := copy(p, buf)
+	newOffset := currentOffset + int64(readSize)
+	r.offset = newOffset
+	if r.offset >= r.cachedObject.Size() {
+		err = io.EOF
+	}
+
+	return readSize, err
+}
+
+// Close will tell the workers to stop
+func (r *Handle) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return errors.New("file already closed")
+	}
+
+	close(r.preloadQueue)
+	r.closed = true
+	// wait for workers to complete their jobs before returning
+	waitCount := 3
+	for i := 0; i < len(r.workers); i++ {
+		waitIdx := 0
+		for r.workers[i].isRunning() && waitIdx < waitCount {
+			time.Sleep(time.Second)
+			waitIdx++
+		}
+	}
+
+	fs.Debugf(r, "cache reader closed %v", r.offset)
+	return nil
+}
+
+// Seek will move the current offset based on whence and instruct the workers to move there too
+func (r *Handle) Seek(offset int64, whence int) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+	switch whence {
+	case os.SEEK_SET:
+		fs.Debugf(r, "moving offset set from %v to %v", r.offset, offset)
+		r.offset = offset
+	case os.SEEK_CUR:
+		fs.Debugf(r, "moving offset cur from %v to %v", r.offset, r.offset+offset)
+		r.offset += offset
+	case os.SEEK_END:
+		fs.Debugf(r, "moving offset end (%v) from %v to %v", r.cachedObject.Size(), r.offset, r.cachedObject.Size()+offset)
+		r.offset = r.cachedObject.Size() + offset
+	default:
+		err = errors.Errorf("cache: unimplemented seek whence %v", whence)
+	}
+
+	chunkStart := r.offset - (r.offset % r.cacheFs().chunkSize)
+	if chunkStart >= r.cacheFs().chunkSize {
+		chunkStart = chunkStart - r.cacheFs().chunkSize
+	}
+	r.queueOffset(chunkStart)
+
+	return r.offset, err
+}
+
+type worker struct {
+	r       *Handle
+	ch      <-chan int64
+	rc      io.ReadCloser
+	id      int
+	running bool
+	mu      sync.Mutex
+}
+
+// String is a representation of this worker
+func (w *worker) String() string {
+	return fmt.Sprintf("worker-%v <%v>", w.id, w.r.cachedObject.Name)
+}
+
+// reader will return a reader depending on the capabilities of the source reader:
+//   - if it supports seeking it will seek to the desired offset and return the same reader
+//   - if it doesn't support seeking it will close a possible existing one and open at the desired offset
+//   - if there's no reader associated with this worker, it will create one
+func (w *worker) reader(offset, end int64) (io.ReadCloser, error) {
+	var err error
+	r := w.rc
+	if w.rc == nil {
+		r, err = w.r.cacheFs().OpenRateLimited(func() (io.ReadCloser, error) {
+			return w.r.cachedObject.Object.Open(&fs.RangeOption{Start: offset, End: end}, &fs.SeekOption{Offset: offset})
+		})
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	seekerObj, ok := r.(io.Seeker)
+	if ok {
+		_, err = seekerObj.Seek(offset, os.SEEK_SET)
+		return r, err
+	}
+
+	_ = w.rc.Close()
+	return w.r.cacheFs().OpenRateLimited(func() (io.ReadCloser, error) {
+		r, err = w.r.cachedObject.Object.Open(&fs.RangeOption{Start: offset, End: end}, &fs.SeekOption{Offset: offset})
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	})
+}
+
+func (w *worker) isRunning() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}
+
+func (w *worker) setRunning(f bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.running = f
+}
+
+// run is the main loop for the worker which receives offsets to preload
+func (w *worker) run() {
+	var err error
+	var data []byte
+	defer w.setRunning(false)
+	defer func() {
+		if w.rc != nil {
+			_ = w.rc.Close()
+			w.setRunning(false)
+		}
+	}()
+
+	for {
+		chunkStart, open := <-w.ch
+		w.setRunning(true)
+		if chunkStart < 0 || !open {
+			break
+		}
+
+		// skip if it exists
+		if w.r.UseMemory {
+			if w.r.memory.HasChunk(w.r.cachedObject, chunkStart) {
+				continue
+			}
+
+			// add it in ram if it's in the persistent storage
+			data, err = w.r.storage().GetChunk(w.r.cachedObject, chunkStart)
+			if err == nil {
+				err = w.r.memory.AddChunk(w.r.cachedObject, data, chunkStart)
+				if err != nil {
+					fs.Errorf(w, "failed caching chunk in ram %v: %v", chunkStart, err)
+				} else {
+					continue
+				}
+			}
+			err = nil
+		} else {
+			if w.r.storage().HasChunk(w.r.cachedObject, chunkStart) {
+				continue
+			}
+		}
+
+		chunkEnd := chunkStart + w.r.cacheFs().chunkSize
+		if chunkEnd > w.r.cachedObject.Size() {
+			chunkEnd = w.r.cachedObject.Size()
+		}
+		w.rc, err = w.reader(chunkStart, chunkEnd)
+		// we seem to be getting only errors so we abort
+		if err != nil {
+			fs.Errorf(w, "object open failed %v: %v", chunkStart, err)
+			return
+		}
+
+		data = make([]byte, chunkEnd-chunkStart)
+		sourceRead := 0
+		sourceRead, err = io.ReadFull(w.rc, data)
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			fs.Errorf(w, "failed to read chunk %v: %v", chunkStart, err)
+			return
+		}
+		if err == io.ErrUnexpectedEOF {
+			fs.Debugf(w, "partial read chunk %v: %v", chunkStart, err)
+		}
+		data = data[:sourceRead] // reslice to remove extra garbage
+		fs.Debugf(w, "downloaded chunk %v", fs.SizeSuffix(chunkStart))
+
+		if w.r.UseMemory {
+			err = w.r.memory.AddChunk(w.r.cachedObject, data, chunkStart)
+			if err != nil {
+				fs.Errorf(w, "failed caching chunk in ram %v: %v", chunkStart, err)
+			}
+		}
+
+		err = w.r.storage().AddChunkAhead(w.r.cachedObject.abs(), data, chunkStart, w.r.chunkAge)
+		if err != nil {
+			fs.Errorf(w, "failed caching chunk in storage %v: %v", chunkStart, err)
+		}
+	}
+}
+
+// Check the interfaces are satisfied
+var (
+	_ io.ReadCloser = (*Handle)(nil)
+	_ io.Seeker     = (*Handle)(nil)
+)

--- a/cache/object.go
+++ b/cache/object.go
@@ -1,0 +1,303 @@
+// +build !plan9
+
+package cache
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"strconv"
+
+	"github.com/ncw/rclone/fs"
+)
+
+// Object is a generic file like object that stores basic information about it
+type Object struct {
+	fs.Object `json:"-"`
+
+	CacheFs       *Fs                    `json:"-"`        // cache fs
+	Name          string                 `json:"name"`     // name of the directory
+	Dir           string                 `json:"dir"`      // abs path of the object
+	CacheModTime  int64                  `json:"modTime"`  // modification or creation time - IsZero for unknown
+	CacheSize     int64                  `json:"size"`     // size of directory and contents or -1 if unknown
+	CacheStorable bool                   `json:"storable"` // says whether this object can be stored
+	CacheType     string                 `json:"cacheType"`
+	cacheHashes   map[fs.HashType]string // all supported hashes cached
+
+	refreshMutex sync.Mutex
+}
+
+// NewObject builds one from a generic fs.Object
+func NewObject(f *Fs, remote string) *Object { //0745 379 768
+	fullRemote := path.Join(f.Root(), remote)
+	dir, name := path.Split(fullRemote)
+
+	co := &Object{
+		CacheFs:       f,
+		Name:          cleanPath(name),
+		Dir:           cleanPath(dir),
+		CacheModTime:  time.Now().UnixNano(),
+		CacheSize:     0,
+		CacheStorable: false,
+		CacheType:     "Object",
+	}
+	return co
+}
+
+// MarshalJSON is needed to override the hashes map (needed to support older versions of Go)
+func (o *Object) MarshalJSON() ([]byte, error) {
+	hashes := make(map[string]string)
+	for k, v := range o.cacheHashes {
+		hashes[strconv.Itoa(int(k))] = v
+	}
+
+	type Alias Object
+	return json.Marshal(&struct {
+		Hashes map[string]string `json:"hashes"`
+		*Alias
+	}{
+		Alias:  (*Alias)(o),
+		Hashes: hashes,
+	})
+}
+
+// UnmarshalJSON is needed to override the CacheHashes map (needed to support older versions of Go)
+func (o *Object) UnmarshalJSON(b []byte) error {
+	type Alias Object
+	aux := &struct {
+		Hashes map[string]string `json:"hashes"`
+		*Alias
+	}{
+		Alias: (*Alias)(o),
+	}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	o.cacheHashes = make(map[fs.HashType]string)
+	for k, v := range aux.Hashes {
+		ht, _ := strconv.Atoi(k)
+		o.cacheHashes[fs.HashType(ht)] = v
+	}
+
+	return nil
+}
+
+// ObjectFromOriginal builds one from a generic fs.Object
+func ObjectFromOriginal(f *Fs, o fs.Object) *Object {
+	var co *Object
+	fullRemote := cleanPath(path.Join(f.Root(), o.Remote()))
+
+	dir, name := path.Split(fullRemote)
+	co = &Object{
+		CacheFs:   f,
+		Name:      cleanPath(name),
+		Dir:       cleanPath(dir),
+		CacheType: "Object",
+	}
+	co.updateData(o)
+	return co
+}
+
+func (o *Object) updateData(source fs.Object) {
+	o.Object = source
+	o.CacheModTime = source.ModTime().UnixNano()
+	o.CacheSize = source.Size()
+	o.CacheStorable = source.Storable()
+	o.cacheHashes = make(map[fs.HashType]string)
+}
+
+// Fs returns its FS info
+func (o *Object) Fs() fs.Info {
+	return o.CacheFs
+}
+
+// String returns a human friendly name for this object
+func (o *Object) String() string {
+	if o == nil {
+		return "<nil>"
+	}
+	return o.Remote()
+}
+
+// Remote returns the remote path
+func (o *Object) Remote() string {
+	p := path.Join(o.Dir, o.Name)
+	if o.CacheFs.Root() != "" {
+		p = strings.Replace(p, o.CacheFs.Root(), "", 1)
+		p = strings.TrimPrefix(p, string(os.PathSeparator))
+	}
+
+	return p
+}
+
+// abs returns the absolute path to the object
+func (o *Object) abs() string {
+	return path.Join(o.Dir, o.Name)
+}
+
+// parentRemote returns the absolute path parent remote
+func (o *Object) parentRemote() string {
+	absPath := o.abs()
+	return cleanPath(path.Dir(absPath))
+}
+
+// ModTime returns the cached ModTime
+func (o *Object) ModTime() time.Time {
+	return time.Unix(0, o.CacheModTime)
+}
+
+// Size returns the cached Size
+func (o *Object) Size() int64 {
+	return o.CacheSize
+}
+
+// Storable returns the cached Storable
+func (o *Object) Storable() bool {
+	return o.CacheStorable
+}
+
+// refreshFromSource requests the original FS for the object in case it comes from a cached entry
+func (o *Object) refreshFromSource() error {
+	o.refreshMutex.Lock()
+	defer o.refreshMutex.Unlock()
+
+	if o.Object != nil {
+		return nil
+	}
+
+	liveObject, err := o.CacheFs.Fs.NewObject(o.Remote())
+	if err != nil {
+		fs.Errorf(o, "error refreshing object: %v", err)
+		return err
+	}
+	o.updateData(liveObject)
+	o.persist()
+
+	return nil
+}
+
+// SetModTime sets the ModTime of this object
+func (o *Object) SetModTime(t time.Time) error {
+	if err := o.refreshFromSource(); err != nil {
+		return err
+	}
+
+	err := o.Object.SetModTime(t)
+	if err != nil {
+		return err
+	}
+
+	o.CacheModTime = t.UnixNano()
+	o.persist()
+	fs.Debugf(o.Fs(), "updated ModTime %v: %v", o, t)
+
+	return nil
+}
+
+// Open is used to request a specific part of the file using fs.RangeOption
+func (o *Object) Open(options ...fs.OpenOption) (io.ReadCloser, error) {
+	if err := o.refreshFromSource(); err != nil {
+		return nil, err
+	}
+	o.CacheFs.CheckIfWarmupNeeded(o.Remote())
+
+	cacheReader := NewObjectHandle(o)
+	for _, option := range options {
+		switch x := option.(type) {
+		case *fs.SeekOption:
+			_, err := cacheReader.Seek(x.Offset, os.SEEK_SET)
+			if err != nil {
+				return cacheReader, err
+			}
+		}
+	}
+
+	return cacheReader, nil
+}
+
+// Update will change the object data
+func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+	if err := o.refreshFromSource(); err != nil {
+		return err
+	}
+	fs.Infof(o, "updating object contents with size %v", src.Size())
+
+	// deleting cached chunks and info to be replaced with new ones
+	_ = o.CacheFs.cache.RemoveObject(o.abs())
+
+	err := o.Object.Update(in, src, options...)
+	if err != nil {
+		fs.Errorf(o, "error updating source: %v", err)
+		return err
+	}
+
+	o.CacheModTime = src.ModTime().UnixNano()
+	o.CacheSize = src.Size()
+	o.cacheHashes = make(map[fs.HashType]string)
+	o.persist()
+
+	return nil
+}
+
+// Remove deletes the object from both the cache and the source
+func (o *Object) Remove() error {
+	if err := o.refreshFromSource(); err != nil {
+		return err
+	}
+	err := o.Object.Remove()
+	if err != nil {
+		return err
+	}
+	fs.Infof(o, "removing object")
+
+	_ = o.CacheFs.cache.RemoveObject(o.abs())
+	return err
+}
+
+// Hash requests a hash of the object and stores in the cache
+// since it might or might not be called, this is lazy loaded
+func (o *Object) Hash(ht fs.HashType) (string, error) {
+	if o.cacheHashes == nil {
+		o.cacheHashes = make(map[fs.HashType]string)
+	}
+
+	cachedHash, found := o.cacheHashes[ht]
+	if found {
+		return cachedHash, nil
+	}
+
+	if err := o.refreshFromSource(); err != nil {
+		return "", err
+	}
+
+	liveHash, err := o.Object.Hash(ht)
+	if err != nil {
+		return "", err
+	}
+
+	o.cacheHashes[ht] = liveHash
+
+	o.persist()
+	fs.Debugf(o, "object hash cached: %v", liveHash)
+
+	return liveHash, nil
+}
+
+// persist adds this object to the persistent cache
+func (o *Object) persist() *Object {
+	err := o.CacheFs.cache.AddObject(o)
+	if err != nil {
+		fs.Errorf(o, "failed to cache object: %v", err)
+	}
+	return o
+}
+
+var (
+	_ fs.Object = (*Object)(nil)
+)

--- a/cache/storage_memory.go
+++ b/cache/storage_memory.go
@@ -1,0 +1,95 @@
+// +build !plan9
+
+package cache
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ncw/rclone/fs"
+	"github.com/patrickmn/go-cache"
+	"github.com/pkg/errors"
+)
+
+// Memory is a wrapper of transient storage for a go-cache store
+type Memory struct {
+	ChunkStorage
+
+	db *cache.Cache
+}
+
+// NewMemory builds this cache storage
+// defaultExpiration will set the expiry time of chunks in this storage
+func NewMemory(defaultExpiration time.Duration) *Memory {
+	mem := &Memory{}
+	err := mem.Connect(defaultExpiration)
+	if err != nil {
+		fs.Errorf("cache", "can't open ram connection: %v", err)
+	}
+
+	return mem
+}
+
+// Connect will create a connection for the storage
+func (m *Memory) Connect(defaultExpiration time.Duration) error {
+	m.db = cache.New(defaultExpiration, -1)
+	return nil
+}
+
+// HasChunk confirms the existence of a single chunk of an object
+func (m *Memory) HasChunk(cachedObject *Object, offset int64) bool {
+	key := cachedObject.abs() + "-" + strconv.FormatInt(offset, 10)
+	_, found := m.db.Get(key)
+	return found
+}
+
+// GetChunk will retrieve a single chunk which belongs to a cached object or an error if it doesn't find it
+func (m *Memory) GetChunk(cachedObject *Object, offset int64) ([]byte, error) {
+	key := cachedObject.abs() + "-" + strconv.FormatInt(offset, 10)
+	var data []byte
+
+	if x, found := m.db.Get(key); found {
+		data = x.([]byte)
+		return data, nil
+	}
+
+	return nil, errors.Errorf("couldn't get cached object data at offset %v", offset)
+}
+
+// AddChunk adds a new chunk of a cached object
+func (m *Memory) AddChunk(cachedObject *Object, data []byte, offset int64) error {
+	return m.AddChunkAhead(cachedObject.abs(), data, offset, time.Second)
+}
+
+// AddChunkAhead adds a new chunk of a cached object
+func (m *Memory) AddChunkAhead(fp string, data []byte, offset int64, t time.Duration) error {
+	key := fp + "-" + strconv.FormatInt(offset, 10)
+	m.db.Set(key, data, cache.DefaultExpiration)
+
+	return nil
+}
+
+// CleanChunksByAge will cleanup on a cron basis
+func (m *Memory) CleanChunksByAge(chunkAge time.Duration) {
+	m.db.DeleteExpired()
+}
+
+// CleanChunksByNeed will cleanup chunks after the FS passes a specific chunk
+func (m *Memory) CleanChunksByNeed(offset int64) {
+	var items map[string]cache.Item
+
+	items = m.db.Items()
+	for key := range items {
+		sepIdx := strings.LastIndex(key, "-")
+		keyOffset, err := strconv.ParseInt(key[sepIdx+1:], 10, 64)
+		if err != nil {
+			fs.Errorf("cache", "couldn't parse offset entry %v", key)
+			continue
+		}
+
+		if keyOffset < offset {
+			m.db.Delete(key)
+		}
+	}
+}

--- a/cache/storage_persistent.go
+++ b/cache/storage_persistent.go
@@ -1,0 +1,758 @@
+// +build !plan9
+
+package cache
+
+import (
+	"time"
+
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+
+	"io/ioutil"
+	"path/filepath"
+
+	bolt "github.com/coreos/bbolt"
+	"github.com/ncw/rclone/fs"
+	"github.com/pkg/errors"
+)
+
+// Constants
+const (
+	RootBucket   = "root"
+	RootTsBucket = "rootTs"
+	DataTsBucket = "dataTs"
+)
+
+var boltMap = make(map[string]*Persistent)
+var boltMapMx sync.RWMutex
+
+// GetPersistent returns a single instance for the specific store
+func GetPersistent(dbPath string, refreshDb bool) *Persistent {
+	// read lock to check if it exists
+	boltMapMx.RLock()
+	if b, ok := boltMap[dbPath]; ok {
+		boltMapMx.RUnlock()
+		return b
+	}
+	boltMapMx.RUnlock()
+
+	// write lock to create one but let's check a 2nd time
+	boltMapMx.Lock()
+	defer boltMapMx.Unlock()
+	if b, ok := boltMap[dbPath]; ok {
+		return b
+	}
+
+	boltMap[dbPath] = newPersistent(dbPath, refreshDb)
+	return boltMap[dbPath]
+}
+
+// Persistent is a wrapper of persistent storage for a bolt.DB file
+type Persistent struct {
+	Storage
+
+	dbPath     string
+	dataPath   string
+	db         *bolt.DB
+	cleanupMux sync.Mutex
+}
+
+// newPersistent builds a new wrapper and connects to the bolt.DB file
+func newPersistent(dbPath string, refreshDb bool) *Persistent {
+	dataPath := strings.TrimSuffix(dbPath, filepath.Ext(dbPath))
+
+	b := &Persistent{
+		dbPath:   dbPath,
+		dataPath: dataPath,
+	}
+
+	err := b.Connect(refreshDb)
+	if err != nil {
+		fs.Errorf(dbPath, "error opening storage cache: %v", err)
+	}
+
+	return b
+}
+
+// String will return a human friendly string for this DB (currently the dbPath)
+func (b *Persistent) String() string {
+	return "<Cache DB> " + b.dbPath
+}
+
+// Connect creates a connection to the configured file
+// refreshDb will delete the file before to create an empty DB if it's set to true
+func (b *Persistent) Connect(refreshDb bool) error {
+	var db *bolt.DB
+	var err error
+
+	if refreshDb {
+		err := os.Remove(b.dbPath)
+		if err != nil {
+			fs.Errorf(b, "failed to remove cache file: %v", err)
+		}
+		err = os.RemoveAll(b.dataPath)
+		if err != nil {
+			fs.Errorf(b, "failed to remove cache data: %v", err)
+		}
+	}
+
+	err = os.MkdirAll(b.dataPath, os.ModePerm)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create a data directory %q", b.dataPath)
+	}
+	db, err = bolt.Open(b.dbPath, 0644, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return errors.Wrapf(err, "failed to open a cache connection to %q", b.dbPath)
+	}
+
+	_ = db.Update(func(tx *bolt.Tx) error {
+		_, _ = tx.CreateBucketIfNotExists([]byte(RootBucket))
+		_, _ = tx.CreateBucketIfNotExists([]byte(RootTsBucket))
+		_, _ = tx.CreateBucketIfNotExists([]byte(DataTsBucket))
+
+		return nil
+	})
+
+	b.db = db
+
+	return nil
+}
+
+// getBucket prepares and cleans a specific path of the form: /var/tmp and will iterate through each path component
+// to get to the nested bucket of the final part (in this example: tmp)
+func (b *Persistent) getBucket(dir string, createIfMissing bool, tx *bolt.Tx) *bolt.Bucket {
+	cleanPath(dir)
+
+	entries := strings.FieldsFunc(dir, func(c rune) bool {
+		return os.PathSeparator == c
+	})
+	bucket := tx.Bucket([]byte(RootBucket))
+
+	for _, entry := range entries {
+		if createIfMissing {
+			bucket, _ = bucket.CreateBucketIfNotExists([]byte(entry))
+		} else {
+			bucket = bucket.Bucket([]byte(entry))
+		}
+
+		if bucket == nil {
+			return nil
+		}
+	}
+
+	return bucket
+}
+
+// updateChunkTs is a convenience method to update a chunk timestamp to mark that it was used recently
+func (b *Persistent) updateChunkTs(tx *bolt.Tx, path string, offset int64, t time.Duration) {
+	tsBucket := tx.Bucket([]byte(DataTsBucket))
+	tsVal := path + "-" + strconv.FormatInt(offset, 10)
+	ts := time.Now().Add(t)
+	found := false
+
+	// delete previous timestamps for the same object
+	c := tsBucket.Cursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		if bytes.Equal(v, []byte(tsVal)) {
+			if tsInCache := time.Unix(0, btoi(k)); tsInCache.After(ts) && !found {
+				found = true
+				continue
+			}
+			err := c.Delete()
+			if err != nil {
+				fs.Debugf(path, "failed to clean chunk: %v", err)
+			}
+		}
+	}
+	if found {
+		return
+	}
+
+	err := tsBucket.Put(itob(ts.UnixNano()), []byte(tsVal))
+	if err != nil {
+		fs.Debugf(path, "failed to timestamp chunk: %v", err)
+	}
+}
+
+// updateRootTs is a convenience method to update an object timestamp to mark that it was used recently
+func (b *Persistent) updateRootTs(tx *bolt.Tx, path string, t time.Duration) {
+	tsBucket := tx.Bucket([]byte(RootTsBucket))
+	ts := time.Now().Add(t)
+	found := false
+
+	// delete previous timestamps for the same object
+	c := tsBucket.Cursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		if bytes.Equal(v, []byte(path)) {
+			if tsInCache := time.Unix(0, btoi(k)); tsInCache.After(ts) && !found {
+				found = true
+				continue
+			}
+			err := c.Delete()
+			if err != nil {
+				fs.Debugf(path, "failed to clean object: %v", err)
+			}
+		}
+	}
+	if found {
+		return
+	}
+
+	err := tsBucket.Put(itob(ts.UnixNano()), []byte(path))
+	if err != nil {
+		fs.Debugf(path, "failed to timestamp chunk: %v", err)
+	}
+}
+
+// AddDir will update a CachedDirectory metadata and all its entries
+func (b *Persistent) AddDir(cachedDir *Directory) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(cachedDir.abs(), true, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open bucket (%v)", cachedDir)
+		}
+
+		encoded, err := json.Marshal(cachedDir)
+		if err != nil {
+			return errors.Errorf("couldn't marshal object (%v): %v", cachedDir, err)
+		}
+		err = bucket.Put([]byte("."), encoded)
+		if err != nil {
+			return err
+		}
+
+		b.updateRootTs(tx, cachedDir.abs(), cachedDir.CacheFs.fileAge)
+		return nil
+	})
+}
+
+// GetDirEntries will return a CachedDirectory, its list of dir entries and/or an error if it encountered issues
+func (b *Persistent) GetDirEntries(cachedDir *Directory) (fs.DirEntries, error) {
+	var dirEntries fs.DirEntries
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(cachedDir.abs(), false, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open bucket (%v)", cachedDir.abs())
+		}
+
+		val := bucket.Get([]byte("."))
+		if val != nil {
+			err := json.Unmarshal(val, cachedDir)
+			if err != nil {
+				fs.Debugf(cachedDir.abs(), "error during unmarshalling obj: %v", err)
+			}
+		} else {
+			return errors.Errorf("missing cached dir: %v", cachedDir)
+		}
+
+		c := bucket.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			// ignore metadata key: .
+			if bytes.Equal(k, []byte(".")) {
+				continue
+			}
+			entryPath := path.Join(cachedDir.Remote(), string(k))
+
+			if v == nil { // directory
+				// we try to find a cached meta for the dir
+				currentBucket := c.Bucket().Bucket(k)
+				if currentBucket == nil {
+					return errors.Errorf("couldn't open bucket (%v)", string(k))
+				}
+
+				metaKey := currentBucket.Get([]byte("."))
+				d := NewDirectory(cachedDir.CacheFs, entryPath)
+				if metaKey != nil { //if we don't find it, we create an empty dir
+					err := json.Unmarshal(metaKey, d)
+					if err != nil { // if even this fails, we fallback to an empty dir
+						fs.Debugf(string(k), "error during unmarshalling obj: %v", err)
+					}
+				}
+
+				dirEntries = append(dirEntries, d)
+			} else { // object
+				o := NewObject(cachedDir.CacheFs, entryPath)
+				err := json.Unmarshal(v, o)
+				if err != nil {
+					fs.Debugf(string(k), "error during unmarshalling obj: %v", err)
+					continue
+				}
+
+				dirEntries = append(dirEntries, o)
+			}
+		}
+
+		return nil
+	})
+
+	return dirEntries, err
+}
+
+// RemoveDir will delete a CachedDirectory, all its objects and all the chunks stored for it
+func (b *Persistent) RemoveDir(fp string) error {
+	err := b.ExpireDir(fp)
+
+	// delete chunks on disk
+	// safe to ignore as the files might not have been open
+	if err != nil {
+		_ = os.RemoveAll(path.Join(b.dataPath, fp))
+	}
+
+	return nil
+}
+
+// ExpireDir will flush a CachedDirectory and all its objects from the objects
+// chunks will remain as they are
+func (b *Persistent) ExpireDir(fp string) error {
+	parentDir, dirName := path.Split(fp)
+	if fp == "" {
+		return b.db.Update(func(tx *bolt.Tx) error {
+			err := tx.DeleteBucket([]byte(RootBucket))
+			if err != nil {
+				fs.Debugf(fp, "couldn't delete from cache: %v", err)
+				return err
+			}
+			err = tx.DeleteBucket([]byte(RootTsBucket))
+			if err != nil {
+				fs.Debugf(fp, "couldn't delete from cache: %v", err)
+				return err
+			}
+			_, _ = tx.CreateBucketIfNotExists([]byte(RootBucket))
+			_, _ = tx.CreateBucketIfNotExists([]byte(RootTsBucket))
+			return nil
+		})
+	}
+
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(cleanPath(parentDir), false, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open bucket (%v)", fp)
+		}
+		// delete the cached dir
+		err := bucket.DeleteBucket([]byte(cleanPath(dirName)))
+		if err != nil {
+			fs.Debugf(fp, "couldn't delete from cache: %v", err)
+		}
+		return nil
+	})
+}
+
+// GetObject will return a CachedObject from its parent directory or an error if it doesn't find it
+func (b *Persistent) GetObject(cachedObject *Object) (err error) {
+	return b.db.View(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(cachedObject.Dir, false, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open parent bucket for %v", cachedObject.Dir)
+		}
+		val := bucket.Get([]byte(cachedObject.Name))
+		if val != nil {
+			return json.Unmarshal(val, cachedObject)
+		}
+		return errors.Errorf("couldn't find object (%v)", cachedObject.Name)
+	})
+}
+
+// AddObject will create a cached object in its parent directory
+func (b *Persistent) AddObject(cachedObject *Object) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(cachedObject.Dir, true, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open parent bucket for %v", cachedObject)
+		}
+		// cache Object Info
+		encoded, err := json.Marshal(cachedObject)
+		if err != nil {
+			return errors.Errorf("couldn't marshal object (%v) info: %v", cachedObject, err)
+		}
+		err = bucket.Put([]byte(cachedObject.Name), []byte(encoded))
+		if err != nil {
+			return errors.Errorf("couldn't cache object (%v) info: %v", cachedObject, err)
+		}
+		b.updateRootTs(tx, cachedObject.abs(), cachedObject.CacheFs.fileAge)
+		return nil
+	})
+}
+
+// RemoveObject will delete a single cached object and all the chunks which belong to it
+func (b *Persistent) RemoveObject(fp string) error {
+	parentDir, objName := path.Split(fp)
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(cleanPath(parentDir), false, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open parent bucket for %v", cleanPath(parentDir))
+		}
+		err := bucket.Delete([]byte(cleanPath(objName)))
+		if err != nil {
+			fs.Debugf(fp, "couldn't delete obj from storage: %v", err)
+		}
+		// delete chunks on disk
+		// safe to ignore as the file might not have been open
+		_ = os.RemoveAll(path.Join(b.dataPath, fp))
+		return nil
+	})
+}
+
+// HasEntry confirms the existence of a single entry (dir or object)
+func (b *Persistent) HasEntry(remote string) bool {
+	dir, name := path.Split(remote)
+	dir = cleanPath(dir)
+	name = cleanPath(name)
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		bucket := b.getBucket(dir, false, tx)
+		if bucket == nil {
+			return errors.Errorf("couldn't open parent bucket for %v", remote)
+		}
+		if f := bucket.Bucket([]byte(name)); f != nil {
+			return nil
+		}
+		if f := bucket.Get([]byte(name)); f != nil {
+			return nil
+		}
+
+		return errors.Errorf("couldn't find object (%v)", remote)
+	})
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+// HasChunk confirms the existence of a single chunk of an object
+func (b *Persistent) HasChunk(cachedObject *Object, offset int64) bool {
+	fp := path.Join(b.dataPath, cachedObject.abs(), strconv.FormatInt(offset, 10))
+	if _, err := os.Stat(fp); !os.IsNotExist(err) {
+		return true
+	}
+	return false
+}
+
+// GetChunk will retrieve a single chunk which belongs to a cached object or an error if it doesn't find it
+func (b *Persistent) GetChunk(cachedObject *Object, offset int64) ([]byte, error) {
+	p := cachedObject.abs()
+	var data []byte
+
+	fp := path.Join(b.dataPath, cachedObject.abs(), strconv.FormatInt(offset, 10))
+	data, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	d := cachedObject.CacheFs.chunkAge
+	if cachedObject.CacheFs.InWarmUp() {
+		d = cachedObject.CacheFs.metaAge
+	}
+
+	err = b.db.Update(func(tx *bolt.Tx) error {
+		b.updateChunkTs(tx, p, offset, d)
+		return nil
+	})
+
+	return data, err
+}
+
+// AddChunk adds a new chunk of a cached object
+func (b *Persistent) AddChunk(cachedObject *Object, data []byte, offset int64) error {
+	t := cachedObject.CacheFs.chunkAge
+	if cachedObject.CacheFs.InWarmUp() {
+		t = cachedObject.CacheFs.metaAge
+	}
+	return b.AddChunkAhead(cachedObject.abs(), data, offset, t)
+}
+
+// AddChunkAhead adds a new chunk before caching an Object for it
+// see fs.cacheWrites
+func (b *Persistent) AddChunkAhead(fp string, data []byte, offset int64, t time.Duration) error {
+	_ = os.MkdirAll(path.Join(b.dataPath, fp), os.ModePerm)
+
+	filePath := path.Join(b.dataPath, fp, strconv.FormatInt(offset, 10))
+	err := ioutil.WriteFile(filePath, data, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	return b.db.Update(func(tx *bolt.Tx) error {
+		b.updateChunkTs(tx, fp, offset, t)
+		return nil
+	})
+}
+
+// CleanChunksByAge will cleanup on a cron basis
+func (b *Persistent) CleanChunksByAge(chunkAge time.Duration) {
+	b.cleanupMux.Lock()
+	defer b.cleanupMux.Unlock()
+	var cntChunks int
+
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		min := itob(0)
+		max := itob(time.Now().UnixNano())
+
+		dataTsBucket := tx.Bucket([]byte(DataTsBucket))
+		if dataTsBucket == nil {
+			return errors.Errorf("Couldn't open (%v) bucket", DataTsBucket)
+		}
+		// iterate through ts
+		c := dataTsBucket.Cursor()
+		for k, v := c.Seek(min); k != nil && bytes.Compare(k, max) <= 0; k, v = c.Next() {
+			if v == nil {
+				continue
+			}
+			// split to get (abs path - offset)
+			val := string(v[:])
+			sepIdx := strings.LastIndex(val, "-")
+			pathCmp := val[:sepIdx]
+			offsetCmp := val[sepIdx+1:]
+
+			// delete this ts entry
+			err := c.Delete()
+			if err != nil {
+				fs.Errorf(pathCmp, "failed deleting chunk ts during cleanup (%v): %v", val, err)
+				continue
+			}
+
+			err = os.Remove(path.Join(b.dataPath, pathCmp, offsetCmp))
+			if err == nil {
+				cntChunks = cntChunks + 1
+			}
+		}
+		fs.Infof("cache", "deleted (%v) chunks", cntChunks)
+		return nil
+	})
+
+	if err != nil {
+		fs.Errorf("cache", "cleanup failed: %v", err)
+	}
+}
+
+// CleanEntriesByAge will cleanup on a cron basis
+func (b *Persistent) CleanEntriesByAge(entryAge time.Duration) {
+	b.cleanupMux.Lock()
+	defer b.cleanupMux.Unlock()
+	var cntEntries int
+
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		min := itob(0)
+		max := itob(time.Now().UnixNano())
+
+		rootTsBucket := tx.Bucket([]byte(RootTsBucket))
+		if rootTsBucket == nil {
+			return errors.Errorf("Couldn't open (%v) bucket", rootTsBucket)
+		}
+		// iterate through ts
+		c := rootTsBucket.Cursor()
+		for k, v := c.Seek(min); k != nil && bytes.Compare(k, max) <= 0; k, v = c.Next() {
+			if v == nil {
+				continue
+			}
+			// get the path
+			absPath := string(v)
+			absDir, absName := path.Split(absPath)
+
+			// delete this ts entry
+			err := c.Delete()
+			if err != nil {
+				fs.Errorf(absPath, "failed deleting object during cleanup: %v", err)
+				continue
+			}
+
+			// search for the entry in the root bucket, skip it if it's not found
+			parentBucket := b.getBucket(cleanPath(absDir), false, tx)
+			if parentBucket == nil {
+				continue
+			}
+			_ = parentBucket.Delete([]byte(cleanPath(absName)))
+			cntEntries = cntEntries + 1
+		}
+		fs.Infof("cache", "deleted (%v) entries", cntEntries)
+		return nil
+	})
+
+	if err != nil {
+		fs.Errorf("cache", "cleanup failed: %v", err)
+	}
+}
+
+// CleanChunksByNeed is a noop for this implementation
+func (b *Persistent) CleanChunksByNeed(offset int64) {
+	// noop: we want to clean a Bolt DB by time only
+}
+
+// Stats returns a go map with the stats key values
+func (b *Persistent) Stats() (map[string]map[string]interface{}, error) {
+	r := make(map[string]map[string]interface{})
+	r["data"] = make(map[string]interface{})
+	r["data"]["oldest-ts"] = time.Now()
+	r["data"]["oldest-file"] = ""
+	r["data"]["newest-ts"] = time.Now()
+	r["data"]["newest-file"] = ""
+	r["data"]["total-chunks"] = 0
+	r["files"] = make(map[string]interface{})
+	r["files"]["oldest-ts"] = time.Now()
+	r["files"]["oldest-name"] = ""
+	r["files"]["newest-ts"] = time.Now()
+	r["files"]["newest-name"] = ""
+	r["files"]["total-files"] = 0
+
+	_ = b.db.View(func(tx *bolt.Tx) error {
+		dataTsBucket := tx.Bucket([]byte(DataTsBucket))
+		rootTsBucket := tx.Bucket([]byte(RootTsBucket))
+
+		var totalDirs int
+		var totalFiles int
+		_ = b.iterateBuckets(tx.Bucket([]byte(RootBucket)), func(name string) {
+			totalDirs++
+		}, func(key string, val []byte) {
+			totalFiles++
+		})
+		r["files"]["total-dir"] = totalDirs
+		r["files"]["total-files"] = totalFiles
+
+		c := dataTsBucket.Cursor()
+		if k, v := c.First(); k != nil {
+			// split to get (abs path - offset)
+			val := string(v[:])
+			p := val[:strings.LastIndex(val, "-")]
+			r["data"]["oldest-ts"] = time.Unix(0, btoi(k))
+			r["data"]["oldest-file"] = p
+		}
+		if k, v := c.Last(); k != nil {
+			// split to get (abs path - offset)
+			val := string(v[:])
+			p := val[:strings.LastIndex(val, "-")]
+			r["data"]["newest-ts"] = time.Unix(0, btoi(k))
+			r["data"]["newest-file"] = p
+		}
+
+		c = rootTsBucket.Cursor()
+		if k, v := c.First(); k != nil {
+			// split to get (abs path - offset)
+			r["files"]["oldest-ts"] = time.Unix(0, btoi(k))
+			r["files"]["oldest-name"] = string(v)
+		}
+		if k, v := c.Last(); k != nil {
+			r["files"]["newest-ts"] = time.Unix(0, btoi(k))
+			r["files"]["newest-name"] = string(v)
+		}
+
+		return nil
+	})
+
+	return r, nil
+}
+
+// Purge will flush the entire cache
+func (b *Persistent) Purge() {
+	_ = b.db.Update(func(tx *bolt.Tx) error {
+		_ = tx.DeleteBucket([]byte(RootBucket))
+		_ = tx.DeleteBucket([]byte(RootTsBucket))
+		_ = tx.DeleteBucket([]byte(DataTsBucket))
+
+		_, _ = tx.CreateBucketIfNotExists([]byte(RootBucket))
+		_, _ = tx.CreateBucketIfNotExists([]byte(RootTsBucket))
+		_, _ = tx.CreateBucketIfNotExists([]byte(DataTsBucket))
+
+		return nil
+	})
+
+	err := os.RemoveAll(b.dataPath)
+	if err != nil {
+		fs.Errorf(b, "issue removing data folder: %v", err)
+	}
+	err = os.MkdirAll(b.dataPath, os.ModePerm)
+	if err != nil {
+		fs.Errorf(b, "issue removing data folder: %v", err)
+	}
+}
+
+// GetChunkTs retrieves the current timestamp of this chunk
+func (b *Persistent) GetChunkTs(path string, offset int64) (time.Time, error) {
+	var t time.Time
+	tsVal := path + "-" + strconv.FormatInt(offset, 10)
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		tsBucket := tx.Bucket([]byte(DataTsBucket))
+		c := tsBucket.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if bytes.Equal(v, []byte(tsVal)) {
+				t = time.Unix(0, btoi(k))
+				return nil
+			}
+		}
+		return errors.Errorf("not found %v-%v", path, offset)
+	})
+
+	return t, err
+}
+
+// GetRootTs retrieves the current timestamp of an object or dir
+func (b *Persistent) GetRootTs(path string) (time.Time, error) {
+	var t time.Time
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		tsBucket := tx.Bucket([]byte(RootTsBucket))
+		c := tsBucket.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if bytes.Equal(v, []byte(path)) {
+				t = time.Unix(0, btoi(k))
+				return nil
+			}
+		}
+		return errors.Errorf("not found %v", path)
+	})
+
+	return t, err
+}
+
+func (b *Persistent) iterateBuckets(buk *bolt.Bucket, bucketFn func(name string), kvFn func(key string, val []byte)) error {
+	err := b.db.View(func(tx *bolt.Tx) error {
+		var c *bolt.Cursor
+		if buk == nil {
+			c = tx.Cursor()
+		} else {
+			c = buk.Cursor()
+		}
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if v == nil {
+				var buk2 *bolt.Bucket
+				if buk == nil {
+					buk2 = tx.Bucket(k)
+				} else {
+					buk2 = buk.Bucket(k)
+				}
+
+				bucketFn(string(k))
+				_ = b.iterateBuckets(buk2, bucketFn, kvFn)
+			} else {
+				kvFn(string(k), v)
+			}
+		}
+		return nil
+	})
+
+	return err
+}
+
+// itob returns an 8-byte big endian representation of v.
+func itob(v int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}
+
+func btoi(d []byte) int64 {
+	return int64(binary.BigEndian.Uint64(d))
+}
+
+// cloneBytes returns a copy of a given slice.
+func cloneBytes(v []byte) []byte {
+	var clone = make([]byte, len(v))
+	copy(clone, v)
+	return clone
+}

--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -5,6 +5,7 @@ import (
 	// Active commands
 	_ "github.com/ncw/rclone/cmd"
 	_ "github.com/ncw/rclone/cmd/authorize"
+	_ "github.com/ncw/rclone/cmd/cachestats"
 	_ "github.com/ncw/rclone/cmd/cat"
 	_ "github.com/ncw/rclone/cmd/check"
 	_ "github.com/ncw/rclone/cmd/cleanup"

--- a/cmd/cachestats/cachestats.go
+++ b/cmd/cachestats/cachestats.go
@@ -1,0 +1,61 @@
+// +build !plan9
+
+package cachestats
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ncw/rclone/cache"
+	"github.com/ncw/rclone/cmd"
+	"github.com/ncw/rclone/fs"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd.Root.AddCommand(commandDefinition)
+}
+
+var commandDefinition = &cobra.Command{
+	Use:   "cachestats source:",
+	Short: `Print cache stats for a remote`,
+	Long: `
+Print cache stats for a remote in JSON format
+`,
+	Run: func(command *cobra.Command, args []string) {
+		cmd.CheckArgs(1, 1, command, args)
+
+		_, configName, _, err := fs.ParseRemote(args[0])
+		if err != nil {
+			fs.Errorf("cachestats", "%s", err.Error())
+			return
+		}
+
+		if !fs.ConfigFileGetBool(configName, "read_only", false) {
+			fs.ConfigFileSet(configName, "read_only", "true")
+			defer fs.ConfigFileDeleteKey(configName, "read_only")
+		}
+
+		fsrc := cmd.NewFsSrc(args)
+		cmd.Run(true, true, command, func() error {
+			var fsCache *cache.Fs
+			fsCache, ok := fsrc.(*cache.Fs)
+			if !ok {
+				fsCache, ok = fsrc.Features().UnWrap().(*cache.Fs)
+				if !ok {
+					return errors.Errorf("%s: is not a cache remote", fsrc.Name())
+				}
+			}
+			m, err := fsCache.Stats()
+
+			raw, err := json.MarshalIndent(m, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s\n", string(raw))
+			return nil
+		})
+	},
+}

--- a/cmd/cachestats/cachestats_unsupported.go
+++ b/cmd/cachestats/cachestats_unsupported.go
@@ -1,0 +1,6 @@
+// Build for cache for unsupported platforms to stop go complaining
+// about "no buildable Go source files "
+
+// +build plan9
+
+package cachestats

--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -55,6 +55,7 @@ Features
   * [Check](/commands/rclone_check/) mode to check for file hash equality
   * Can sync to and from network, eg two different cloud accounts
   * Optional encryption ([Crypt](/crypt/))
+  * Optional cache ([Cache](/cache/))
   * Optional FUSE mount ([rclone mount](/commands/rclone_mount/))
 
 Links

--- a/docs/content/cache.md
+++ b/docs/content/cache.md
@@ -1,0 +1,309 @@
+---
+title: "Cache"
+description: "Rclone docs for cache remote"
+date: "2017-09-03"
+---
+
+<i class="fa fa-archive"></i> Cache
+-----------------------------------------
+
+The `cache` remote wraps another existing remote and stores file structure
+and its data for long running tasks like `rclone mount`.
+
+To get started you just need to have an existing remote which can be configured
+with `cache`.
+
+Here is an example of how to make a remote called `test-cache`.  First run:
+
+     rclone config
+
+This will guide you through an interactive setup process:
+
+```
+No remotes found - make a new one
+n) New remote
+r) Rename remote
+c) Copy remote
+s) Set configuration password
+q) Quit config
+n/r/c/s/q> n
+name> remote
+Type of storage to configure.
+Choose a number from below, or type in your own value
+...
+ 5 / Cache a remote
+   \ "cache"
+...
+Storage> 5
+Remote to cache.
+Normally should contain a ':' and a path, eg "myremote:path/to/dir",
+"myremote:bucket" or maybe "myremote:" (not recommended).
+remote> local:/test
+The size of a chunk. Lower value good for slow connections but can affect seamless reading.
+Default: 5M
+Choose a number from below, or type in your own value
+ 1 / 1MB
+   \ "1m"
+ 2 / 5 MB
+   \ "5M"
+ 3 / 10 MB
+   \ "10M"
+chunk_size> 2
+How much time should object info (file size, file hashes etc) be stored in cache. Use a very high value if you don't plan on changing the source FS from outside the cache.
+Accepted units are: "s", "m", "h".
+Default: 5m
+Choose a number from below, or type in your own value
+ 1 / 1 hour
+   \ "1h"
+ 2 / 24 hours
+   \ "24h"
+ 3 / 24 hours
+   \ "48h"
+info_age> 2
+How much time should a chunk (file data) be stored in cache.
+Accepted units are: "s", "m", "h".
+Default: 3h
+Choose a number from below, or type in your own value
+ 1 / 30 seconds
+   \ "30s"
+ 2 / 1 minute
+   \ "1m"
+ 3 / 1 hour and 30 minutes
+   \ "1h30m"
+chunk_age> 3h
+How much time should data be cached during warm up.
+Accepted units are: "s", "m", "h".
+Default: 24h
+Choose a number from below, or type in your own value
+ 1 / 3 hours
+   \ "3h"
+ 2 / 6 hours
+   \ "6h"
+ 3 / 24 hours
+   \ "24h"
+warmup_age> 3
+Remote config
+--------------------
+[test-cache]
+remote = local:/test
+chunk_size = 5M
+info_age = 24h
+chunk_age = 3h
+warmup_age = 24h
+```
+
+You can then use it like this,
+
+List directories in top level of your drive
+
+    rclone lsd test-cache:
+
+List all the files in your drive
+
+    rclone ls test-cache:
+
+To start a cached mount
+
+    rclone mount --allow-other test-cache: /var/tmp/test-cache
+
+### Write Support ###
+
+Writes are supported through `cache`.
+One caveat is that a mounted cache remote does not add any retry or fallback
+mechanism to the upload operation. This will depend on the implementation
+of the wrapped remote.
+
+One special case is covered with `cache-writes` which will cache the file
+data at the same time as the upload when it is enabled making it available
+from the cache store immediately once the upload is finished.
+
+### Read Features ###
+
+#### Multiple connections ####
+
+To counter the high latency between a local PC where rclone is running
+and cloud providers, the cache remote can split multiple requests to the
+cloud provider for smaller file chunks and combines them together locally
+where they can be available almost immediately before the reader usually
+needs them.
+This is similar to buffering when media files are played online. Rclone
+will stay around the current marker but always try its best to stay ahead
+and prepare the data before.
+
+#### Warmup mode ####
+
+A negative side of running multiple requests on the cloud provider is
+that you can easily reach a limit on how many requests or how much data
+you can download from a cloud provider in a window of time.
+For this reason, a warmup mode is a state where `cache` changes its settings
+to talk less with the cloud provider.
+
+To prevent a ban or a similar action from the cloud provider, `cache` will
+keep track of all the open files and during intensive times when it passes
+a configured threshold, it will change its settings to a warmup mode.
+
+It can also be disabled during single file streaming if `cache` sees that we're
+reading the file in sequence and can go load its parts in advance.
+
+Affected settings:
+- `cache-chunk-no-memory`: _disabled_
+- `cache-workers`: _1_
+- file chunks will now be cached using `cache-warm-up-age` as a duration instead of the
+regular `cache-chunk-age`
+
+### Known issues ###
+
+#### cache and crypt ####
+
+One common scenario is to keep your data encrypted in the cloud provider
+using the `crypt` remote. `crypt` uses a similar technique to wrap around
+an existing remote and handles this translation in a seamless way.
+
+There is an issue with wrapping the remotes in this order:
+<span style="color:red">**cloud remote** -> **crypt** -> **cache**</span>
+
+During testing, I experienced a lot of bans with the remotes in this order.
+I suspect it might be related to how crypt opens files on the cloud provider
+which makes it think we're downloading the full file instead of small chunks.
+Organizing the remotes in this order yelds better results:
+<span style="color:green">**cloud remote** -> **cache** -> **crypt**</span>
+
+### Specific options ###
+
+Here are the command line options specific to this cloud storage
+system.
+
+#### --cache-db-path=PATH ####
+
+Path to where partial file data (chunks) and the file structure metadata 
+are stored locally.
+
+**Default**: <rclone default config path>/<remote name>
+**Example**: ~/.config/rclone/test-cache
+
+#### --cache-db-purge ####
+
+Flag to clear all the cached data for this remote before.
+
+**Default**: not set
+
+#### --cache-chunk-size=SIZE ####
+
+The size of a chunk (partial file data). Use lower numbers for slower
+connections.
+
+**Default**: 5M
+
+#### --cache-info-age=DURATION ####
+
+How long to keep file structure information (directory listings, file size, 
+mod times etc) locally. 
+
+If all write operations are done through `cache` then you can safely make
+this value very large as the cache store will also be updated in real time.
+
+**Default**: 6h
+
+#### --cache-chunk-age=DURATION ####
+
+How long to keep file chunks (partial data) locally. 
+
+Longer durations will result in larger cache stores as data will be cleared
+less often.
+
+**Default**: 3h
+
+#### --cache-warm-up-age=DURATION ####
+
+How long to keep file chunks (partial data) locally during warmup times.
+
+If `cache` goes through intensive read times when it is scanned for information
+then this setting will allow you to customize higher storage times for that
+data. Otherwise, it's safe to keep the same value as `cache-chunk-age`.
+
+**Default**: 3h
+
+#### --cache-read-retries=RETRIES ####
+
+How many times to retry a read from a cache storage.
+
+Since reading from a `cache` stream is independent from downloading file data, 
+readers can get to a point where there's no more data in the cache. 
+Most of the times this can indicate a connectivity issue if `cache` isn't
+able to provide file data anymore.
+
+For really slow connections, increase this to a point where the stream is
+able to provide data but your experience will be very stuttering. 
+
+**Default**: 3
+
+#### --cache-workers=WORKERS ####
+
+How many workers should run in parallel to download chunks.
+
+Higher values will mean more parallel processing (better CPU needed) and
+more concurrent requests on the cloud provider. 
+This impacts several aspects like the cloud provider API limits, more stress
+on the hardware that rclone runs on but it also means that streams will 
+be more fluid and data will be available much more faster to readers.
+
+**Default**: 4
+
+#### --cache-chunk-no-memory ####
+
+By default, `cache` will keep file data during streaming in RAM as well
+to provide it to readers as fast as possible.
+
+This transient data is evicted as soon as it is read and the number of
+chunks stored doesn't exceed the number of workers. However, depending
+on other settings like `cache-chunk-size` and `cache-workers` this footprint
+can increase if there are parallel streams too (multiple files being read
+at the same time).
+
+If the hardware permits it, use this feature to provide an overall better
+performance during streaming but it can also be disabled if RAM is not
+available on the local machine.
+
+**Default**: not set
+
+#### --cache-rps=NUMBER ####
+
+Some of the rclone remotes that `cache` will wrap have back-off or limits
+in place to not reach cloud provider limits. This is similar to that.
+It places a hard limit on the number of requests per second that `cache`
+will be doing to the cloud provider remote and try to respect that value
+by setting waits between reads.
+
+If you find that you're getting banned or limited on the cloud provider
+through cache and know that a smaller number of requests per second will
+allow you to work with it then you can use this setting for that.
+
+A good balance of all the other settings and warmup times should make this
+setting useless but it is available to set for more special cases.
+
+**NOTE**: This will limit the number of requests during streams but other
+API calls to the cloud provider like directory listings will still pass.
+
+**Default**: 4
+
+#### --cache-warm-up-rps=RATE/SECONDS ####
+
+This setting allows `cache` to change its settings for warmup mode or revert
+back from it.
+
+`cache` keeps track of all open files and when there are `RATE` files open
+during `SECONDS` window of time reached it will activate warmup and change
+its settings as explained in the `Warmup mode` section.
+
+When the number of files being open goes under `RATE` in the same amount
+of time, `cache` will disable this mode.
+
+**Default**: 3/20
+
+#### --cache-writes ####
+
+If you need to read files immediately after you upload them through `cache`
+you can enable this flag to have their data stored in the cache store at the
+same time during upload.
+
+**Default**: not set

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -23,6 +23,7 @@ See the following for detailed instructions for
   * [Amazon S3](/s3/)
   * [Backblaze B2](/b2/)
   * [Box](/box/)
+  * [Cache](/cache/)
   * [Crypt](/crypt/) - to encrypt other remotes
   * [DigitalOcean Spaces](/s3/#digitalocean-spaces)
   * [Dropbox](/dropbox/)

--- a/docs/layouts/chrome/navbar.html
+++ b/docs/layouts/chrome/navbar.html
@@ -53,6 +53,7 @@
                     <li><a href="/s3/"><i class="fa fa-amazon"></i> Amazon S3</a></li>
                     <li><a href="/b2/"><i class="fa fa-fire"></i> Backblaze B2</a></li>
                     <li><a href="/box/"><i class="fa fa-archive"></i> Box</a></li>
+                    <li><a href="/cache/"><i class="fa fa-archive"></i> Cache</a></li>
                     <li><a href="/crypt/"><i class="fa fa-lock"></i> Crypt (encrypts the others)</a></li>
                     <li><a href="/dropbox/"><i class="fa fa-dropbox"></i> Dropbox</a></li>
                     <li><a href="/ftp/"><i class="fa fa-file"></i> FTP</a></li>

--- a/fs/all/all.go
+++ b/fs/all/all.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/ncw/rclone/azureblob"
 	_ "github.com/ncw/rclone/b2"
 	_ "github.com/ncw/rclone/box"
+	_ "github.com/ncw/rclone/cache"
 	_ "github.com/ncw/rclone/crypt"
 	_ "github.com/ncw/rclone/drive"
 	_ "github.com/ncw/rclone/dropbox"

--- a/fs/test_all.go
+++ b/fs/test_all.go
@@ -123,6 +123,11 @@ var (
 			SubDir:   false,
 			FastList: false,
 		},
+		{
+			Name:     "TestCache:",
+			SubDir:   true,
+			FastList: true,
+		},
 	}
 	binary = "fs.test"
 	// Flags

--- a/fstest/fstests/gen_tests.go
+++ b/fstest/fstests/gen_tests.go
@@ -66,7 +66,7 @@ import (
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 	"github.com/ncw/rclone/{{ .FsName }}"
-{{ if eq .FsName "crypt" }}	_ "github.com/ncw/rclone/local"
+{{ if (or (eq .FsName "crypt") (eq .FsName "cache")) }}	_ "github.com/ncw/rclone/local"
 {{end}})
 
 func TestSetup{{ .Suffix }}(t *testing.T)() {
@@ -166,5 +166,6 @@ func main() {
 	generateTestProgram(t, fns, "AzureBlob", buildConstraint("go1.7"))
 	generateTestProgram(t, fns, "Pcloud")
 	generateTestProgram(t, fns, "Webdav")
+	generateTestProgram(t, fns, "Cache", buildConstraint("!plan9"))
 	log.Printf("Done")
 }

--- a/vendor/github.com/coreos/bbolt/.gitignore
+++ b/vendor/github.com/coreos/bbolt/.gitignore
@@ -1,0 +1,4 @@
+*.prof
+*.test
+*.swp
+/bin/

--- a/vendor/github.com/coreos/bbolt/LICENSE
+++ b/vendor/github.com/coreos/bbolt/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/coreos/bbolt/Makefile
+++ b/vendor/github.com/coreos/bbolt/Makefile
@@ -1,0 +1,27 @@
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+COMMIT=`git rev-parse --short HEAD`
+GOLDFLAGS="-X main.branch $(BRANCH) -X main.commit $(COMMIT)"
+
+default: build
+
+race:
+	@go test -v -race -test.run="TestSimulate_(100op|1000op)"
+
+# go get honnef.co/go/tools/simple
+# go get honnef.co/go/tools/unused
+fmt:
+	gosimple ./...
+	unused ./...
+	gofmt -l -s -d $(find -name \*.go)
+
+
+# go get github.com/kisielk/errcheck
+errcheck:
+	@errcheck -ignorepkg=bytes -ignore=os:Remove github.com/coreos/bbolt
+
+test:
+	go test -timeout 20m -v -coverprofile cover.out -covermode atomic
+	# Note: gets "program not an importable package" in out of path builds
+	go test -v ./cmd/bolt
+
+.PHONY: race fmt errcheck test

--- a/vendor/github.com/coreos/bbolt/README.md
+++ b/vendor/github.com/coreos/bbolt/README.md
@@ -1,0 +1,927 @@
+bbolt
+====
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/coreos/bbolt?style=flat-square)](https://goreportcard.com/report/github.com/coreos/bbolt)
+[![Coverage](https://codecov.io/gh/coreos/bbolt/branch/master/graph/badge.svg)](https://codecov.io/gh/coreos/bbolt)
+[![Godoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/coreos/bbolt)
+
+bbolt is a fork of [Ben Johnson's][gh_ben] moribund [Bolt][bolt] key/value
+store. The purpose of this fork is to provide the Go community with an active
+maintenance and development target for Bolt; the goal is improved reliability
+and stability. bbolt includes bug fixes, performance enhancements, and features
+not found in Bolt while preserving backwards compatibility with the Bolt API.
+
+Bolt is a pure Go key/value store inspired by [Howard Chu's][hyc_symas]
+[LMDB project][lmdb]. The goal of the project is to provide a simple,
+fast, and reliable database for projects that don't require a full database
+server such as Postgres or MySQL.
+
+Since Bolt is meant to be used as such a low-level piece of functionality,
+simplicity is key. The API will be small and only focus on getting values
+and setting values. That's it.
+
+[gh_ben]: https://github.com/benbjohnson
+[bolt]: https://github.com/boltdb/bolt
+[hyc_symas]: https://twitter.com/hyc_symas
+[lmdb]: http://symas.com/mdb/
+
+## Project Status
+
+Bolt is stable, the API is fixed, and the file format is fixed. Full unit
+test coverage and randomized black box testing are used to ensure database
+consistency and thread safety. Bolt is currently used in high-load production
+environments serving databases as large as 1TB. Many companies such as
+Shopify and Heroku use Bolt-backed services every day.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+  - [Installing](#installing)
+  - [Opening a database](#opening-a-database)
+  - [Transactions](#transactions)
+    - [Read-write transactions](#read-write-transactions)
+    - [Read-only transactions](#read-only-transactions)
+    - [Batch read-write transactions](#batch-read-write-transactions)
+    - [Managing transactions manually](#managing-transactions-manually)
+  - [Using buckets](#using-buckets)
+  - [Using key/value pairs](#using-keyvalue-pairs)
+  - [Autoincrementing integer for the bucket](#autoincrementing-integer-for-the-bucket)
+  - [Iterating over keys](#iterating-over-keys)
+    - [Prefix scans](#prefix-scans)
+    - [Range scans](#range-scans)
+    - [ForEach()](#foreach)
+  - [Nested buckets](#nested-buckets)
+  - [Database backups](#database-backups)
+  - [Statistics](#statistics)
+  - [Read-Only Mode](#read-only-mode)
+  - [Mobile Use (iOS/Android)](#mobile-use-iosandroid)
+- [Resources](#resources)
+- [Comparison with other databases](#comparison-with-other-databases)
+  - [Postgres, MySQL, & other relational databases](#postgres-mysql--other-relational-databases)
+  - [LevelDB, RocksDB](#leveldb-rocksdb)
+  - [LMDB](#lmdb)
+- [Caveats & Limitations](#caveats--limitations)
+- [Reading the Source](#reading-the-source)
+- [Other Projects Using Bolt](#other-projects-using-bolt)
+
+## Getting Started
+
+### Installing
+
+To start using Bolt, install Go and run `go get`:
+
+```sh
+$ go get github.com/coreos/bbolt/...
+```
+
+This will retrieve the library and install the `bolt` command line utility into
+your `$GOBIN` path.
+
+
+### Opening a database
+
+The top-level object in Bolt is a `DB`. It is represented as a single file on
+your disk and represents a consistent snapshot of your data.
+
+To open your database, simply use the `bolt.Open()` function:
+
+```go
+package main
+
+import (
+	"log"
+
+	bolt "github.com/coreos/bbolt"
+)
+
+func main() {
+	// Open the my.db data file in your current directory.
+	// It will be created if it doesn't exist.
+	db, err := bolt.Open("my.db", 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	...
+}
+```
+
+Please note that Bolt obtains a file lock on the data file so multiple processes
+cannot open the same database at the same time. Opening an already open Bolt
+database will cause it to hang until the other process closes it. To prevent
+an indefinite wait you can pass a timeout option to the `Open()` function:
+
+```go
+db, err := bolt.Open("my.db", 0600, &bolt.Options{Timeout: 1 * time.Second})
+```
+
+
+### Transactions
+
+Bolt allows only one read-write transaction at a time but allows as many
+read-only transactions as you want at a time. Each transaction has a consistent
+view of the data as it existed when the transaction started.
+
+Individual transactions and all objects created from them (e.g. buckets, keys)
+are not thread safe. To work with data in multiple goroutines you must start
+a transaction for each one or use locking to ensure only one goroutine accesses
+a transaction at a time. Creating transaction from the `DB` is thread safe.
+
+Read-only transactions and read-write transactions should not depend on one
+another and generally shouldn't be opened simultaneously in the same goroutine.
+This can cause a deadlock as the read-write transaction needs to periodically
+re-map the data file but it cannot do so while a read-only transaction is open.
+
+
+#### Read-write transactions
+
+To start a read-write transaction, you can use the `DB.Update()` function:
+
+```go
+err := db.Update(func(tx *bolt.Tx) error {
+	...
+	return nil
+})
+```
+
+Inside the closure, you have a consistent view of the database. You commit the
+transaction by returning `nil` at the end. You can also rollback the transaction
+at any point by returning an error. All database operations are allowed inside
+a read-write transaction.
+
+Always check the return error as it will report any disk failures that can cause
+your transaction to not complete. If you return an error within your closure
+it will be passed through.
+
+
+#### Read-only transactions
+
+To start a read-only transaction, you can use the `DB.View()` function:
+
+```go
+err := db.View(func(tx *bolt.Tx) error {
+	...
+	return nil
+})
+```
+
+You also get a consistent view of the database within this closure, however,
+no mutating operations are allowed within a read-only transaction. You can only
+retrieve buckets, retrieve values, and copy the database within a read-only
+transaction.
+
+
+#### Batch read-write transactions
+
+Each `DB.Update()` waits for disk to commit the writes. This overhead
+can be minimized by combining multiple updates with the `DB.Batch()`
+function:
+
+```go
+err := db.Batch(func(tx *bolt.Tx) error {
+	...
+	return nil
+})
+```
+
+Concurrent Batch calls are opportunistically combined into larger
+transactions. Batch is only useful when there are multiple goroutines
+calling it.
+
+The trade-off is that `Batch` can call the given
+function multiple times, if parts of the transaction fail. The
+function must be idempotent and side effects must take effect only
+after a successful return from `DB.Batch()`.
+
+For example: don't display messages from inside the function, instead
+set variables in the enclosing scope:
+
+```go
+var id uint64
+err := db.Batch(func(tx *bolt.Tx) error {
+	// Find last key in bucket, decode as bigendian uint64, increment
+	// by one, encode back to []byte, and add new key.
+	...
+	id = newValue
+	return nil
+})
+if err != nil {
+	return ...
+}
+fmt.Println("Allocated ID %d", id)
+```
+
+
+#### Managing transactions manually
+
+The `DB.View()` and `DB.Update()` functions are wrappers around the `DB.Begin()`
+function. These helper functions will start the transaction, execute a function,
+and then safely close your transaction if an error is returned. This is the
+recommended way to use Bolt transactions.
+
+However, sometimes you may want to manually start and end your transactions.
+You can use the `DB.Begin()` function directly but **please** be sure to close
+the transaction.
+
+```go
+// Start a writable transaction.
+tx, err := db.Begin(true)
+if err != nil {
+    return err
+}
+defer tx.Rollback()
+
+// Use the transaction...
+_, err := tx.CreateBucket([]byte("MyBucket"))
+if err != nil {
+    return err
+}
+
+// Commit the transaction and check for error.
+if err := tx.Commit(); err != nil {
+    return err
+}
+```
+
+The first argument to `DB.Begin()` is a boolean stating if the transaction
+should be writable.
+
+
+### Using buckets
+
+Buckets are collections of key/value pairs within the database. All keys in a
+bucket must be unique. You can create a bucket using the `DB.CreateBucket()`
+function:
+
+```go
+db.Update(func(tx *bolt.Tx) error {
+	b, err := tx.CreateBucket([]byte("MyBucket"))
+	if err != nil {
+		return fmt.Errorf("create bucket: %s", err)
+	}
+	return nil
+})
+```
+
+You can also create a bucket only if it doesn't exist by using the
+`Tx.CreateBucketIfNotExists()` function. It's a common pattern to call this
+function for all your top-level buckets after you open your database so you can
+guarantee that they exist for future transactions.
+
+To delete a bucket, simply call the `Tx.DeleteBucket()` function.
+
+
+### Using key/value pairs
+
+To save a key/value pair to a bucket, use the `Bucket.Put()` function:
+
+```go
+db.Update(func(tx *bolt.Tx) error {
+	b := tx.Bucket([]byte("MyBucket"))
+	err := b.Put([]byte("answer"), []byte("42"))
+	return err
+})
+```
+
+This will set the value of the `"answer"` key to `"42"` in the `MyBucket`
+bucket. To retrieve this value, we can use the `Bucket.Get()` function:
+
+```go
+db.View(func(tx *bolt.Tx) error {
+	b := tx.Bucket([]byte("MyBucket"))
+	v := b.Get([]byte("answer"))
+	fmt.Printf("The answer is: %s\n", v)
+	return nil
+})
+```
+
+The `Get()` function does not return an error because its operation is
+guaranteed to work (unless there is some kind of system failure). If the key
+exists then it will return its byte slice value. If it doesn't exist then it
+will return `nil`. It's important to note that you can have a zero-length value
+set to a key which is different than the key not existing.
+
+Use the `Bucket.Delete()` function to delete a key from the bucket.
+
+Please note that values returned from `Get()` are only valid while the
+transaction is open. If you need to use a value outside of the transaction
+then you must use `copy()` to copy it to another byte slice.
+
+
+### Autoincrementing integer for the bucket
+By using the `NextSequence()` function, you can let Bolt determine a sequence
+which can be used as the unique identifier for your key/value pairs. See the
+example below.
+
+```go
+// CreateUser saves u to the store. The new user ID is set on u once the data is persisted.
+func (s *Store) CreateUser(u *User) error {
+    return s.db.Update(func(tx *bolt.Tx) error {
+        // Retrieve the users bucket.
+        // This should be created when the DB is first opened.
+        b := tx.Bucket([]byte("users"))
+
+        // Generate ID for the user.
+        // This returns an error only if the Tx is closed or not writeable.
+        // That can't happen in an Update() call so I ignore the error check.
+        id, _ := b.NextSequence()
+        u.ID = int(id)
+
+        // Marshal user data into bytes.
+        buf, err := json.Marshal(u)
+        if err != nil {
+            return err
+        }
+
+        // Persist bytes to users bucket.
+        return b.Put(itob(u.ID), buf)
+    })
+}
+
+// itob returns an 8-byte big endian representation of v.
+func itob(v int) []byte {
+    b := make([]byte, 8)
+    binary.BigEndian.PutUint64(b, uint64(v))
+    return b
+}
+
+type User struct {
+    ID int
+    ...
+}
+```
+
+### Iterating over keys
+
+Bolt stores its keys in byte-sorted order within a bucket. This makes sequential
+iteration over these keys extremely fast. To iterate over keys we'll use a
+`Cursor`:
+
+```go
+db.View(func(tx *bolt.Tx) error {
+	// Assume bucket exists and has keys
+	b := tx.Bucket([]byte("MyBucket"))
+
+	c := b.Cursor()
+
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		fmt.Printf("key=%s, value=%s\n", k, v)
+	}
+
+	return nil
+})
+```
+
+The cursor allows you to move to a specific point in the list of keys and move
+forward or backward through the keys one at a time.
+
+The following functions are available on the cursor:
+
+```
+First()  Move to the first key.
+Last()   Move to the last key.
+Seek()   Move to a specific key.
+Next()   Move to the next key.
+Prev()   Move to the previous key.
+```
+
+Each of those functions has a return signature of `(key []byte, value []byte)`.
+When you have iterated to the end of the cursor then `Next()` will return a
+`nil` key.  You must seek to a position using `First()`, `Last()`, or `Seek()`
+before calling `Next()` or `Prev()`. If you do not seek to a position then
+these functions will return a `nil` key.
+
+During iteration, if the key is non-`nil` but the value is `nil`, that means
+the key refers to a bucket rather than a value.  Use `Bucket.Bucket()` to
+access the sub-bucket.
+
+
+#### Prefix scans
+
+To iterate over a key prefix, you can combine `Seek()` and `bytes.HasPrefix()`:
+
+```go
+db.View(func(tx *bolt.Tx) error {
+	// Assume bucket exists and has keys
+	c := tx.Bucket([]byte("MyBucket")).Cursor()
+
+	prefix := []byte("1234")
+	for k, v := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
+		fmt.Printf("key=%s, value=%s\n", k, v)
+	}
+
+	return nil
+})
+```
+
+#### Range scans
+
+Another common use case is scanning over a range such as a time range. If you
+use a sortable time encoding such as RFC3339 then you can query a specific
+date range like this:
+
+```go
+db.View(func(tx *bolt.Tx) error {
+	// Assume our events bucket exists and has RFC3339 encoded time keys.
+	c := tx.Bucket([]byte("Events")).Cursor()
+
+	// Our time range spans the 90's decade.
+	min := []byte("1990-01-01T00:00:00Z")
+	max := []byte("2000-01-01T00:00:00Z")
+
+	// Iterate over the 90's.
+	for k, v := c.Seek(min); k != nil && bytes.Compare(k, max) <= 0; k, v = c.Next() {
+		fmt.Printf("%s: %s\n", k, v)
+	}
+
+	return nil
+})
+```
+
+Note that, while RFC3339 is sortable, the Golang implementation of RFC3339Nano does not use a fixed number of digits after the decimal point and is therefore not sortable.
+
+
+#### ForEach()
+
+You can also use the function `ForEach()` if you know you'll be iterating over
+all the keys in a bucket:
+
+```go
+db.View(func(tx *bolt.Tx) error {
+	// Assume bucket exists and has keys
+	b := tx.Bucket([]byte("MyBucket"))
+
+	b.ForEach(func(k, v []byte) error {
+		fmt.Printf("key=%s, value=%s\n", k, v)
+		return nil
+	})
+	return nil
+})
+```
+
+Please note that keys and values in `ForEach()` are only valid while
+the transaction is open. If you need to use a key or value outside of
+the transaction, you must use `copy()` to copy it to another byte
+slice.
+
+### Nested buckets
+
+You can also store a bucket in a key to create nested buckets. The API is the
+same as the bucket management API on the `DB` object:
+
+```go
+func (*Bucket) CreateBucket(key []byte) (*Bucket, error)
+func (*Bucket) CreateBucketIfNotExists(key []byte) (*Bucket, error)
+func (*Bucket) DeleteBucket(key []byte) error
+```
+
+Say you had a multi-tenant application where the root level bucket was the account bucket. Inside of this bucket was a sequence of accounts which themselves are buckets. And inside the sequence bucket you could have many buckets pertaining to the Account itself (Users, Notes, etc) isolating the information into logical groupings.
+
+```go
+
+// createUser creates a new user in the given account.
+func createUser(accountID int, u *User) error {
+    // Start the transaction.
+    tx, err := db.Begin(true)
+    if err != nil {
+        return err
+    }
+    defer tx.Rollback()
+
+    // Retrieve the root bucket for the account.
+    // Assume this has already been created when the account was set up.
+    root := tx.Bucket([]byte(strconv.FormatUint(accountID, 10)))
+
+    // Setup the users bucket.
+    bkt, err := root.CreateBucketIfNotExists([]byte("USERS"))
+    if err != nil {
+        return err
+    }
+
+    // Generate an ID for the new user.
+    userID, err := bkt.NextSequence()
+    if err != nil {
+        return err
+    }
+    u.ID = userID
+
+    // Marshal and save the encoded user.
+    if buf, err := json.Marshal(u); err != nil {
+        return err
+    } else if err := bkt.Put([]byte(strconv.FormatUint(u.ID, 10)), buf); err != nil {
+        return err
+    }
+
+    // Commit the transaction.
+    if err := tx.Commit(); err != nil {
+        return err
+    }
+
+    return nil
+}
+
+```
+
+
+
+
+### Database backups
+
+Bolt is a single file so it's easy to backup. You can use the `Tx.WriteTo()`
+function to write a consistent view of the database to a writer. If you call
+this from a read-only transaction, it will perform a hot backup and not block
+your other database reads and writes.
+
+By default, it will use a regular file handle which will utilize the operating
+system's page cache. See the [`Tx`](https://godoc.org/github.com/coreos/bbolt#Tx)
+documentation for information about optimizing for larger-than-RAM datasets.
+
+One common use case is to backup over HTTP so you can use tools like `cURL` to
+do database backups:
+
+```go
+func BackupHandleFunc(w http.ResponseWriter, req *http.Request) {
+	err := db.View(func(tx *bolt.Tx) error {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="my.db"`)
+		w.Header().Set("Content-Length", strconv.Itoa(int(tx.Size())))
+		_, err := tx.WriteTo(w)
+		return err
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+```
+
+Then you can backup using this command:
+
+```sh
+$ curl http://localhost/backup > my.db
+```
+
+Or you can open your browser to `http://localhost/backup` and it will download
+automatically.
+
+If you want to backup to another file you can use the `Tx.CopyFile()` helper
+function.
+
+
+### Statistics
+
+The database keeps a running count of many of the internal operations it
+performs so you can better understand what's going on. By grabbing a snapshot
+of these stats at two points in time we can see what operations were performed
+in that time range.
+
+For example, we could start a goroutine to log stats every 10 seconds:
+
+```go
+go func() {
+	// Grab the initial stats.
+	prev := db.Stats()
+
+	for {
+		// Wait for 10s.
+		time.Sleep(10 * time.Second)
+
+		// Grab the current stats and diff them.
+		stats := db.Stats()
+		diff := stats.Sub(&prev)
+
+		// Encode stats to JSON and print to STDERR.
+		json.NewEncoder(os.Stderr).Encode(diff)
+
+		// Save stats for the next loop.
+		prev = stats
+	}
+}()
+```
+
+It's also useful to pipe these stats to a service such as statsd for monitoring
+or to provide an HTTP endpoint that will perform a fixed-length sample.
+
+
+### Read-Only Mode
+
+Sometimes it is useful to create a shared, read-only Bolt database. To this,
+set the `Options.ReadOnly` flag when opening your database. Read-only mode
+uses a shared lock to allow multiple processes to read from the database but
+it will block any processes from opening the database in read-write mode.
+
+```go
+db, err := bolt.Open("my.db", 0666, &bolt.Options{ReadOnly: true})
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+### Mobile Use (iOS/Android)
+
+Bolt is able to run on mobile devices by leveraging the binding feature of the
+[gomobile](https://github.com/golang/mobile) tool. Create a struct that will
+contain your database logic and a reference to a `*bolt.DB` with a initializing
+constructor that takes in a filepath where the database file will be stored.
+Neither Android nor iOS require extra permissions or cleanup from using this method.
+
+```go
+func NewBoltDB(filepath string) *BoltDB {
+	db, err := bolt.Open(filepath+"/demo.db", 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return &BoltDB{db}
+}
+
+type BoltDB struct {
+	db *bolt.DB
+	...
+}
+
+func (b *BoltDB) Path() string {
+	return b.db.Path()
+}
+
+func (b *BoltDB) Close() {
+	b.db.Close()
+}
+```
+
+Database logic should be defined as methods on this wrapper struct.
+
+To initialize this struct from the native language (both platforms now sync
+their local storage to the cloud. These snippets disable that functionality for the
+database file):
+
+#### Android
+
+```java
+String path;
+if (android.os.Build.VERSION.SDK_INT >=android.os.Build.VERSION_CODES.LOLLIPOP){
+    path = getNoBackupFilesDir().getAbsolutePath();
+} else{
+    path = getFilesDir().getAbsolutePath();
+}
+Boltmobiledemo.BoltDB boltDB = Boltmobiledemo.NewBoltDB(path)
+```
+
+#### iOS
+
+```objc
+- (void)demo {
+    NSString* path = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory,
+                                                          NSUserDomainMask,
+                                                          YES) objectAtIndex:0];
+	GoBoltmobiledemoBoltDB * demo = GoBoltmobiledemoNewBoltDB(path);
+	[self addSkipBackupAttributeToItemAtPath:demo.path];
+	//Some DB Logic would go here
+	[demo close];
+}
+
+- (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *) filePathString
+{
+    NSURL* URL= [NSURL fileURLWithPath: filePathString];
+    assert([[NSFileManager defaultManager] fileExistsAtPath: [URL path]]);
+
+    NSError *error = nil;
+    BOOL success = [URL setResourceValue: [NSNumber numberWithBool: YES]
+                                  forKey: NSURLIsExcludedFromBackupKey error: &error];
+    if(!success){
+        NSLog(@"Error excluding %@ from backup %@", [URL lastPathComponent], error);
+    }
+    return success;
+}
+
+```
+
+## Resources
+
+For more information on getting started with Bolt, check out the following articles:
+
+* [Intro to BoltDB: Painless Performant Persistence](http://npf.io/2014/07/intro-to-boltdb-painless-performant-persistence/) by [Nate Finch](https://github.com/natefinch).
+* [Bolt -- an embedded key/value database for Go](https://www.progville.com/go/bolt-embedded-db-golang/) by Progville
+
+
+## Comparison with other databases
+
+### Postgres, MySQL, & other relational databases
+
+Relational databases structure data into rows and are only accessible through
+the use of SQL. This approach provides flexibility in how you store and query
+your data but also incurs overhead in parsing and planning SQL statements. Bolt
+accesses all data by a byte slice key. This makes Bolt fast to read and write
+data by key but provides no built-in support for joining values together.
+
+Most relational databases (with the exception of SQLite) are standalone servers
+that run separately from your application. This gives your systems
+flexibility to connect multiple application servers to a single database
+server but also adds overhead in serializing and transporting data over the
+network. Bolt runs as a library included in your application so all data access
+has to go through your application's process. This brings data closer to your
+application but limits multi-process access to the data.
+
+
+### LevelDB, RocksDB
+
+LevelDB and its derivatives (RocksDB, HyperLevelDB) are similar to Bolt in that
+they are libraries bundled into the application, however, their underlying
+structure is a log-structured merge-tree (LSM tree). An LSM tree optimizes
+random writes by using a write ahead log and multi-tiered, sorted files called
+SSTables. Bolt uses a B+tree internally and only a single file. Both approaches
+have trade-offs.
+
+If you require a high random write throughput (>10,000 w/sec) or you need to use
+spinning disks then LevelDB could be a good choice. If your application is
+read-heavy or does a lot of range scans then Bolt could be a good choice.
+
+One other important consideration is that LevelDB does not have transactions.
+It supports batch writing of key/values pairs and it supports read snapshots
+but it will not give you the ability to do a compare-and-swap operation safely.
+Bolt supports fully serializable ACID transactions.
+
+
+### LMDB
+
+Bolt was originally a port of LMDB so it is architecturally similar. Both use
+a B+tree, have ACID semantics with fully serializable transactions, and support
+lock-free MVCC using a single writer and multiple readers.
+
+The two projects have somewhat diverged. LMDB heavily focuses on raw performance
+while Bolt has focused on simplicity and ease of use. For example, LMDB allows
+several unsafe actions such as direct writes for the sake of performance. Bolt
+opts to disallow actions which can leave the database in a corrupted state. The
+only exception to this in Bolt is `DB.NoSync`.
+
+There are also a few differences in API. LMDB requires a maximum mmap size when
+opening an `mdb_env` whereas Bolt will handle incremental mmap resizing
+automatically. LMDB overloads the getter and setter functions with multiple
+flags whereas Bolt splits these specialized cases into their own functions.
+
+
+## Caveats & Limitations
+
+It's important to pick the right tool for the job and Bolt is no exception.
+Here are a few things to note when evaluating and using Bolt:
+
+* Bolt is good for read intensive workloads. Sequential write performance is
+  also fast but random writes can be slow. You can use `DB.Batch()` or add a
+  write-ahead log to help mitigate this issue.
+
+* Bolt uses a B+tree internally so there can be a lot of random page access.
+  SSDs provide a significant performance boost over spinning disks.
+
+* Try to avoid long running read transactions. Bolt uses copy-on-write so
+  old pages cannot be reclaimed while an old transaction is using them.
+
+* Byte slices returned from Bolt are only valid during a transaction. Once the
+  transaction has been committed or rolled back then the memory they point to
+  can be reused by a new page or can be unmapped from virtual memory and you'll
+  see an `unexpected fault address` panic when accessing it.
+
+* Bolt uses an exclusive write lock on the database file so it cannot be
+  shared by multiple processes.
+
+* Be careful when using `Bucket.FillPercent`. Setting a high fill percent for
+  buckets that have random inserts will cause your database to have very poor
+  page utilization.
+
+* Use larger buckets in general. Smaller buckets causes poor page utilization
+  once they become larger than the page size (typically 4KB).
+
+* Bulk loading a lot of random writes into a new bucket can be slow as the
+  page will not split until the transaction is committed. Randomly inserting
+  more than 100,000 key/value pairs into a single new bucket in a single
+  transaction is not advised.
+
+* Bolt uses a memory-mapped file so the underlying operating system handles the
+  caching of the data. Typically, the OS will cache as much of the file as it
+  can in memory and will release memory as needed to other processes. This means
+  that Bolt can show very high memory usage when working with large databases.
+  However, this is expected and the OS will release memory as needed. Bolt can
+  handle databases much larger than the available physical RAM, provided its
+  memory-map fits in the process virtual address space. It may be problematic
+  on 32-bits systems.
+
+* The data structures in the Bolt database are memory mapped so the data file
+  will be endian specific. This means that you cannot copy a Bolt file from a
+  little endian machine to a big endian machine and have it work. For most
+  users this is not a concern since most modern CPUs are little endian.
+
+* Because of the way pages are laid out on disk, Bolt cannot truncate data files
+  and return free pages back to the disk. Instead, Bolt maintains a free list
+  of unused pages within its data file. These free pages can be reused by later
+  transactions. This works well for many use cases as databases generally tend
+  to grow. However, it's important to note that deleting large chunks of data
+  will not allow you to reclaim that space on disk.
+
+  For more information on page allocation, [see this comment][page-allocation].
+
+[page-allocation]: https://github.com/boltdb/bolt/issues/308#issuecomment-74811638
+
+
+## Reading the Source
+
+Bolt is a relatively small code base (<5KLOC) for an embedded, serializable,
+transactional key/value database so it can be a good starting point for people
+interested in how databases work.
+
+The best places to start are the main entry points into Bolt:
+
+- `Open()` - Initializes the reference to the database. It's responsible for
+  creating the database if it doesn't exist, obtaining an exclusive lock on the
+  file, reading the meta pages, & memory-mapping the file.
+
+- `DB.Begin()` - Starts a read-only or read-write transaction depending on the
+  value of the `writable` argument. This requires briefly obtaining the "meta"
+  lock to keep track of open transactions. Only one read-write transaction can
+  exist at a time so the "rwlock" is acquired during the life of a read-write
+  transaction.
+
+- `Bucket.Put()` - Writes a key/value pair into a bucket. After validating the
+  arguments, a cursor is used to traverse the B+tree to the page and position
+  where they key & value will be written. Once the position is found, the bucket
+  materializes the underlying page and the page's parent pages into memory as
+  "nodes". These nodes are where mutations occur during read-write transactions.
+  These changes get flushed to disk during commit.
+
+- `Bucket.Get()` - Retrieves a key/value pair from a bucket. This uses a cursor
+  to move to the page & position of a key/value pair. During a read-only
+  transaction, the key and value data is returned as a direct reference to the
+  underlying mmap file so there's no allocation overhead. For read-write
+  transactions, this data may reference the mmap file or one of the in-memory
+  node values.
+
+- `Cursor` - This object is simply for traversing the B+tree of on-disk pages
+  or in-memory nodes. It can seek to a specific key, move to the first or last
+  value, or it can move forward or backward. The cursor handles the movement up
+  and down the B+tree transparently to the end user.
+
+- `Tx.Commit()` - Converts the in-memory dirty nodes and the list of free pages
+  into pages to be written to disk. Writing to disk then occurs in two phases.
+  First, the dirty pages are written to disk and an `fsync()` occurs. Second, a
+  new meta page with an incremented transaction ID is written and another
+  `fsync()` occurs. This two phase write ensures that partially written data
+  pages are ignored in the event of a crash since the meta page pointing to them
+  is never written. Partially written meta pages are invalidated because they
+  are written with a checksum.
+
+If you have additional notes that could be helpful for others, please submit
+them via pull request.
+
+
+## Other Projects Using Bolt
+
+Below is a list of public, open source projects that use Bolt:
+
+* [BoltDbWeb](https://github.com/evnix/boltdbweb) - A web based GUI for BoltDB files.
+* [Operation Go: A Routine Mission](http://gocode.io) - An online programming game for Golang using Bolt for user accounts and a leaderboard.
+* [Bazil](https://bazil.org/) - A file system that lets your data reside where it is most convenient for it to reside.
+* [DVID](https://github.com/janelia-flyem/dvid) - Added Bolt as optional storage engine and testing it against Basho-tuned leveldb.
+* [Skybox Analytics](https://github.com/skybox/skybox) - A standalone funnel analysis tool for web analytics.
+* [Scuttlebutt](https://github.com/benbjohnson/scuttlebutt) - Uses Bolt to store and process all Twitter mentions of GitHub projects.
+* [Wiki](https://github.com/peterhellberg/wiki) - A tiny wiki using Goji, BoltDB and Blackfriday.
+* [ChainStore](https://github.com/pressly/chainstore) - Simple key-value interface to a variety of storage engines organized as a chain of operations.
+* [MetricBase](https://github.com/msiebuhr/MetricBase) - Single-binary version of Graphite.
+* [Gitchain](https://github.com/gitchain/gitchain) - Decentralized, peer-to-peer Git repositories aka "Git meets Bitcoin".
+* [event-shuttle](https://github.com/sclasen/event-shuttle) - A Unix system service to collect and reliably deliver messages to Kafka.
+* [ipxed](https://github.com/kelseyhightower/ipxed) - Web interface and api for ipxed.
+* [BoltStore](https://github.com/yosssi/boltstore) - Session store using Bolt.
+* [photosite/session](https://godoc.org/bitbucket.org/kardianos/photosite/session) - Sessions for a photo viewing site.
+* [LedisDB](https://github.com/siddontang/ledisdb) - A high performance NoSQL, using Bolt as optional storage.
+* [ipLocator](https://github.com/AndreasBriese/ipLocator) - A fast ip-geo-location-server using bolt with bloom filters.
+* [cayley](https://github.com/google/cayley) - Cayley is an open-source graph database using Bolt as optional backend.
+* [bleve](http://www.blevesearch.com/) - A pure Go search engine similar to ElasticSearch that uses Bolt as the default storage backend.
+* [tentacool](https://github.com/optiflows/tentacool) - REST api server to manage system stuff (IP, DNS, Gateway...) on a linux server.
+* [Seaweed File System](https://github.com/chrislusf/seaweedfs) - Highly scalable distributed key~file system with O(1) disk read.
+* [InfluxDB](https://influxdata.com) - Scalable datastore for metrics, events, and real-time analytics.
+* [Freehold](http://tshannon.bitbucket.org/freehold/) - An open, secure, and lightweight platform for your files and data.
+* [Prometheus Annotation Server](https://github.com/oliver006/prom_annotation_server) - Annotation server for PromDash & Prometheus service monitoring system.
+* [Consul](https://github.com/hashicorp/consul) - Consul is service discovery and configuration made easy. Distributed, highly available, and datacenter-aware.
+* [Kala](https://github.com/ajvb/kala) - Kala is a modern job scheduler optimized to run on a single node. It is persistent, JSON over HTTP API, ISO 8601 duration notation, and dependent jobs.
+* [drive](https://github.com/odeke-em/drive) - drive is an unofficial Google Drive command line client for \*NIX operating systems.
+* [stow](https://github.com/djherbis/stow) -  a persistence manager for objects
+  backed by boltdb.
+* [buckets](https://github.com/joyrexus/buckets) - a bolt wrapper streamlining
+  simple tx and key scans.
+* [mbuckets](https://github.com/abhigupta912/mbuckets) - A Bolt wrapper that allows easy operations on multi level (nested) buckets.
+* [Request Baskets](https://github.com/darklynx/request-baskets) - A web service to collect arbitrary HTTP requests and inspect them via REST API or simple web UI, similar to [RequestBin](http://requestb.in/) service
+* [Go Report Card](https://goreportcard.com/) - Go code quality report cards as a (free and open source) service.
+* [Boltdb Boilerplate](https://github.com/bobintornado/boltdb-boilerplate) - Boilerplate wrapper around bolt aiming to make simple calls one-liners.
+* [lru](https://github.com/crowdriff/lru) - Easy to use Bolt-backed Least-Recently-Used (LRU) read-through cache with chainable remote stores.
+* [Storm](https://github.com/asdine/storm) - Simple and powerful ORM for BoltDB.
+* [GoWebApp](https://github.com/josephspurrier/gowebapp) - A basic MVC web application in Go using BoltDB.
+* [SimpleBolt](https://github.com/xyproto/simplebolt) - A simple way to use BoltDB. Deals mainly with strings.
+* [Algernon](https://github.com/xyproto/algernon) - A HTTP/2 web server with built-in support for Lua. Uses BoltDB as the default database backend.
+* [MuLiFS](https://github.com/dankomiocevic/mulifs) - Music Library Filesystem creates a filesystem to organise your music files.
+* [GoShort](https://github.com/pankajkhairnar/goShort) - GoShort is a URL shortener written in Golang and BoltDB for persistent key/value storage and for routing it's using high performent HTTPRouter.
+* [torrent](https://github.com/anacrolix/torrent) - Full-featured BitTorrent client package and utilities in Go. BoltDB is a storage backend in development.
+* [gopherpit](https://github.com/gopherpit/gopherpit) - A web service to manage Go remote import paths with custom domains
+* [bolter](https://github.com/hasit/bolter) - Command-line app for viewing BoltDB file in your terminal.
+* [btcwallet](https://github.com/btcsuite/btcwallet) - A bitcoin wallet.
+* [dcrwallet](https://github.com/decred/dcrwallet) - A wallet for the Decred cryptocurrency.
+* [Ironsmith](https://github.com/timshannon/ironsmith) - A simple, script-driven continuous integration (build - > test -> release) tool, with no external dependencies
+* [BoltHold](https://github.com/timshannon/bolthold) - An embeddable NoSQL store for Go types built on BoltDB
+
+If you are using Bolt in a project please send a pull request to add it to the list.

--- a/vendor/github.com/coreos/bbolt/appveyor.yml
+++ b/vendor/github.com/coreos/bbolt/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\boltdb\bolt
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - go version
+  - go env
+  - go get -v -t ./...
+
+build_script:
+  - go test -v ./...

--- a/vendor/github.com/coreos/bbolt/bolt_386.go
+++ b/vendor/github.com/coreos/bbolt/bolt_386.go
@@ -1,0 +1,10 @@
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x7FFFFFFF // 2GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_amd64.go
+++ b/vendor/github.com/coreos/bbolt/bolt_amd64.go
@@ -1,0 +1,10 @@
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_arm.go
+++ b/vendor/github.com/coreos/bbolt/bolt_arm.go
@@ -1,0 +1,28 @@
+package bolt
+
+import "unsafe"
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x7FFFFFFF // 2GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned bool
+
+func init() {
+	// Simple check to see whether this arch handles unaligned load/stores
+	// correctly.
+
+	// ARM9 and older devices require load/stores to be from/to aligned
+	// addresses. If not, the lower 2 bits are cleared and that address is
+	// read in a jumbled up order.
+
+	// See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
+
+	raw := [6]byte{0xfe, 0xef, 0x11, 0x22, 0x22, 0x11}
+	val := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&raw)) + 2))
+
+	brokenUnaligned = val != 0x11222211
+}

--- a/vendor/github.com/coreos/bbolt/bolt_arm64.go
+++ b/vendor/github.com/coreos/bbolt/bolt_arm64.go
@@ -1,0 +1,12 @@
+// +build arm64
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_linux.go
+++ b/vendor/github.com/coreos/bbolt/bolt_linux.go
@@ -1,0 +1,10 @@
+package bolt
+
+import (
+	"syscall"
+)
+
+// fdatasync flushes written data to a file descriptor.
+func fdatasync(db *DB) error {
+	return syscall.Fdatasync(int(db.file.Fd()))
+}

--- a/vendor/github.com/coreos/bbolt/bolt_mips64x.go
+++ b/vendor/github.com/coreos/bbolt/bolt_mips64x.go
@@ -1,0 +1,12 @@
+// +build mips64 mips64le
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x8000000000 // 512GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_mipsx.go
+++ b/vendor/github.com/coreos/bbolt/bolt_mipsx.go
@@ -1,0 +1,12 @@
+// +build mips mipsle
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x40000000 // 1GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_openbsd.go
+++ b/vendor/github.com/coreos/bbolt/bolt_openbsd.go
@@ -1,0 +1,27 @@
+package bolt
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	msAsync      = 1 << iota // perform asynchronous writes
+	msSync                   // perform synchronous writes
+	msInvalidate             // invalidate cached data
+)
+
+func msync(db *DB) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_MSYNC, uintptr(unsafe.Pointer(db.data)), uintptr(db.datasz), msInvalidate)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func fdatasync(db *DB) error {
+	if db.data != nil {
+		return msync(db)
+	}
+	return db.file.Sync()
+}

--- a/vendor/github.com/coreos/bbolt/bolt_ppc.go
+++ b/vendor/github.com/coreos/bbolt/bolt_ppc.go
@@ -1,0 +1,9 @@
+// +build ppc
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x7FFFFFFF // 2GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF

--- a/vendor/github.com/coreos/bbolt/bolt_ppc64.go
+++ b/vendor/github.com/coreos/bbolt/bolt_ppc64.go
@@ -1,0 +1,12 @@
+// +build ppc64
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_ppc64le.go
+++ b/vendor/github.com/coreos/bbolt/bolt_ppc64le.go
@@ -1,0 +1,12 @@
+// +build ppc64le
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_s390x.go
+++ b/vendor/github.com/coreos/bbolt/bolt_s390x.go
@@ -1,0 +1,12 @@
+// +build s390x
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/coreos/bbolt/bolt_unix.go
+++ b/vendor/github.com/coreos/bbolt/bolt_unix.go
@@ -1,0 +1,89 @@
+// +build !windows,!plan9,!solaris
+
+package bolt
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// flock acquires an advisory lock on a file descriptor.
+func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	var t time.Time
+	for {
+		// If we're beyond our timeout then return an error.
+		// This can only occur after we've attempted a flock once.
+		if t.IsZero() {
+			t = time.Now()
+		} else if timeout > 0 && time.Since(t) > timeout {
+			return ErrTimeout
+		}
+		flag := syscall.LOCK_SH
+		if exclusive {
+			flag = syscall.LOCK_EX
+		}
+
+		// Otherwise attempt to obtain an exclusive lock.
+		err := syscall.Flock(int(db.file.Fd()), flag|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		} else if err != syscall.EWOULDBLOCK {
+			return err
+		}
+
+		// Wait for a bit and try again.
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// funlock releases an advisory lock on a file descriptor.
+func funlock(db *DB) error {
+	return syscall.Flock(int(db.file.Fd()), syscall.LOCK_UN)
+}
+
+// mmap memory maps a DB's data file.
+func mmap(db *DB, sz int) error {
+	// Map the data file to memory.
+	b, err := syscall.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED|db.MmapFlags)
+	if err != nil {
+		return err
+	}
+
+	// Advise the kernel that the mmap is accessed randomly.
+	if err := madvise(b, syscall.MADV_RANDOM); err != nil {
+		return fmt.Errorf("madvise: %s", err)
+	}
+
+	// Save the original byte slice and convert to a byte array pointer.
+	db.dataref = b
+	db.data = (*[maxMapSize]byte)(unsafe.Pointer(&b[0]))
+	db.datasz = sz
+	return nil
+}
+
+// munmap unmaps a DB's data file from memory.
+func munmap(db *DB) error {
+	// Ignore the unmap if we have no mapped data.
+	if db.dataref == nil {
+		return nil
+	}
+
+	// Unmap using the original byte slice.
+	err := syscall.Munmap(db.dataref)
+	db.dataref = nil
+	db.data = nil
+	db.datasz = 0
+	return err
+}
+
+// NOTE: This function is copied from stdlib because it is not available on darwin.
+func madvise(b []byte, advice int) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), uintptr(advice))
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/vendor/github.com/coreos/bbolt/bolt_unix_solaris.go
+++ b/vendor/github.com/coreos/bbolt/bolt_unix_solaris.go
@@ -1,0 +1,90 @@
+package bolt
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// flock acquires an advisory lock on a file descriptor.
+func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	var t time.Time
+	for {
+		// If we're beyond our timeout then return an error.
+		// This can only occur after we've attempted a flock once.
+		if t.IsZero() {
+			t = time.Now()
+		} else if timeout > 0 && time.Since(t) > timeout {
+			return ErrTimeout
+		}
+		var lock syscall.Flock_t
+		lock.Start = 0
+		lock.Len = 0
+		lock.Pid = 0
+		lock.Whence = 0
+		lock.Pid = 0
+		if exclusive {
+			lock.Type = syscall.F_WRLCK
+		} else {
+			lock.Type = syscall.F_RDLCK
+		}
+		err := syscall.FcntlFlock(db.file.Fd(), syscall.F_SETLK, &lock)
+		if err == nil {
+			return nil
+		} else if err != syscall.EAGAIN {
+			return err
+		}
+
+		// Wait for a bit and try again.
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// funlock releases an advisory lock on a file descriptor.
+func funlock(db *DB) error {
+	var lock syscall.Flock_t
+	lock.Start = 0
+	lock.Len = 0
+	lock.Type = syscall.F_UNLCK
+	lock.Whence = 0
+	return syscall.FcntlFlock(uintptr(db.file.Fd()), syscall.F_SETLK, &lock)
+}
+
+// mmap memory maps a DB's data file.
+func mmap(db *DB, sz int) error {
+	// Map the data file to memory.
+	b, err := unix.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED|db.MmapFlags)
+	if err != nil {
+		return err
+	}
+
+	// Advise the kernel that the mmap is accessed randomly.
+	if err := unix.Madvise(b, syscall.MADV_RANDOM); err != nil {
+		return fmt.Errorf("madvise: %s", err)
+	}
+
+	// Save the original byte slice and convert to a byte array pointer.
+	db.dataref = b
+	db.data = (*[maxMapSize]byte)(unsafe.Pointer(&b[0]))
+	db.datasz = sz
+	return nil
+}
+
+// munmap unmaps a DB's data file from memory.
+func munmap(db *DB) error {
+	// Ignore the unmap if we have no mapped data.
+	if db.dataref == nil {
+		return nil
+	}
+
+	// Unmap using the original byte slice.
+	err := unix.Munmap(db.dataref)
+	db.dataref = nil
+	db.data = nil
+	db.datasz = 0
+	return err
+}

--- a/vendor/github.com/coreos/bbolt/bolt_windows.go
+++ b/vendor/github.com/coreos/bbolt/bolt_windows.go
@@ -1,0 +1,144 @@
+package bolt
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// LockFileEx code derived from golang build filemutex_windows.go @ v1.5.1
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	lockExt = ".lock"
+
+	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+	flagLockExclusive       = 2
+	flagLockFailImmediately = 1
+
+	// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+	errLockViolation syscall.Errno = 0x21
+)
+
+func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r, _, err := procLockFileEx.Call(uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r, _, err := procUnlockFileEx.Call(uintptr(h), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)), 0)
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+// fdatasync flushes written data to a file descriptor.
+func fdatasync(db *DB) error {
+	return db.file.Sync()
+}
+
+// flock acquires an advisory lock on a file descriptor.
+func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	// Create a separate lock file on windows because a process
+	// cannot share an exclusive lock on the same file. This is
+	// needed during Tx.WriteTo().
+	f, err := os.OpenFile(db.path+lockExt, os.O_CREATE, mode)
+	if err != nil {
+		return err
+	}
+	db.lockfile = f
+
+	var t time.Time
+	for {
+		// If we're beyond our timeout then return an error.
+		// This can only occur after we've attempted a flock once.
+		if t.IsZero() {
+			t = time.Now()
+		} else if timeout > 0 && time.Since(t) > timeout {
+			return ErrTimeout
+		}
+
+		var flag uint32 = flagLockFailImmediately
+		if exclusive {
+			flag |= flagLockExclusive
+		}
+
+		err := lockFileEx(syscall.Handle(db.lockfile.Fd()), flag, 0, 1, 0, &syscall.Overlapped{})
+		if err == nil {
+			return nil
+		} else if err != errLockViolation {
+			return err
+		}
+
+		// Wait for a bit and try again.
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// funlock releases an advisory lock on a file descriptor.
+func funlock(db *DB) error {
+	err := unlockFileEx(syscall.Handle(db.lockfile.Fd()), 0, 1, 0, &syscall.Overlapped{})
+	db.lockfile.Close()
+	os.Remove(db.path + lockExt)
+	return err
+}
+
+// mmap memory maps a DB's data file.
+// Based on: https://github.com/edsrzf/mmap-go
+func mmap(db *DB, sz int) error {
+	if !db.readOnly {
+		// Truncate the database to the size of the mmap.
+		if err := db.file.Truncate(int64(sz)); err != nil {
+			return fmt.Errorf("truncate: %s", err)
+		}
+	}
+
+	// Open a file mapping handle.
+	sizelo := uint32(sz >> 32)
+	sizehi := uint32(sz) & 0xffffffff
+	h, errno := syscall.CreateFileMapping(syscall.Handle(db.file.Fd()), nil, syscall.PAGE_READONLY, sizelo, sizehi, nil)
+	if h == 0 {
+		return os.NewSyscallError("CreateFileMapping", errno)
+	}
+
+	// Create the memory map.
+	addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(sz))
+	if addr == 0 {
+		return os.NewSyscallError("MapViewOfFile", errno)
+	}
+
+	// Close mapping handle.
+	if err := syscall.CloseHandle(syscall.Handle(h)); err != nil {
+		return os.NewSyscallError("CloseHandle", err)
+	}
+
+	// Convert to a byte array.
+	db.data = ((*[maxMapSize]byte)(unsafe.Pointer(addr)))
+	db.datasz = sz
+
+	return nil
+}
+
+// munmap unmaps a pointer from a file.
+// Based on: https://github.com/edsrzf/mmap-go
+func munmap(db *DB) error {
+	if db.data == nil {
+		return nil
+	}
+
+	addr := (uintptr)(unsafe.Pointer(&db.data[0]))
+	if err := syscall.UnmapViewOfFile(addr); err != nil {
+		return os.NewSyscallError("UnmapViewOfFile", err)
+	}
+	return nil
+}

--- a/vendor/github.com/coreos/bbolt/boltsync_unix.go
+++ b/vendor/github.com/coreos/bbolt/boltsync_unix.go
@@ -1,0 +1,8 @@
+// +build !windows,!plan9,!linux,!openbsd
+
+package bolt
+
+// fdatasync flushes written data to a file descriptor.
+func fdatasync(db *DB) error {
+	return db.file.Sync()
+}

--- a/vendor/github.com/coreos/bbolt/bucket.go
+++ b/vendor/github.com/coreos/bbolt/bucket.go
@@ -1,0 +1,775 @@
+package bolt
+
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+)
+
+const (
+	// MaxKeySize is the maximum length of a key, in bytes.
+	MaxKeySize = 32768
+
+	// MaxValueSize is the maximum length of a value, in bytes.
+	MaxValueSize = (1 << 31) - 2
+)
+
+const bucketHeaderSize = int(unsafe.Sizeof(bucket{}))
+
+const (
+	minFillPercent = 0.1
+	maxFillPercent = 1.0
+)
+
+// DefaultFillPercent is the percentage that split pages are filled.
+// This value can be changed by setting Bucket.FillPercent.
+const DefaultFillPercent = 0.5
+
+// Bucket represents a collection of key/value pairs inside the database.
+type Bucket struct {
+	*bucket
+	tx       *Tx                // the associated transaction
+	buckets  map[string]*Bucket // subbucket cache
+	page     *page              // inline page reference
+	rootNode *node              // materialized node for the root page.
+	nodes    map[pgid]*node     // node cache
+
+	// Sets the threshold for filling nodes when they split. By default,
+	// the bucket will fill to 50% but it can be useful to increase this
+	// amount if you know that your write workloads are mostly append-only.
+	//
+	// This is non-persisted across transactions so it must be set in every Tx.
+	FillPercent float64
+}
+
+// bucket represents the on-file representation of a bucket.
+// This is stored as the "value" of a bucket key. If the bucket is small enough,
+// then its root page can be stored inline in the "value", after the bucket
+// header. In the case of inline buckets, the "root" will be 0.
+type bucket struct {
+	root     pgid   // page id of the bucket's root-level page
+	sequence uint64 // monotonically incrementing, used by NextSequence()
+}
+
+// newBucket returns a new bucket associated with a transaction.
+func newBucket(tx *Tx) Bucket {
+	var b = Bucket{tx: tx, FillPercent: DefaultFillPercent}
+	if tx.writable {
+		b.buckets = make(map[string]*Bucket)
+		b.nodes = make(map[pgid]*node)
+	}
+	return b
+}
+
+// Tx returns the tx of the bucket.
+func (b *Bucket) Tx() *Tx {
+	return b.tx
+}
+
+// Root returns the root of the bucket.
+func (b *Bucket) Root() pgid {
+	return b.root
+}
+
+// Writable returns whether the bucket is writable.
+func (b *Bucket) Writable() bool {
+	return b.tx.writable
+}
+
+// Cursor creates a cursor associated with the bucket.
+// The cursor is only valid as long as the transaction is open.
+// Do not use a cursor after the transaction is closed.
+func (b *Bucket) Cursor() *Cursor {
+	// Update transaction statistics.
+	b.tx.stats.CursorCount++
+
+	// Allocate and return a cursor.
+	return &Cursor{
+		bucket: b,
+		stack:  make([]elemRef, 0),
+	}
+}
+
+// Bucket retrieves a nested bucket by name.
+// Returns nil if the bucket does not exist.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (b *Bucket) Bucket(name []byte) *Bucket {
+	if b.buckets != nil {
+		if child := b.buckets[string(name)]; child != nil {
+			return child
+		}
+	}
+
+	// Move cursor to key.
+	c := b.Cursor()
+	k, v, flags := c.seek(name)
+
+	// Return nil if the key doesn't exist or it is not a bucket.
+	if !bytes.Equal(name, k) || (flags&bucketLeafFlag) == 0 {
+		return nil
+	}
+
+	// Otherwise create a bucket and cache it.
+	var child = b.openBucket(v)
+	if b.buckets != nil {
+		b.buckets[string(name)] = child
+	}
+
+	return child
+}
+
+// Helper method that re-interprets a sub-bucket value
+// from a parent into a Bucket
+func (b *Bucket) openBucket(value []byte) *Bucket {
+	var child = newBucket(b.tx)
+
+	// If unaligned load/stores are broken on this arch and value is
+	// unaligned simply clone to an aligned byte array.
+	unaligned := brokenUnaligned && uintptr(unsafe.Pointer(&value[0]))&3 != 0
+
+	if unaligned {
+		value = cloneBytes(value)
+	}
+
+	// If this is a writable transaction then we need to copy the bucket entry.
+	// Read-only transactions can point directly at the mmap entry.
+	if b.tx.writable && !unaligned {
+		child.bucket = &bucket{}
+		*child.bucket = *(*bucket)(unsafe.Pointer(&value[0]))
+	} else {
+		child.bucket = (*bucket)(unsafe.Pointer(&value[0]))
+	}
+
+	// Save a reference to the inline page if the bucket is inline.
+	if child.root == 0 {
+		child.page = (*page)(unsafe.Pointer(&value[bucketHeaderSize]))
+	}
+
+	return &child
+}
+
+// CreateBucket creates a new bucket at the given key and returns the new bucket.
+// Returns an error if the key already exists, if the bucket name is blank, or if the bucket name is too long.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
+	if b.tx.db == nil {
+		return nil, ErrTxClosed
+	} else if !b.tx.writable {
+		return nil, ErrTxNotWritable
+	} else if len(key) == 0 {
+		return nil, ErrBucketNameRequired
+	}
+
+	// Move cursor to correct position.
+	c := b.Cursor()
+	k, _, flags := c.seek(key)
+
+	// Return an error if there is an existing key.
+	if bytes.Equal(key, k) {
+		if (flags & bucketLeafFlag) != 0 {
+			return nil, ErrBucketExists
+		}
+		return nil, ErrIncompatibleValue
+	}
+
+	// Create empty, inline bucket.
+	var bucket = Bucket{
+		bucket:      &bucket{},
+		rootNode:    &node{isLeaf: true},
+		FillPercent: DefaultFillPercent,
+	}
+	var value = bucket.write()
+
+	// Insert into node.
+	key = cloneBytes(key)
+	c.node().put(key, key, value, 0, bucketLeafFlag)
+
+	// Since subbuckets are not allowed on inline buckets, we need to
+	// dereference the inline page, if it exists. This will cause the bucket
+	// to be treated as a regular, non-inline bucket for the rest of the tx.
+	b.page = nil
+
+	return b.Bucket(key), nil
+}
+
+// CreateBucketIfNotExists creates a new bucket if it doesn't already exist and returns a reference to it.
+// Returns an error if the bucket name is blank, or if the bucket name is too long.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (b *Bucket) CreateBucketIfNotExists(key []byte) (*Bucket, error) {
+	child, err := b.CreateBucket(key)
+	if err == ErrBucketExists {
+		return b.Bucket(key), nil
+	} else if err != nil {
+		return nil, err
+	}
+	return child, nil
+}
+
+// DeleteBucket deletes a bucket at the given key.
+// Returns an error if the bucket does not exists, or if the key represents a non-bucket value.
+func (b *Bucket) DeleteBucket(key []byte) error {
+	if b.tx.db == nil {
+		return ErrTxClosed
+	} else if !b.Writable() {
+		return ErrTxNotWritable
+	}
+
+	// Move cursor to correct position.
+	c := b.Cursor()
+	k, _, flags := c.seek(key)
+
+	// Return an error if bucket doesn't exist or is not a bucket.
+	if !bytes.Equal(key, k) {
+		return ErrBucketNotFound
+	} else if (flags & bucketLeafFlag) == 0 {
+		return ErrIncompatibleValue
+	}
+
+	// Recursively delete all child buckets.
+	child := b.Bucket(key)
+	err := child.ForEach(func(k, v []byte) error {
+		if v == nil {
+			if err := child.DeleteBucket(k); err != nil {
+				return fmt.Errorf("delete bucket: %s", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Remove cached copy.
+	delete(b.buckets, string(key))
+
+	// Release all bucket pages to freelist.
+	child.nodes = nil
+	child.rootNode = nil
+	child.free()
+
+	// Delete the node if we have a matching key.
+	c.node().del(key)
+
+	return nil
+}
+
+// Get retrieves the value for a key in the bucket.
+// Returns a nil value if the key does not exist or if the key is a nested bucket.
+// The returned value is only valid for the life of the transaction.
+func (b *Bucket) Get(key []byte) []byte {
+	k, v, flags := b.Cursor().seek(key)
+
+	// Return nil if this is a bucket.
+	if (flags & bucketLeafFlag) != 0 {
+		return nil
+	}
+
+	// If our target node isn't the same key as what's passed in then return nil.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
+	return v
+}
+
+// Put sets the value for a key in the bucket.
+// If the key exist then its previous value will be overwritten.
+// Supplied value must remain valid for the life of the transaction.
+// Returns an error if the bucket was created from a read-only transaction, if the key is blank, if the key is too large, or if the value is too large.
+func (b *Bucket) Put(key []byte, value []byte) error {
+	if b.tx.db == nil {
+		return ErrTxClosed
+	} else if !b.Writable() {
+		return ErrTxNotWritable
+	} else if len(key) == 0 {
+		return ErrKeyRequired
+	} else if len(key) > MaxKeySize {
+		return ErrKeyTooLarge
+	} else if int64(len(value)) > MaxValueSize {
+		return ErrValueTooLarge
+	}
+
+	// Move cursor to correct position.
+	c := b.Cursor()
+	k, _, flags := c.seek(key)
+
+	// Return an error if there is an existing key with a bucket value.
+	if bytes.Equal(key, k) && (flags&bucketLeafFlag) != 0 {
+		return ErrIncompatibleValue
+	}
+
+	// Insert into node.
+	key = cloneBytes(key)
+	c.node().put(key, key, value, 0, 0)
+
+	return nil
+}
+
+// Delete removes a key from the bucket.
+// If the key does not exist then nothing is done and a nil error is returned.
+// Returns an error if the bucket was created from a read-only transaction.
+func (b *Bucket) Delete(key []byte) error {
+	if b.tx.db == nil {
+		return ErrTxClosed
+	} else if !b.Writable() {
+		return ErrTxNotWritable
+	}
+
+	// Move cursor to correct position.
+	c := b.Cursor()
+	k, _, flags := c.seek(key)
+
+	// Return nil if the key doesn't exist.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
+
+	// Return an error if there is already existing bucket value.
+	if (flags & bucketLeafFlag) != 0 {
+		return ErrIncompatibleValue
+	}
+
+	// Delete the node if we have a matching key.
+	c.node().del(key)
+
+	return nil
+}
+
+// Sequence returns the current integer for the bucket without incrementing it.
+func (b *Bucket) Sequence() uint64 { return b.bucket.sequence }
+
+// SetSequence updates the sequence number for the bucket.
+func (b *Bucket) SetSequence(v uint64) error {
+	if b.tx.db == nil {
+		return ErrTxClosed
+	} else if !b.Writable() {
+		return ErrTxNotWritable
+	}
+
+	// Materialize the root node if it hasn't been already so that the
+	// bucket will be saved during commit.
+	if b.rootNode == nil {
+		_ = b.node(b.root, nil)
+	}
+
+	// Increment and return the sequence.
+	b.bucket.sequence = v
+	return nil
+}
+
+// NextSequence returns an autoincrementing integer for the bucket.
+func (b *Bucket) NextSequence() (uint64, error) {
+	if b.tx.db == nil {
+		return 0, ErrTxClosed
+	} else if !b.Writable() {
+		return 0, ErrTxNotWritable
+	}
+
+	// Materialize the root node if it hasn't been already so that the
+	// bucket will be saved during commit.
+	if b.rootNode == nil {
+		_ = b.node(b.root, nil)
+	}
+
+	// Increment and return the sequence.
+	b.bucket.sequence++
+	return b.bucket.sequence, nil
+}
+
+// ForEach executes a function for each key/value pair in a bucket.
+// If the provided function returns an error then the iteration is stopped and
+// the error is returned to the caller. The provided function must not modify
+// the bucket; this will result in undefined behavior.
+func (b *Bucket) ForEach(fn func(k, v []byte) error) error {
+	if b.tx.db == nil {
+		return ErrTxClosed
+	}
+	c := b.Cursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		if err := fn(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Stat returns stats on a bucket.
+func (b *Bucket) Stats() BucketStats {
+	var s, subStats BucketStats
+	pageSize := b.tx.db.pageSize
+	s.BucketN += 1
+	if b.root == 0 {
+		s.InlineBucketN += 1
+	}
+	b.forEachPage(func(p *page, depth int) {
+		if (p.flags & leafPageFlag) != 0 {
+			s.KeyN += int(p.count)
+
+			// used totals the used bytes for the page
+			used := pageHeaderSize
+
+			if p.count != 0 {
+				// If page has any elements, add all element headers.
+				used += leafPageElementSize * int(p.count-1)
+
+				// Add all element key, value sizes.
+				// The computation takes advantage of the fact that the position
+				// of the last element's key/value equals to the total of the sizes
+				// of all previous elements' keys and values.
+				// It also includes the last element's header.
+				lastElement := p.leafPageElement(p.count - 1)
+				used += int(lastElement.pos + lastElement.ksize + lastElement.vsize)
+			}
+
+			if b.root == 0 {
+				// For inlined bucket just update the inline stats
+				s.InlineBucketInuse += used
+			} else {
+				// For non-inlined bucket update all the leaf stats
+				s.LeafPageN++
+				s.LeafInuse += used
+				s.LeafOverflowN += int(p.overflow)
+
+				// Collect stats from sub-buckets.
+				// Do that by iterating over all element headers
+				// looking for the ones with the bucketLeafFlag.
+				for i := uint16(0); i < p.count; i++ {
+					e := p.leafPageElement(i)
+					if (e.flags & bucketLeafFlag) != 0 {
+						// For any bucket element, open the element value
+						// and recursively call Stats on the contained bucket.
+						subStats.Add(b.openBucket(e.value()).Stats())
+					}
+				}
+			}
+		} else if (p.flags & branchPageFlag) != 0 {
+			s.BranchPageN++
+			lastElement := p.branchPageElement(p.count - 1)
+
+			// used totals the used bytes for the page
+			// Add header and all element headers.
+			used := pageHeaderSize + (branchPageElementSize * int(p.count-1))
+
+			// Add size of all keys and values.
+			// Again, use the fact that last element's position equals to
+			// the total of key, value sizes of all previous elements.
+			used += int(lastElement.pos + lastElement.ksize)
+			s.BranchInuse += used
+			s.BranchOverflowN += int(p.overflow)
+		}
+
+		// Keep track of maximum page depth.
+		if depth+1 > s.Depth {
+			s.Depth = (depth + 1)
+		}
+	})
+
+	// Alloc stats can be computed from page counts and pageSize.
+	s.BranchAlloc = (s.BranchPageN + s.BranchOverflowN) * pageSize
+	s.LeafAlloc = (s.LeafPageN + s.LeafOverflowN) * pageSize
+
+	// Add the max depth of sub-buckets to get total nested depth.
+	s.Depth += subStats.Depth
+	// Add the stats for all sub-buckets
+	s.Add(subStats)
+	return s
+}
+
+// forEachPage iterates over every page in a bucket, including inline pages.
+func (b *Bucket) forEachPage(fn func(*page, int)) {
+	// If we have an inline page then just use that.
+	if b.page != nil {
+		fn(b.page, 0)
+		return
+	}
+
+	// Otherwise traverse the page hierarchy.
+	b.tx.forEachPage(b.root, 0, fn)
+}
+
+// forEachPageNode iterates over every page (or node) in a bucket.
+// This also includes inline pages.
+func (b *Bucket) forEachPageNode(fn func(*page, *node, int)) {
+	// If we have an inline page or root node then just use that.
+	if b.page != nil {
+		fn(b.page, nil, 0)
+		return
+	}
+	b._forEachPageNode(b.root, 0, fn)
+}
+
+func (b *Bucket) _forEachPageNode(pgid pgid, depth int, fn func(*page, *node, int)) {
+	var p, n = b.pageNode(pgid)
+
+	// Execute function.
+	fn(p, n, depth)
+
+	// Recursively loop over children.
+	if p != nil {
+		if (p.flags & branchPageFlag) != 0 {
+			for i := 0; i < int(p.count); i++ {
+				elem := p.branchPageElement(uint16(i))
+				b._forEachPageNode(elem.pgid, depth+1, fn)
+			}
+		}
+	} else {
+		if !n.isLeaf {
+			for _, inode := range n.inodes {
+				b._forEachPageNode(inode.pgid, depth+1, fn)
+			}
+		}
+	}
+}
+
+// spill writes all the nodes for this bucket to dirty pages.
+func (b *Bucket) spill() error {
+	// Spill all child buckets first.
+	for name, child := range b.buckets {
+		// If the child bucket is small enough and it has no child buckets then
+		// write it inline into the parent bucket's page. Otherwise spill it
+		// like a normal bucket and make the parent value a pointer to the page.
+		var value []byte
+		if child.inlineable() {
+			child.free()
+			value = child.write()
+		} else {
+			if err := child.spill(); err != nil {
+				return err
+			}
+
+			// Update the child bucket header in this bucket.
+			value = make([]byte, unsafe.Sizeof(bucket{}))
+			var bucket = (*bucket)(unsafe.Pointer(&value[0]))
+			*bucket = *child.bucket
+		}
+
+		// Skip writing the bucket if there are no materialized nodes.
+		if child.rootNode == nil {
+			continue
+		}
+
+		// Update parent node.
+		var c = b.Cursor()
+		k, _, flags := c.seek([]byte(name))
+		if !bytes.Equal([]byte(name), k) {
+			panic(fmt.Sprintf("misplaced bucket header: %x -> %x", []byte(name), k))
+		}
+		if flags&bucketLeafFlag == 0 {
+			panic(fmt.Sprintf("unexpected bucket header flag: %x", flags))
+		}
+		c.node().put([]byte(name), []byte(name), value, 0, bucketLeafFlag)
+	}
+
+	// Ignore if there's not a materialized root node.
+	if b.rootNode == nil {
+		return nil
+	}
+
+	// Spill nodes.
+	if err := b.rootNode.spill(); err != nil {
+		return err
+	}
+	b.rootNode = b.rootNode.root()
+
+	// Update the root node for this bucket.
+	if b.rootNode.pgid >= b.tx.meta.pgid {
+		panic(fmt.Sprintf("pgid (%d) above high water mark (%d)", b.rootNode.pgid, b.tx.meta.pgid))
+	}
+	b.root = b.rootNode.pgid
+
+	return nil
+}
+
+// inlineable returns true if a bucket is small enough to be written inline
+// and if it contains no subbuckets. Otherwise returns false.
+func (b *Bucket) inlineable() bool {
+	var n = b.rootNode
+
+	// Bucket must only contain a single leaf node.
+	if n == nil || !n.isLeaf {
+		return false
+	}
+
+	// Bucket is not inlineable if it contains subbuckets or if it goes beyond
+	// our threshold for inline bucket size.
+	var size = pageHeaderSize
+	for _, inode := range n.inodes {
+		size += leafPageElementSize + len(inode.key) + len(inode.value)
+
+		if inode.flags&bucketLeafFlag != 0 {
+			return false
+		} else if size > b.maxInlineBucketSize() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Returns the maximum total size of a bucket to make it a candidate for inlining.
+func (b *Bucket) maxInlineBucketSize() int {
+	return b.tx.db.pageSize / 4
+}
+
+// write allocates and writes a bucket to a byte slice.
+func (b *Bucket) write() []byte {
+	// Allocate the appropriate size.
+	var n = b.rootNode
+	var value = make([]byte, bucketHeaderSize+n.size())
+
+	// Write a bucket header.
+	var bucket = (*bucket)(unsafe.Pointer(&value[0]))
+	*bucket = *b.bucket
+
+	// Convert byte slice to a fake page and write the root node.
+	var p = (*page)(unsafe.Pointer(&value[bucketHeaderSize]))
+	n.write(p)
+
+	return value
+}
+
+// rebalance attempts to balance all nodes.
+func (b *Bucket) rebalance() {
+	for _, n := range b.nodes {
+		n.rebalance()
+	}
+	for _, child := range b.buckets {
+		child.rebalance()
+	}
+}
+
+// node creates a node from a page and associates it with a given parent.
+func (b *Bucket) node(pgid pgid, parent *node) *node {
+	_assert(b.nodes != nil, "nodes map expected")
+
+	// Retrieve node if it's already been created.
+	if n := b.nodes[pgid]; n != nil {
+		return n
+	}
+
+	// Otherwise create a node and cache it.
+	n := &node{bucket: b, parent: parent}
+	if parent == nil {
+		b.rootNode = n
+	} else {
+		parent.children = append(parent.children, n)
+	}
+
+	// Use the inline page if this is an inline bucket.
+	var p = b.page
+	if p == nil {
+		p = b.tx.page(pgid)
+	}
+
+	// Read the page into the node and cache it.
+	n.read(p)
+	b.nodes[pgid] = n
+
+	// Update statistics.
+	b.tx.stats.NodeCount++
+
+	return n
+}
+
+// free recursively frees all pages in the bucket.
+func (b *Bucket) free() {
+	if b.root == 0 {
+		return
+	}
+
+	var tx = b.tx
+	b.forEachPageNode(func(p *page, n *node, _ int) {
+		if p != nil {
+			tx.db.freelist.free(tx.meta.txid, p)
+		} else {
+			n.free()
+		}
+	})
+	b.root = 0
+}
+
+// dereference removes all references to the old mmap.
+func (b *Bucket) dereference() {
+	if b.rootNode != nil {
+		b.rootNode.root().dereference()
+	}
+
+	for _, child := range b.buckets {
+		child.dereference()
+	}
+}
+
+// pageNode returns the in-memory node, if it exists.
+// Otherwise returns the underlying page.
+func (b *Bucket) pageNode(id pgid) (*page, *node) {
+	// Inline buckets have a fake page embedded in their value so treat them
+	// differently. We'll return the rootNode (if available) or the fake page.
+	if b.root == 0 {
+		if id != 0 {
+			panic(fmt.Sprintf("inline bucket non-zero page access(2): %d != 0", id))
+		}
+		if b.rootNode != nil {
+			return nil, b.rootNode
+		}
+		return b.page, nil
+	}
+
+	// Check the node cache for non-inline buckets.
+	if b.nodes != nil {
+		if n := b.nodes[id]; n != nil {
+			return nil, n
+		}
+	}
+
+	// Finally lookup the page from the transaction if no node is materialized.
+	return b.tx.page(id), nil
+}
+
+// BucketStats records statistics about resources used by a bucket.
+type BucketStats struct {
+	// Page count statistics.
+	BranchPageN     int // number of logical branch pages
+	BranchOverflowN int // number of physical branch overflow pages
+	LeafPageN       int // number of logical leaf pages
+	LeafOverflowN   int // number of physical leaf overflow pages
+
+	// Tree statistics.
+	KeyN  int // number of keys/value pairs
+	Depth int // number of levels in B+tree
+
+	// Page size utilization.
+	BranchAlloc int // bytes allocated for physical branch pages
+	BranchInuse int // bytes actually used for branch data
+	LeafAlloc   int // bytes allocated for physical leaf pages
+	LeafInuse   int // bytes actually used for leaf data
+
+	// Bucket statistics
+	BucketN           int // total number of buckets including the top bucket
+	InlineBucketN     int // total number on inlined buckets
+	InlineBucketInuse int // bytes used for inlined buckets (also accounted for in LeafInuse)
+}
+
+func (s *BucketStats) Add(other BucketStats) {
+	s.BranchPageN += other.BranchPageN
+	s.BranchOverflowN += other.BranchOverflowN
+	s.LeafPageN += other.LeafPageN
+	s.LeafOverflowN += other.LeafOverflowN
+	s.KeyN += other.KeyN
+	if s.Depth < other.Depth {
+		s.Depth = other.Depth
+	}
+	s.BranchAlloc += other.BranchAlloc
+	s.BranchInuse += other.BranchInuse
+	s.LeafAlloc += other.LeafAlloc
+	s.LeafInuse += other.LeafInuse
+
+	s.BucketN += other.BucketN
+	s.InlineBucketN += other.InlineBucketN
+	s.InlineBucketInuse += other.InlineBucketInuse
+}
+
+// cloneBytes returns a copy of a given slice.
+func cloneBytes(v []byte) []byte {
+	var clone = make([]byte, len(v))
+	copy(clone, v)
+	return clone
+}

--- a/vendor/github.com/coreos/bbolt/bucket_test.go
+++ b/vendor/github.com/coreos/bbolt/bucket_test.go
@@ -1,0 +1,1959 @@
+package bolt_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/quick"
+
+	"github.com/coreos/bbolt"
+)
+
+// Ensure that a bucket that gets a non-existent key returns nil.
+func TestBucket_Get_NonExistent(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v := b.Get([]byte("foo")); v != nil {
+			t.Fatal("expected nil value")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can read a value that is not flushed yet.
+func TestBucket_Get_FromNode(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if v := b.Get([]byte("foo")); !bytes.Equal(v, []byte("bar")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket retrieved via Get() returns a nil.
+func TestBucket_Get_IncompatibleValue(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := tx.Bucket([]byte("widgets")).CreateBucket([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+
+		if tx.Bucket([]byte("widgets")).Get([]byte("foo")) != nil {
+			t.Fatal("expected nil value")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a slice returned from a bucket has a capacity equal to its length.
+// This also allows slices to be appended to since it will require a realloc by Go.
+//
+// https://github.com/boltdb/bolt/issues/544
+func TestBucket_Get_Capacity(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Write key to a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("bucket"))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("key"), []byte("val"))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve value and attempt to append to it.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		k, v := tx.Bucket([]byte("bucket")).Cursor().First()
+
+		// Verify capacity.
+		if len(k) != cap(k) {
+			t.Fatalf("unexpected key slice capacity: %d", cap(k))
+		} else if len(v) != cap(v) {
+			t.Fatalf("unexpected value slice capacity: %d", cap(v))
+		}
+
+		// Ensure slice can be appended to without a segfault.
+		k = append(k, []byte("123")...)
+		v = append(v, []byte("123")...)
+		_, _ = k, v // to pass ineffassign
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can write a key/value.
+func TestBucket_Put(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+
+		v := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		if !bytes.Equal([]byte("bar"), v) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can rewrite a key in the same transaction.
+func TestBucket_Put_Repeat(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("baz")); err != nil {
+			t.Fatal(err)
+		}
+
+		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		if !bytes.Equal([]byte("baz"), value) {
+			t.Fatalf("unexpected value: %v", value)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can write a bunch of large values.
+func TestBucket_Put_Large(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	count, factor := 100, 200
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 1; i < count; i++ {
+			if err := b.Put([]byte(strings.Repeat("0", i*factor)), []byte(strings.Repeat("X", (count-i)*factor))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 1; i < count; i++ {
+			value := b.Get([]byte(strings.Repeat("0", i*factor)))
+			if !bytes.Equal(value, []byte(strings.Repeat("X", (count-i)*factor))) {
+				t.Fatalf("unexpected value: %v", value)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a database can perform multiple large appends safely.
+func TestDB_Put_VeryLarge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	n, batchN := 400000, 200000
+	ksize, vsize := 8, 500
+
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	for i := 0; i < n; i += batchN {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists([]byte("widgets"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for j := 0; j < batchN; j++ {
+				k, v := make([]byte, ksize), make([]byte, vsize)
+				binary.BigEndian.PutUint32(k, uint32(i+j))
+				if err := b.Put(k, v); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// Ensure that a setting a value on a key with a bucket value returns an error.
+func TestBucket_Put_IncompatibleValue(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b0, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := tx.Bucket([]byte("widgets")).CreateBucket([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b0.Put([]byte("foo"), []byte("bar")); err != bolt.ErrIncompatibleValue {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a setting a value while the transaction is closed returns an error.
+func TestBucket_Put_Closed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := tx.CreateBucket([]byte("widgets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.Put([]byte("foo"), []byte("bar")); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that setting a value on a read-only bucket returns an error.
+func TestBucket_Put_ReadOnly(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		if err := b.Put([]byte("foo"), []byte("bar")); err != bolt.ErrTxNotWritable {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can delete an existing key.
+func TestBucket_Delete(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Delete([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if v := b.Get([]byte("foo")); v != nil {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a large set of keys will work correctly.
+func TestBucket_Delete_Large(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < 100; i++ {
+			if err := b.Put([]byte(strconv.Itoa(i)), []byte(strings.Repeat("*", 1024))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 0; i < 100; i++ {
+			if err := b.Delete([]byte(strconv.Itoa(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 0; i < 100; i++ {
+			if v := b.Get([]byte(strconv.Itoa(i))); v != nil {
+				t.Fatalf("unexpected value: %v, i=%d", v, i)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Deleting a very large list of keys will cause the freelist to use overflow.
+func TestBucket_Delete_FreelistOverflow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	k := make([]byte, 16)
+	for i := uint64(0); i < 10000; i++ {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists([]byte("0"))
+			if err != nil {
+				t.Fatalf("bucket error: %s", err)
+			}
+
+			for j := uint64(0); j < 1000; j++ {
+				binary.BigEndian.PutUint64(k[:8], i)
+				binary.BigEndian.PutUint64(k[8:], j)
+				if err := b.Put(k, nil); err != nil {
+					t.Fatalf("put error: %s", err)
+				}
+			}
+
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Delete all of them in one large transaction
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("0"))
+		c := b.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if err := c.Delete(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check more than an overflow's worth of pages are freed.
+	stats := db.Stats()
+	freePages := stats.FreePageN + stats.PendingPageN
+	if freePages <= 0xFFFF {
+		t.Fatalf("expected more than 0xFFFF free pages, got %v", freePages)
+	}
+
+	// Free page count should be preserved on reopen.
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db.MustReopen()
+	if reopenFreePages := db.Stats().FreePageN; freePages != reopenFreePages {
+		t.Fatalf("expected %d free pages, got %+v", freePages, db.Stats())
+	}
+}
+
+// Ensure that deleting of non-existing key is a no-op.
+func TestBucket_Delete_NonExisting(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err = b.CreateBucket([]byte("nested")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		if err := b.Delete([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if b.Bucket([]byte("nested")) == nil {
+			t.Fatal("nested bucket has been deleted")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that accessing and updating nested buckets is ok across transactions.
+func TestBucket_Nested(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create a widgets bucket.
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a widgets/foo bucket.
+		_, err = b.CreateBucket([]byte("foo"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a widgets/bar key.
+		if err := b.Put([]byte("bar"), []byte("0000")); err != nil {
+			t.Fatal(err)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.MustCheck()
+
+	// Update widgets/bar.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		if err := b.Put([]byte("bar"), []byte("xxxx")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.MustCheck()
+
+	// Cause a split.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		var b = tx.Bucket([]byte("widgets"))
+		for i := 0; i < 10000; i++ {
+			if err := b.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.MustCheck()
+
+	// Insert into widgets/foo/baz.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		var b = tx.Bucket([]byte("widgets"))
+		if err := b.Bucket([]byte("foo")).Put([]byte("baz"), []byte("yyyy")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.MustCheck()
+
+	// Verify.
+	if err := db.View(func(tx *bolt.Tx) error {
+		var b = tx.Bucket([]byte("widgets"))
+		if v := b.Bucket([]byte("foo")).Get([]byte("baz")); !bytes.Equal(v, []byte("yyyy")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		if v := b.Get([]byte("bar")); !bytes.Equal(v, []byte("xxxx")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		for i := 0; i < 10000; i++ {
+			if v := b.Get([]byte(strconv.Itoa(i))); !bytes.Equal(v, []byte(strconv.Itoa(i))) {
+				t.Fatalf("unexpected value: %v", v)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a bucket using Delete() returns an error.
+func TestBucket_Delete_Bucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Delete([]byte("foo")); err != bolt.ErrIncompatibleValue {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a key on a read-only bucket returns an error.
+func TestBucket_Delete_ReadOnly(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		if err := tx.Bucket([]byte("widgets")).Delete([]byte("foo")); err != bolt.ErrTxNotWritable {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a deleting value while the transaction is closed returns an error.
+func TestBucket_Delete_Closed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := tx.CreateBucket([]byte("widgets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Delete([]byte("foo")); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that deleting a bucket causes nested buckets to be deleted.
+func TestBucket_DeleteBucket_Nested(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		foo, err := widgets.CreateBucket([]byte("foo"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		bar, err := foo.CreateBucket([]byte("bar"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := bar.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Bucket([]byte("widgets")).DeleteBucket([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a bucket causes nested buckets to be deleted after they have been committed.
+func TestBucket_DeleteBucket_Nested2(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		foo, err := widgets.CreateBucket([]byte("foo"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		bar, err := foo.CreateBucket([]byte("bar"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := bar.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets := tx.Bucket([]byte("widgets"))
+		if widgets == nil {
+			t.Fatal("expected widgets bucket")
+		}
+
+		foo := widgets.Bucket([]byte("foo"))
+		if foo == nil {
+			t.Fatal("expected foo bucket")
+		}
+
+		bar := foo.Bucket([]byte("bar"))
+		if bar == nil {
+			t.Fatal("expected bar bucket")
+		}
+
+		if v := bar.Get([]byte("baz")); !bytes.Equal(v, []byte("bat")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		if err := tx.DeleteBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte("widgets")) != nil {
+			t.Fatal("expected bucket to be deleted")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a child bucket with multiple pages causes all pages to get collected.
+// NOTE: Consistency check in bolt_test.DB.Close() will panic if pages not freed properly.
+func TestBucket_DeleteBucket_Large(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		foo, err := widgets.CreateBucket([]byte("foo"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < 1000; i++ {
+			if err := foo.Put([]byte(fmt.Sprintf("%d", i)), []byte(fmt.Sprintf("%0100d", i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a simple value retrieved via Bucket() returns a nil.
+func TestBucket_Bucket_IncompatibleValue(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := widgets.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if b := tx.Bucket([]byte("widgets")).Bucket([]byte("foo")); b != nil {
+			t.Fatal("expected nil bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that creating a bucket on an existing non-bucket key returns an error.
+func TestBucket_CreateBucket_IncompatibleValue(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := widgets.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := widgets.CreateBucket([]byte("foo")); err != bolt.ErrIncompatibleValue {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a bucket on an existing non-bucket key returns an error.
+func TestBucket_DeleteBucket_IncompatibleValue(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := widgets.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Bucket([]byte("widgets")).DeleteBucket([]byte("foo")); err != bolt.ErrIncompatibleValue {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure bucket can set and update its sequence number.
+func TestBucket_Sequence(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		bkt, err := tx.CreateBucket([]byte("0"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Retrieve sequence.
+		if v := bkt.Sequence(); v != 0 {
+			t.Fatalf("unexpected sequence: %d", v)
+		}
+
+		// Update sequence.
+		if err := bkt.SetSequence(1000); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read sequence again.
+		if v := bkt.Sequence(); v != 1000 {
+			t.Fatalf("unexpected sequence: %d", v)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify sequence in separate transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		if v := tx.Bucket([]byte("0")).Sequence(); v != 1000 {
+			t.Fatalf("unexpected sequence: %d", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can return an autoincrementing sequence.
+func TestBucket_NextSequence(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		widgets, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		woojits, err := tx.CreateBucket([]byte("woojits"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Make sure sequence increments.
+		if seq, err := widgets.NextSequence(); err != nil {
+			t.Fatal(err)
+		} else if seq != 1 {
+			t.Fatalf("unexpecte sequence: %d", seq)
+		}
+
+		if seq, err := widgets.NextSequence(); err != nil {
+			t.Fatal(err)
+		} else if seq != 2 {
+			t.Fatalf("unexpected sequence: %d", seq)
+		}
+
+		// Buckets should be separate.
+		if seq, err := woojits.NextSequence(); err != nil {
+			t.Fatal(err)
+		} else if seq != 1 {
+			t.Fatalf("unexpected sequence: %d", 1)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket will persist an autoincrementing sequence even if its
+// the only thing updated on the bucket.
+// https://github.com/boltdb/bolt/issues/296
+func TestBucket_NextSequence_Persist(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.Bucket([]byte("widgets")).NextSequence(); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		seq, err := tx.Bucket([]byte("widgets")).NextSequence()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		} else if seq != 2 {
+			t.Fatalf("unexpected sequence: %d", seq)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that retrieving the next sequence on a read-only bucket returns an error.
+func TestBucket_NextSequence_ReadOnly(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		_, err := tx.Bucket([]byte("widgets")).NextSequence()
+		if err != bolt.ErrTxNotWritable {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that retrieving the next sequence for a bucket on a closed database return an error.
+func TestBucket_NextSequence_Closed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := tx.CreateBucket([]byte("widgets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.NextSequence(); err != bolt.ErrTxClosed {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a user can loop over all key/value pairs in a bucket.
+func TestBucket_ForEach(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("0000")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("0001")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("bar"), []byte("0002")); err != nil {
+			t.Fatal(err)
+		}
+
+		var index int
+		if err := b.ForEach(func(k, v []byte) error {
+			switch index {
+			case 0:
+				if !bytes.Equal(k, []byte("bar")) {
+					t.Fatalf("unexpected key: %v", k)
+				} else if !bytes.Equal(v, []byte("0002")) {
+					t.Fatalf("unexpected value: %v", v)
+				}
+			case 1:
+				if !bytes.Equal(k, []byte("baz")) {
+					t.Fatalf("unexpected key: %v", k)
+				} else if !bytes.Equal(v, []byte("0001")) {
+					t.Fatalf("unexpected value: %v", v)
+				}
+			case 2:
+				if !bytes.Equal(k, []byte("foo")) {
+					t.Fatalf("unexpected key: %v", k)
+				} else if !bytes.Equal(v, []byte("0000")) {
+					t.Fatalf("unexpected value: %v", v)
+				}
+			}
+			index++
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if index != 3 {
+			t.Fatalf("unexpected index: %d", index)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a database can stop iteration early.
+func TestBucket_ForEach_ShortCircuit(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("bar"), []byte("0000")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("0000")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("0000")); err != nil {
+			t.Fatal(err)
+		}
+
+		var index int
+		if err := tx.Bucket([]byte("widgets")).ForEach(func(k, v []byte) error {
+			index++
+			if bytes.Equal(k, []byte("baz")) {
+				return errors.New("marker")
+			}
+			return nil
+		}); err == nil || err.Error() != "marker" {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if index != 2 {
+			t.Fatalf("unexpected index: %d", index)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that looping over a bucket on a closed database returns an error.
+func TestBucket_ForEach_Closed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := tx.CreateBucket([]byte("widgets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.ForEach(func(k, v []byte) error { return nil }); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that an error is returned when inserting with an empty key.
+func TestBucket_Put_EmptyKey(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte(""), []byte("bar")); err != bolt.ErrKeyRequired {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := b.Put(nil, []byte("bar")); err != bolt.ErrKeyRequired {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that an error is returned when inserting with a key that's too large.
+func TestBucket_Put_KeyTooLarge(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put(make([]byte, 32769), []byte("bar")); err != bolt.ErrKeyTooLarge {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that an error is returned when inserting a value that's too large.
+func TestBucket_Put_ValueTooLarge(t *testing.T) {
+	// Skip this test on DroneCI because the machine is resource constrained.
+	if os.Getenv("DRONE") == "true" {
+		t.Skip("not enough RAM for test")
+	}
+
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), make([]byte, bolt.MaxValueSize+1)); err != bolt.ErrValueTooLarge {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a bucket can calculate stats.
+func TestBucket_Stats(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Add bucket with fewer keys but one big value.
+	bigKey := []byte("really-big-value")
+	for i := 0; i < 500; i++ {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists([]byte("woojits"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := b.Put([]byte(fmt.Sprintf("%03d", i)), []byte(strconv.Itoa(i))); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if err := tx.Bucket([]byte("woojits")).Put(bigKey, []byte(strings.Repeat("*", 10000))); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db.MustCheck()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		stats := tx.Bucket([]byte("woojits")).Stats()
+		if stats.BranchPageN != 1 {
+			t.Fatalf("unexpected BranchPageN: %d", stats.BranchPageN)
+		} else if stats.BranchOverflowN != 0 {
+			t.Fatalf("unexpected BranchOverflowN: %d", stats.BranchOverflowN)
+		} else if stats.LeafPageN != 7 {
+			t.Fatalf("unexpected LeafPageN: %d", stats.LeafPageN)
+		} else if stats.LeafOverflowN != 2 {
+			t.Fatalf("unexpected LeafOverflowN: %d", stats.LeafOverflowN)
+		} else if stats.KeyN != 501 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		} else if stats.Depth != 2 {
+			t.Fatalf("unexpected Depth: %d", stats.Depth)
+		}
+
+		branchInuse := 16     // branch page header
+		branchInuse += 7 * 16 // branch elements
+		branchInuse += 7 * 3  // branch keys (6 3-byte keys)
+		if stats.BranchInuse != branchInuse {
+			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+		}
+
+		leafInuse := 7 * 16                      // leaf page header
+		leafInuse += 501 * 16                    // leaf elements
+		leafInuse += 500*3 + len(bigKey)         // leaf keys
+		leafInuse += 1*10 + 2*90 + 3*400 + 10000 // leaf values
+		if stats.LeafInuse != leafInuse {
+			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+		}
+
+		// Only check allocations for 4KB pages.
+		if db.Info().PageSize == 4096 {
+			if stats.BranchAlloc != 4096 {
+				t.Fatalf("unexpected BranchAlloc: %d", stats.BranchAlloc)
+			} else if stats.LeafAlloc != 36864 {
+				t.Fatalf("unexpected LeafAlloc: %d", stats.LeafAlloc)
+			}
+		}
+
+		if stats.BucketN != 1 {
+			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
+		} else if stats.InlineBucketN != 0 {
+			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
+		} else if stats.InlineBucketInuse != 0 {
+			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a bucket with random insertion utilizes fill percentage correctly.
+func TestBucket_Stats_RandomFill(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	} else if os.Getpagesize() != 4096 {
+		t.Skip("invalid page size for test")
+	}
+
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Add a set of values in random order. It will be the same random
+	// order so we can maintain consistency between test runs.
+	var count int
+	rand := rand.New(rand.NewSource(42))
+	for _, i := range rand.Perm(1000) {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists([]byte("woojits"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			b.FillPercent = 0.9
+			for _, j := range rand.Perm(100) {
+				index := (j * 10000) + i
+				if err := b.Put([]byte(fmt.Sprintf("%d000000000000000", index)), []byte("0000000000")); err != nil {
+					t.Fatal(err)
+				}
+				count++
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	db.MustCheck()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		stats := tx.Bucket([]byte("woojits")).Stats()
+		if stats.KeyN != 100000 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		}
+
+		if stats.BranchPageN != 98 {
+			t.Fatalf("unexpected BranchPageN: %d", stats.BranchPageN)
+		} else if stats.BranchOverflowN != 0 {
+			t.Fatalf("unexpected BranchOverflowN: %d", stats.BranchOverflowN)
+		} else if stats.BranchInuse != 130984 {
+			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+		} else if stats.BranchAlloc != 401408 {
+			t.Fatalf("unexpected BranchAlloc: %d", stats.BranchAlloc)
+		}
+
+		if stats.LeafPageN != 3412 {
+			t.Fatalf("unexpected LeafPageN: %d", stats.LeafPageN)
+		} else if stats.LeafOverflowN != 0 {
+			t.Fatalf("unexpected LeafOverflowN: %d", stats.LeafOverflowN)
+		} else if stats.LeafInuse != 4742482 {
+			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+		} else if stats.LeafAlloc != 13975552 {
+			t.Fatalf("unexpected LeafAlloc: %d", stats.LeafAlloc)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a bucket can calculate stats.
+func TestBucket_Stats_Small(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Add a bucket that fits on a single root leaf.
+		b, err := tx.CreateBucket([]byte("whozawhats"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db.MustCheck()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("whozawhats"))
+		stats := b.Stats()
+		if stats.BranchPageN != 0 {
+			t.Fatalf("unexpected BranchPageN: %d", stats.BranchPageN)
+		} else if stats.BranchOverflowN != 0 {
+			t.Fatalf("unexpected BranchOverflowN: %d", stats.BranchOverflowN)
+		} else if stats.LeafPageN != 0 {
+			t.Fatalf("unexpected LeafPageN: %d", stats.LeafPageN)
+		} else if stats.LeafOverflowN != 0 {
+			t.Fatalf("unexpected LeafOverflowN: %d", stats.LeafOverflowN)
+		} else if stats.KeyN != 1 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		} else if stats.Depth != 1 {
+			t.Fatalf("unexpected Depth: %d", stats.Depth)
+		} else if stats.BranchInuse != 0 {
+			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+		} else if stats.LeafInuse != 0 {
+			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+		}
+
+		if db.Info().PageSize == 4096 {
+			if stats.BranchAlloc != 0 {
+				t.Fatalf("unexpected BranchAlloc: %d", stats.BranchAlloc)
+			} else if stats.LeafAlloc != 0 {
+				t.Fatalf("unexpected LeafAlloc: %d", stats.LeafAlloc)
+			}
+		}
+
+		if stats.BucketN != 1 {
+			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
+		} else if stats.InlineBucketN != 1 {
+			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
+		} else if stats.InlineBucketInuse != 16+16+6 {
+			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBucket_Stats_EmptyBucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Add a bucket that fits on a single root leaf.
+		if _, err := tx.CreateBucket([]byte("whozawhats")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db.MustCheck()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("whozawhats"))
+		stats := b.Stats()
+		if stats.BranchPageN != 0 {
+			t.Fatalf("unexpected BranchPageN: %d", stats.BranchPageN)
+		} else if stats.BranchOverflowN != 0 {
+			t.Fatalf("unexpected BranchOverflowN: %d", stats.BranchOverflowN)
+		} else if stats.LeafPageN != 0 {
+			t.Fatalf("unexpected LeafPageN: %d", stats.LeafPageN)
+		} else if stats.LeafOverflowN != 0 {
+			t.Fatalf("unexpected LeafOverflowN: %d", stats.LeafOverflowN)
+		} else if stats.KeyN != 0 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		} else if stats.Depth != 1 {
+			t.Fatalf("unexpected Depth: %d", stats.Depth)
+		} else if stats.BranchInuse != 0 {
+			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+		} else if stats.LeafInuse != 0 {
+			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+		}
+
+		if db.Info().PageSize == 4096 {
+			if stats.BranchAlloc != 0 {
+				t.Fatalf("unexpected BranchAlloc: %d", stats.BranchAlloc)
+			} else if stats.LeafAlloc != 0 {
+				t.Fatalf("unexpected LeafAlloc: %d", stats.LeafAlloc)
+			}
+		}
+
+		if stats.BucketN != 1 {
+			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
+		} else if stats.InlineBucketN != 1 {
+			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
+		} else if stats.InlineBucketInuse != 16 {
+			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a bucket can calculate stats.
+func TestBucket_Stats_Nested(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("foo"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 100; i++ {
+			if err := b.Put([]byte(fmt.Sprintf("%02d", i)), []byte(fmt.Sprintf("%02d", i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		bar, err := b.CreateBucket([]byte("bar"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 10; i++ {
+			if err := bar.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		baz, err := bar.CreateBucket([]byte("baz"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 10; i++ {
+			if err := baz.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db.MustCheck()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("foo"))
+		stats := b.Stats()
+		if stats.BranchPageN != 0 {
+			t.Fatalf("unexpected BranchPageN: %d", stats.BranchPageN)
+		} else if stats.BranchOverflowN != 0 {
+			t.Fatalf("unexpected BranchOverflowN: %d", stats.BranchOverflowN)
+		} else if stats.LeafPageN != 2 {
+			t.Fatalf("unexpected LeafPageN: %d", stats.LeafPageN)
+		} else if stats.LeafOverflowN != 0 {
+			t.Fatalf("unexpected LeafOverflowN: %d", stats.LeafOverflowN)
+		} else if stats.KeyN != 122 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		} else if stats.Depth != 3 {
+			t.Fatalf("unexpected Depth: %d", stats.Depth)
+		} else if stats.BranchInuse != 0 {
+			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+		}
+
+		foo := 16            // foo (pghdr)
+		foo += 101 * 16      // foo leaf elements
+		foo += 100*2 + 100*2 // foo leaf key/values
+		foo += 3 + 16        // foo -> bar key/value
+
+		bar := 16      // bar (pghdr)
+		bar += 11 * 16 // bar leaf elements
+		bar += 10 + 10 // bar leaf key/values
+		bar += 3 + 16  // bar -> baz key/value
+
+		baz := 16      // baz (inline) (pghdr)
+		baz += 10 * 16 // baz leaf elements
+		baz += 10 + 10 // baz leaf key/values
+
+		if stats.LeafInuse != foo+bar+baz {
+			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+		}
+
+		if db.Info().PageSize == 4096 {
+			if stats.BranchAlloc != 0 {
+				t.Fatalf("unexpected BranchAlloc: %d", stats.BranchAlloc)
+			} else if stats.LeafAlloc != 8192 {
+				t.Fatalf("unexpected LeafAlloc: %d", stats.LeafAlloc)
+			}
+		}
+
+		if stats.BucketN != 3 {
+			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
+		} else if stats.InlineBucketN != 1 {
+			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
+		} else if stats.InlineBucketInuse != baz {
+			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a large bucket can calculate stats.
+func TestBucket_Stats_Large(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var index int
+	for i := 0; i < 100; i++ {
+		// Add bucket with lots of keys.
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists([]byte("widgets"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < 1000; i++ {
+				if err := b.Put([]byte(strconv.Itoa(index)), []byte(strconv.Itoa(index))); err != nil {
+					t.Fatal(err)
+				}
+				index++
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	db.MustCheck()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		stats := tx.Bucket([]byte("widgets")).Stats()
+		if stats.BranchPageN != 13 {
+			t.Fatalf("unexpected BranchPageN: %d", stats.BranchPageN)
+		} else if stats.BranchOverflowN != 0 {
+			t.Fatalf("unexpected BranchOverflowN: %d", stats.BranchOverflowN)
+		} else if stats.LeafPageN != 1196 {
+			t.Fatalf("unexpected LeafPageN: %d", stats.LeafPageN)
+		} else if stats.LeafOverflowN != 0 {
+			t.Fatalf("unexpected LeafOverflowN: %d", stats.LeafOverflowN)
+		} else if stats.KeyN != 100000 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		} else if stats.Depth != 3 {
+			t.Fatalf("unexpected Depth: %d", stats.Depth)
+		} else if stats.BranchInuse != 25257 {
+			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+		} else if stats.LeafInuse != 2596916 {
+			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+		}
+
+		if db.Info().PageSize == 4096 {
+			if stats.BranchAlloc != 53248 {
+				t.Fatalf("unexpected BranchAlloc: %d", stats.BranchAlloc)
+			} else if stats.LeafAlloc != 4898816 {
+				t.Fatalf("unexpected LeafAlloc: %d", stats.LeafAlloc)
+			}
+		}
+
+		if stats.BucketN != 1 {
+			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
+		} else if stats.InlineBucketN != 0 {
+			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
+		} else if stats.InlineBucketInuse != 0 {
+			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can write random keys and values across multiple transactions.
+func TestBucket_Put_Single(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	index := 0
+	if err := quick.Check(func(items testdata) bool {
+		db := MustOpenDB()
+		defer db.MustClose()
+
+		m := make(map[string][]byte)
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, item := range items {
+			if err := db.Update(func(tx *bolt.Tx) error {
+				if err := tx.Bucket([]byte("widgets")).Put(item.Key, item.Value); err != nil {
+					panic("put error: " + err.Error())
+				}
+				m[string(item.Key)] = item.Value
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify all key/values so far.
+			if err := db.View(func(tx *bolt.Tx) error {
+				i := 0
+				for k, v := range m {
+					value := tx.Bucket([]byte("widgets")).Get([]byte(k))
+					if !bytes.Equal(value, v) {
+						t.Logf("value mismatch [run %d] (%d of %d):\nkey: %x\ngot: %x\nexp: %x", index, i, len(m), []byte(k), value, v)
+						db.CopyTempFile()
+						t.FailNow()
+					}
+					i++
+				}
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		index++
+		return true
+	}, qconfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+// Ensure that a transaction can insert multiple key/value pairs at once.
+func TestBucket_Put_Multiple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	if err := quick.Check(func(items testdata) bool {
+		db := MustOpenDB()
+		defer db.MustClose()
+
+		// Bulk insert all values.
+		if err := db.Update(func(tx *bolt.Tx) error {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte("widgets"))
+			for _, item := range items {
+				if err := b.Put(item.Key, item.Value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify all items exist.
+		if err := db.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte("widgets"))
+			for _, item := range items {
+				value := b.Get(item.Key)
+				if !bytes.Equal(item.Value, value) {
+					db.CopyTempFile()
+					t.Fatalf("exp=%x; got=%x", item.Value, value)
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		return true
+	}, qconfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+// Ensure that a transaction can delete all key/value pairs and return to a single leaf page.
+func TestBucket_Delete_Quick(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	if err := quick.Check(func(items testdata) bool {
+		db := MustOpenDB()
+		defer db.MustClose()
+
+		// Bulk insert all values.
+		if err := db.Update(func(tx *bolt.Tx) error {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte("widgets"))
+			for _, item := range items {
+				if err := b.Put(item.Key, item.Value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Remove items one at a time and check consistency.
+		for _, item := range items {
+			if err := db.Update(func(tx *bolt.Tx) error {
+				return tx.Bucket([]byte("widgets")).Delete(item.Key)
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Anything before our deletion index should be nil.
+		if err := db.View(func(tx *bolt.Tx) error {
+			if err := tx.Bucket([]byte("widgets")).ForEach(func(k, v []byte) error {
+				t.Fatalf("bucket should be empty; found: %06x", trunc(k, 3))
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		return true
+	}, qconfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+func ExampleBucket_Put() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Start a write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create a bucket.
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			return err
+		}
+
+		// Set the value "bar" for the key "foo".
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Read value back in a different read-only transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		fmt.Printf("The value of 'foo' is: %s\n", value)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// The value of 'foo' is: bar
+}
+
+func ExampleBucket_Delete() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Start a write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create a bucket.
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			return err
+		}
+
+		// Set the value "bar" for the key "foo".
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			return err
+		}
+
+		// Retrieve the key back from the database and verify it.
+		value := b.Get([]byte("foo"))
+		fmt.Printf("The value of 'foo' was: %s\n", value)
+
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Delete the key in a different write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("widgets")).Delete([]byte("foo"))
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Retrieve the key again.
+	if err := db.View(func(tx *bolt.Tx) error {
+		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		if value == nil {
+			fmt.Printf("The value of 'foo' is now: nil\n")
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// The value of 'foo' was: bar
+	// The value of 'foo' is now: nil
+}
+
+func ExampleBucket_ForEach() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Insert data into a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("animals"))
+		if err != nil {
+			return err
+		}
+
+		if err := b.Put([]byte("dog"), []byte("fun")); err != nil {
+			return err
+		}
+		if err := b.Put([]byte("cat"), []byte("lame")); err != nil {
+			return err
+		}
+		if err := b.Put([]byte("liger"), []byte("awesome")); err != nil {
+			return err
+		}
+
+		// Iterate over items in sorted key order.
+		if err := b.ForEach(func(k, v []byte) error {
+			fmt.Printf("A %s is %s.\n", k, v)
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// A cat is lame.
+	// A dog is fun.
+	// A liger is awesome.
+}

--- a/vendor/github.com/coreos/bbolt/cmd/bolt/main.go
+++ b/vendor/github.com/coreos/bbolt/cmd/bolt/main.go
@@ -1,0 +1,1960 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+	"unsafe"
+
+	bolt "github.com/coreos/bbolt"
+)
+
+var (
+	// ErrUsage is returned when a usage message was printed and the process
+	// should simply exit with an error.
+	ErrUsage = errors.New("usage")
+
+	// ErrUnknownCommand is returned when a CLI command is not specified.
+	ErrUnknownCommand = errors.New("unknown command")
+
+	// ErrPathRequired is returned when the path to a Bolt database is not specified.
+	ErrPathRequired = errors.New("path required")
+
+	// ErrFileNotFound is returned when a Bolt database does not exist.
+	ErrFileNotFound = errors.New("file not found")
+
+	// ErrInvalidValue is returned when a benchmark reads an unexpected value.
+	ErrInvalidValue = errors.New("invalid value")
+
+	// ErrCorrupt is returned when a checking a data file finds errors.
+	ErrCorrupt = errors.New("invalid value")
+
+	// ErrNonDivisibleBatchSize is returned when the batch size can't be evenly
+	// divided by the iteration count.
+	ErrNonDivisibleBatchSize = errors.New("number of iterations must be divisible by the batch size")
+
+	// ErrPageIDRequired is returned when a required page id is not specified.
+	ErrPageIDRequired = errors.New("page id required")
+
+	// ErrBucketRequired is returned when a bucket is not specified.
+	ErrBucketRequired = errors.New("bucket required")
+
+	// ErrBucketNotFound is returned when a bucket is not found.
+	ErrBucketNotFound = errors.New("bucket not found")
+
+	// ErrKeyRequired is returned when a key is not specified.
+	ErrKeyRequired = errors.New("key required")
+
+	// ErrKeyNotFound is returned when a key is not found.
+	ErrKeyNotFound = errors.New("key not found")
+)
+
+// PageHeaderSize represents the size of the bolt.page header.
+const PageHeaderSize = 16
+
+func main() {
+	m := NewMain()
+	if err := m.Run(os.Args[1:]...); err == ErrUsage {
+		os.Exit(2)
+	} else if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+// Main represents the main program execution.
+type Main struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewMain returns a new instance of Main connect to the standard input/output.
+func NewMain() *Main {
+	return &Main{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+// Run executes the program.
+func (m *Main) Run(args ...string) error {
+	// Require a command at the beginning.
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		fmt.Fprintln(m.Stderr, m.Usage())
+		return ErrUsage
+	}
+
+	// Execute command.
+	switch args[0] {
+	case "help":
+		fmt.Fprintln(m.Stderr, m.Usage())
+		return ErrUsage
+	case "bench":
+		return newBenchCommand(m).Run(args[1:]...)
+	case "buckets":
+		return newBucketsCommand(m).Run(args[1:]...)
+	case "check":
+		return newCheckCommand(m).Run(args[1:]...)
+	case "compact":
+		return newCompactCommand(m).Run(args[1:]...)
+	case "dump":
+		return newDumpCommand(m).Run(args[1:]...)
+	case "get":
+		return newGetCommand(m).Run(args[1:]...)
+	case "info":
+		return newInfoCommand(m).Run(args[1:]...)
+	case "keys":
+		return newKeysCommand(m).Run(args[1:]...)
+	case "page":
+		return newPageCommand(m).Run(args[1:]...)
+	case "pages":
+		return newPagesCommand(m).Run(args[1:]...)
+	case "stats":
+		return newStatsCommand(m).Run(args[1:]...)
+	default:
+		return ErrUnknownCommand
+	}
+}
+
+// Usage returns the help message.
+func (m *Main) Usage() string {
+	return strings.TrimLeft(`
+Bolt is a tool for inspecting bolt databases.
+
+Usage:
+
+	bolt command [arguments]
+
+The commands are:
+
+    bench       run synthetic benchmark against bolt
+    buckets     print a list of buckets
+    check       verifies integrity of bolt database
+    compact     copies a bolt database, compacting it in the process
+    dump        print a hexadecimal dump of a single page
+    get         print the value of a key in a bucket
+    info        print basic info
+    keys        print a list of keys in a bucket
+    help        print this screen
+    page        print one or more pages in human readable format
+    pages       print list of pages with their types
+    stats       iterate over all pages and generate usage stats
+
+Use "bolt [command] -h" for more information about a command.
+`, "\n")
+}
+
+// CheckCommand represents the "check" command execution.
+type CheckCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewCheckCommand returns a CheckCommand.
+func newCheckCommand(m *Main) *CheckCommand {
+	return &CheckCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *CheckCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path.
+	path := fs.Arg(0)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Open database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Perform consistency check.
+	return db.View(func(tx *bolt.Tx) error {
+		var count int
+		for err := range tx.Check() {
+			fmt.Fprintln(cmd.Stdout, err)
+			count++
+		}
+
+		// Print summary of errors.
+		if count > 0 {
+			fmt.Fprintf(cmd.Stdout, "%d errors found\n", count)
+			return ErrCorrupt
+		}
+
+		// Notify user that database is valid.
+		fmt.Fprintln(cmd.Stdout, "OK")
+		return nil
+	})
+}
+
+// Usage returns the help message.
+func (cmd *CheckCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt check PATH
+
+Check opens a database at PATH and runs an exhaustive check to verify that
+all pages are accessible or are marked as freed. It also verifies that no
+pages are double referenced.
+
+Verification errors will stream out as they are found and the process will
+return after all pages have been checked.
+`, "\n")
+}
+
+// InfoCommand represents the "info" command execution.
+type InfoCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewInfoCommand returns a InfoCommand.
+func newInfoCommand(m *Main) *InfoCommand {
+	return &InfoCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *InfoCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path.
+	path := fs.Arg(0)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Open the database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Print basic database info.
+	info := db.Info()
+	fmt.Fprintf(cmd.Stdout, "Page Size: %d\n", info.PageSize)
+
+	return nil
+}
+
+// Usage returns the help message.
+func (cmd *InfoCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt info PATH
+
+Info prints basic information about the Bolt database at PATH.
+`, "\n")
+}
+
+// DumpCommand represents the "dump" command execution.
+type DumpCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// newDumpCommand returns a DumpCommand.
+func newDumpCommand(m *Main) *DumpCommand {
+	return &DumpCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *DumpCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path and page id.
+	path := fs.Arg(0)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Read page ids.
+	pageIDs, err := atois(fs.Args()[1:])
+	if err != nil {
+		return err
+	} else if len(pageIDs) == 0 {
+		return ErrPageIDRequired
+	}
+
+	// Open database to retrieve page size.
+	pageSize, err := ReadPageSize(path)
+	if err != nil {
+		return err
+	}
+
+	// Open database file handler.
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Print each page listed.
+	for i, pageID := range pageIDs {
+		// Print a separator.
+		if i > 0 {
+			fmt.Fprintln(cmd.Stdout, "===============================================")
+		}
+
+		// Print page to stdout.
+		if err := cmd.PrintPage(cmd.Stdout, f, pageID, pageSize); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PrintPage prints a given page as hexadecimal.
+func (cmd *DumpCommand) PrintPage(w io.Writer, r io.ReaderAt, pageID int, pageSize int) error {
+	const bytesPerLineN = 16
+
+	// Read page into buffer.
+	buf := make([]byte, pageSize)
+	addr := pageID * pageSize
+	if n, err := r.ReadAt(buf, int64(addr)); err != nil {
+		return err
+	} else if n != pageSize {
+		return io.ErrUnexpectedEOF
+	}
+
+	// Write out to writer in 16-byte lines.
+	var prev []byte
+	var skipped bool
+	for offset := 0; offset < pageSize; offset += bytesPerLineN {
+		// Retrieve current 16-byte line.
+		line := buf[offset : offset+bytesPerLineN]
+		isLastLine := (offset == (pageSize - bytesPerLineN))
+
+		// If it's the same as the previous line then print a skip.
+		if bytes.Equal(line, prev) && !isLastLine {
+			if !skipped {
+				fmt.Fprintf(w, "%07x *\n", addr+offset)
+				skipped = true
+			}
+		} else {
+			// Print line as hexadecimal in 2-byte groups.
+			fmt.Fprintf(w, "%07x %04x %04x %04x %04x %04x %04x %04x %04x\n", addr+offset,
+				line[0:2], line[2:4], line[4:6], line[6:8],
+				line[8:10], line[10:12], line[12:14], line[14:16],
+			)
+
+			skipped = false
+		}
+
+		// Save the previous line.
+		prev = line
+	}
+	fmt.Fprint(w, "\n")
+
+	return nil
+}
+
+// Usage returns the help message.
+func (cmd *DumpCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt dump -page PAGEID PATH
+
+Dump prints a hexadecimal dump of a single page.
+`, "\n")
+}
+
+// PageCommand represents the "page" command execution.
+type PageCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// newPageCommand returns a PageCommand.
+func newPageCommand(m *Main) *PageCommand {
+	return &PageCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *PageCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path and page id.
+	path := fs.Arg(0)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Read page ids.
+	pageIDs, err := atois(fs.Args()[1:])
+	if err != nil {
+		return err
+	} else if len(pageIDs) == 0 {
+		return ErrPageIDRequired
+	}
+
+	// Open database file handler.
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Print each page listed.
+	for i, pageID := range pageIDs {
+		// Print a separator.
+		if i > 0 {
+			fmt.Fprintln(cmd.Stdout, "===============================================")
+		}
+
+		// Retrieve page info and page size.
+		p, buf, err := ReadPage(path, pageID)
+		if err != nil {
+			return err
+		}
+
+		// Print basic page info.
+		fmt.Fprintf(cmd.Stdout, "Page ID:    %d\n", p.id)
+		fmt.Fprintf(cmd.Stdout, "Page Type:  %s\n", p.Type())
+		fmt.Fprintf(cmd.Stdout, "Total Size: %d bytes\n", len(buf))
+
+		// Print type-specific data.
+		switch p.Type() {
+		case "meta":
+			err = cmd.PrintMeta(cmd.Stdout, buf)
+		case "leaf":
+			err = cmd.PrintLeaf(cmd.Stdout, buf)
+		case "branch":
+			err = cmd.PrintBranch(cmd.Stdout, buf)
+		case "freelist":
+			err = cmd.PrintFreelist(cmd.Stdout, buf)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PrintMeta prints the data from the meta page.
+func (cmd *PageCommand) PrintMeta(w io.Writer, buf []byte) error {
+	m := (*meta)(unsafe.Pointer(&buf[PageHeaderSize]))
+	fmt.Fprintf(w, "Version:    %d\n", m.version)
+	fmt.Fprintf(w, "Page Size:  %d bytes\n", m.pageSize)
+	fmt.Fprintf(w, "Flags:      %08x\n", m.flags)
+	fmt.Fprintf(w, "Root:       <pgid=%d>\n", m.root.root)
+	fmt.Fprintf(w, "Freelist:   <pgid=%d>\n", m.freelist)
+	fmt.Fprintf(w, "HWM:        <pgid=%d>\n", m.pgid)
+	fmt.Fprintf(w, "Txn ID:     %d\n", m.txid)
+	fmt.Fprintf(w, "Checksum:   %016x\n", m.checksum)
+	fmt.Fprintf(w, "\n")
+	return nil
+}
+
+// PrintLeaf prints the data for a leaf page.
+func (cmd *PageCommand) PrintLeaf(w io.Writer, buf []byte) error {
+	p := (*page)(unsafe.Pointer(&buf[0]))
+
+	// Print number of items.
+	fmt.Fprintf(w, "Item Count: %d\n", p.count)
+	fmt.Fprintf(w, "\n")
+
+	// Print each key/value.
+	for i := uint16(0); i < p.count; i++ {
+		e := p.leafPageElement(i)
+
+		// Format key as string.
+		var k string
+		if isPrintable(string(e.key())) {
+			k = fmt.Sprintf("%q", string(e.key()))
+		} else {
+			k = fmt.Sprintf("%x", string(e.key()))
+		}
+
+		// Format value as string.
+		var v string
+		if (e.flags & uint32(bucketLeafFlag)) != 0 {
+			b := (*bucket)(unsafe.Pointer(&e.value()[0]))
+			v = fmt.Sprintf("<pgid=%d,seq=%d>", b.root, b.sequence)
+		} else if isPrintable(string(e.value())) {
+			v = fmt.Sprintf("%q", string(e.value()))
+		} else {
+			v = fmt.Sprintf("%x", string(e.value()))
+		}
+
+		fmt.Fprintf(w, "%s: %s\n", k, v)
+	}
+	fmt.Fprintf(w, "\n")
+	return nil
+}
+
+// PrintBranch prints the data for a leaf page.
+func (cmd *PageCommand) PrintBranch(w io.Writer, buf []byte) error {
+	p := (*page)(unsafe.Pointer(&buf[0]))
+
+	// Print number of items.
+	fmt.Fprintf(w, "Item Count: %d\n", p.count)
+	fmt.Fprintf(w, "\n")
+
+	// Print each key/value.
+	for i := uint16(0); i < p.count; i++ {
+		e := p.branchPageElement(i)
+
+		// Format key as string.
+		var k string
+		if isPrintable(string(e.key())) {
+			k = fmt.Sprintf("%q", string(e.key()))
+		} else {
+			k = fmt.Sprintf("%x", string(e.key()))
+		}
+
+		fmt.Fprintf(w, "%s: <pgid=%d>\n", k, e.pgid)
+	}
+	fmt.Fprintf(w, "\n")
+	return nil
+}
+
+// PrintFreelist prints the data for a freelist page.
+func (cmd *PageCommand) PrintFreelist(w io.Writer, buf []byte) error {
+	p := (*page)(unsafe.Pointer(&buf[0]))
+
+	// Print number of items.
+	fmt.Fprintf(w, "Item Count: %d\n", p.count)
+	fmt.Fprintf(w, "\n")
+
+	// Print each page in the freelist.
+	ids := (*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr))
+	for i := uint16(0); i < p.count; i++ {
+		fmt.Fprintf(w, "%d\n", ids[i])
+	}
+	fmt.Fprintf(w, "\n")
+	return nil
+}
+
+// PrintPage prints a given page as hexadecimal.
+func (cmd *PageCommand) PrintPage(w io.Writer, r io.ReaderAt, pageID int, pageSize int) error {
+	const bytesPerLineN = 16
+
+	// Read page into buffer.
+	buf := make([]byte, pageSize)
+	addr := pageID * pageSize
+	if n, err := r.ReadAt(buf, int64(addr)); err != nil {
+		return err
+	} else if n != pageSize {
+		return io.ErrUnexpectedEOF
+	}
+
+	// Write out to writer in 16-byte lines.
+	var prev []byte
+	var skipped bool
+	for offset := 0; offset < pageSize; offset += bytesPerLineN {
+		// Retrieve current 16-byte line.
+		line := buf[offset : offset+bytesPerLineN]
+		isLastLine := (offset == (pageSize - bytesPerLineN))
+
+		// If it's the same as the previous line then print a skip.
+		if bytes.Equal(line, prev) && !isLastLine {
+			if !skipped {
+				fmt.Fprintf(w, "%07x *\n", addr+offset)
+				skipped = true
+			}
+		} else {
+			// Print line as hexadecimal in 2-byte groups.
+			fmt.Fprintf(w, "%07x %04x %04x %04x %04x %04x %04x %04x %04x\n", addr+offset,
+				line[0:2], line[2:4], line[4:6], line[6:8],
+				line[8:10], line[10:12], line[12:14], line[14:16],
+			)
+
+			skipped = false
+		}
+
+		// Save the previous line.
+		prev = line
+	}
+	fmt.Fprint(w, "\n")
+
+	return nil
+}
+
+// Usage returns the help message.
+func (cmd *PageCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt page -page PATH pageid [pageid...]
+
+Page prints one or more pages in human readable format.
+`, "\n")
+}
+
+// PagesCommand represents the "pages" command execution.
+type PagesCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewPagesCommand returns a PagesCommand.
+func newPagesCommand(m *Main) *PagesCommand {
+	return &PagesCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *PagesCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path.
+	path := fs.Arg(0)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Open database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	// Write header.
+	fmt.Fprintln(cmd.Stdout, "ID       TYPE       ITEMS  OVRFLW")
+	fmt.Fprintln(cmd.Stdout, "======== ========== ====== ======")
+
+	return db.Update(func(tx *bolt.Tx) error {
+		var id int
+		for {
+			p, err := tx.Page(id)
+			if err != nil {
+				return &PageError{ID: id, Err: err}
+			} else if p == nil {
+				break
+			}
+
+			// Only display count and overflow if this is a non-free page.
+			var count, overflow string
+			if p.Type != "free" {
+				count = strconv.Itoa(p.Count)
+				if p.OverflowCount > 0 {
+					overflow = strconv.Itoa(p.OverflowCount)
+				}
+			}
+
+			// Print table row.
+			fmt.Fprintf(cmd.Stdout, "%-8d %-10s %-6s %-6s\n", p.ID, p.Type, count, overflow)
+
+			// Move to the next non-overflow page.
+			id += 1
+			if p.Type != "free" {
+				id += p.OverflowCount
+			}
+		}
+		return nil
+	})
+}
+
+// Usage returns the help message.
+func (cmd *PagesCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt pages PATH
+
+Pages prints a table of pages with their type (meta, leaf, branch, freelist).
+Leaf and branch pages will show a key count in the "items" column while the
+freelist will show the number of free pages in the "items" column.
+
+The "overflow" column shows the number of blocks that the page spills over
+into. Normally there is no overflow but large keys and values can cause
+a single page to take up multiple blocks.
+`, "\n")
+}
+
+// StatsCommand represents the "stats" command execution.
+type StatsCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewStatsCommand returns a StatsCommand.
+func newStatsCommand(m *Main) *StatsCommand {
+	return &StatsCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *StatsCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path.
+	path, prefix := fs.Arg(0), fs.Arg(1)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Open database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	return db.View(func(tx *bolt.Tx) error {
+		var s bolt.BucketStats
+		var count int
+		if err := tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			if bytes.HasPrefix(name, []byte(prefix)) {
+				s.Add(b.Stats())
+				count += 1
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.Stdout, "Aggregate statistics for %d buckets\n\n", count)
+
+		fmt.Fprintln(cmd.Stdout, "Page count statistics")
+		fmt.Fprintf(cmd.Stdout, "\tNumber of logical branch pages: %d\n", s.BranchPageN)
+		fmt.Fprintf(cmd.Stdout, "\tNumber of physical branch overflow pages: %d\n", s.BranchOverflowN)
+		fmt.Fprintf(cmd.Stdout, "\tNumber of logical leaf pages: %d\n", s.LeafPageN)
+		fmt.Fprintf(cmd.Stdout, "\tNumber of physical leaf overflow pages: %d\n", s.LeafOverflowN)
+
+		fmt.Fprintln(cmd.Stdout, "Tree statistics")
+		fmt.Fprintf(cmd.Stdout, "\tNumber of keys/value pairs: %d\n", s.KeyN)
+		fmt.Fprintf(cmd.Stdout, "\tNumber of levels in B+tree: %d\n", s.Depth)
+
+		fmt.Fprintln(cmd.Stdout, "Page size utilization")
+		fmt.Fprintf(cmd.Stdout, "\tBytes allocated for physical branch pages: %d\n", s.BranchAlloc)
+		var percentage int
+		if s.BranchAlloc != 0 {
+			percentage = int(float32(s.BranchInuse) * 100.0 / float32(s.BranchAlloc))
+		}
+		fmt.Fprintf(cmd.Stdout, "\tBytes actually used for branch data: %d (%d%%)\n", s.BranchInuse, percentage)
+		fmt.Fprintf(cmd.Stdout, "\tBytes allocated for physical leaf pages: %d\n", s.LeafAlloc)
+		percentage = 0
+		if s.LeafAlloc != 0 {
+			percentage = int(float32(s.LeafInuse) * 100.0 / float32(s.LeafAlloc))
+		}
+		fmt.Fprintf(cmd.Stdout, "\tBytes actually used for leaf data: %d (%d%%)\n", s.LeafInuse, percentage)
+
+		fmt.Fprintln(cmd.Stdout, "Bucket statistics")
+		fmt.Fprintf(cmd.Stdout, "\tTotal number of buckets: %d\n", s.BucketN)
+		percentage = 0
+		if s.BucketN != 0 {
+			percentage = int(float32(s.InlineBucketN) * 100.0 / float32(s.BucketN))
+		}
+		fmt.Fprintf(cmd.Stdout, "\tTotal number on inlined buckets: %d (%d%%)\n", s.InlineBucketN, percentage)
+		percentage = 0
+		if s.LeafInuse != 0 {
+			percentage = int(float32(s.InlineBucketInuse) * 100.0 / float32(s.LeafInuse))
+		}
+		fmt.Fprintf(cmd.Stdout, "\tBytes used for inlined buckets: %d (%d%%)\n", s.InlineBucketInuse, percentage)
+
+		return nil
+	})
+}
+
+// Usage returns the help message.
+func (cmd *StatsCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt stats PATH
+
+Stats performs an extensive search of the database to track every page
+reference. It starts at the current meta page and recursively iterates
+through every accessible bucket.
+
+The following errors can be reported:
+
+    already freed
+        The page is referenced more than once in the freelist.
+
+    unreachable unfreed
+        The page is not referenced by a bucket or in the freelist.
+
+    reachable freed
+        The page is referenced by a bucket but is also in the freelist.
+
+    out of bounds
+        A page is referenced that is above the high water mark.
+
+    multiple references
+        A page is referenced by more than one other page.
+
+    invalid type
+        The page type is not "meta", "leaf", "branch", or "freelist".
+
+No errors should occur in your database. However, if for some reason you
+experience corruption, please submit a ticket to the Bolt project page:
+
+  https://github.com/boltdb/bolt/issues
+`, "\n")
+}
+
+// BucketsCommand represents the "buckets" command execution.
+type BucketsCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewBucketsCommand returns a BucketsCommand.
+func newBucketsCommand(m *Main) *BucketsCommand {
+	return &BucketsCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *BucketsCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path.
+	path := fs.Arg(0)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	}
+
+	// Open database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Print buckets.
+	return db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, _ *bolt.Bucket) error {
+			fmt.Fprintln(cmd.Stdout, string(name))
+			return nil
+		})
+	})
+}
+
+// Usage returns the help message.
+func (cmd *BucketsCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt buckets PATH
+
+Print a list of buckets.
+`, "\n")
+}
+
+// KeysCommand represents the "keys" command execution.
+type KeysCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewKeysCommand returns a KeysCommand.
+func newKeysCommand(m *Main) *KeysCommand {
+	return &KeysCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *KeysCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path and bucket.
+	path, bucket := fs.Arg(0), fs.Arg(1)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	} else if bucket == "" {
+		return ErrBucketRequired
+	}
+
+	// Open database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Print keys.
+	return db.View(func(tx *bolt.Tx) error {
+		// Find bucket.
+		b := tx.Bucket([]byte(bucket))
+		if b == nil {
+			return ErrBucketNotFound
+		}
+
+		// Iterate over each key.
+		return b.ForEach(func(key, _ []byte) error {
+			fmt.Fprintln(cmd.Stdout, string(key))
+			return nil
+		})
+	})
+}
+
+// Usage returns the help message.
+func (cmd *KeysCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt keys PATH BUCKET
+
+Print a list of keys in the given bucket.
+`, "\n")
+}
+
+// GetCommand represents the "get" command execution.
+type GetCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewGetCommand returns a GetCommand.
+func newGetCommand(m *Main) *GetCommand {
+	return &GetCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *GetCommand) Run(args ...string) error {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	help := fs.Bool("h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if *help {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	}
+
+	// Require database path, bucket and key.
+	path, bucket, key := fs.Arg(0), fs.Arg(1), fs.Arg(2)
+	if path == "" {
+		return ErrPathRequired
+	} else if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ErrFileNotFound
+	} else if bucket == "" {
+		return ErrBucketRequired
+	} else if key == "" {
+		return ErrKeyRequired
+	}
+
+	// Open database.
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Print value.
+	return db.View(func(tx *bolt.Tx) error {
+		// Find bucket.
+		b := tx.Bucket([]byte(bucket))
+		if b == nil {
+			return ErrBucketNotFound
+		}
+
+		// Find value for given key.
+		val := b.Get([]byte(key))
+		if val == nil {
+			return ErrKeyNotFound
+		}
+
+		fmt.Fprintln(cmd.Stdout, string(val))
+		return nil
+	})
+}
+
+// Usage returns the help message.
+func (cmd *GetCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt get PATH BUCKET KEY
+
+Print the value of the given key in the given bucket.
+`, "\n")
+}
+
+var benchBucketName = []byte("bench")
+
+// BenchCommand represents the "bench" command execution.
+type BenchCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewBenchCommand returns a BenchCommand using the
+func newBenchCommand(m *Main) *BenchCommand {
+	return &BenchCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the "bench" command.
+func (cmd *BenchCommand) Run(args ...string) error {
+	// Parse CLI arguments.
+	options, err := cmd.ParseFlags(args)
+	if err != nil {
+		return err
+	}
+
+	// Remove path if "-work" is not set. Otherwise keep path.
+	if options.Work {
+		fmt.Fprintf(cmd.Stdout, "work: %s\n", options.Path)
+	} else {
+		defer os.Remove(options.Path)
+	}
+
+	// Create database.
+	db, err := bolt.Open(options.Path, 0666, nil)
+	if err != nil {
+		return err
+	}
+	db.NoSync = options.NoSync
+	defer db.Close()
+
+	// Write to the database.
+	var results BenchResults
+	if err := cmd.runWrites(db, options, &results); err != nil {
+		return fmt.Errorf("write: %v", err)
+	}
+
+	// Read from the database.
+	if err := cmd.runReads(db, options, &results); err != nil {
+		return fmt.Errorf("bench: read: %s", err)
+	}
+
+	// Print results.
+	fmt.Fprintf(os.Stderr, "# Write\t%v\t(%v/op)\t(%v op/sec)\n", results.WriteDuration, results.WriteOpDuration(), results.WriteOpsPerSecond())
+	fmt.Fprintf(os.Stderr, "# Read\t%v\t(%v/op)\t(%v op/sec)\n", results.ReadDuration, results.ReadOpDuration(), results.ReadOpsPerSecond())
+	fmt.Fprintln(os.Stderr, "")
+	return nil
+}
+
+// ParseFlags parses the command line flags.
+func (cmd *BenchCommand) ParseFlags(args []string) (*BenchOptions, error) {
+	var options BenchOptions
+
+	// Parse flagset.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.StringVar(&options.ProfileMode, "profile-mode", "rw", "")
+	fs.StringVar(&options.WriteMode, "write-mode", "seq", "")
+	fs.StringVar(&options.ReadMode, "read-mode", "seq", "")
+	fs.IntVar(&options.Iterations, "count", 1000, "")
+	fs.IntVar(&options.BatchSize, "batch-size", 0, "")
+	fs.IntVar(&options.KeySize, "key-size", 8, "")
+	fs.IntVar(&options.ValueSize, "value-size", 32, "")
+	fs.StringVar(&options.CPUProfile, "cpuprofile", "", "")
+	fs.StringVar(&options.MemProfile, "memprofile", "", "")
+	fs.StringVar(&options.BlockProfile, "blockprofile", "", "")
+	fs.Float64Var(&options.FillPercent, "fill-percent", bolt.DefaultFillPercent, "")
+	fs.BoolVar(&options.NoSync, "no-sync", false, "")
+	fs.BoolVar(&options.Work, "work", false, "")
+	fs.StringVar(&options.Path, "path", "", "")
+	fs.SetOutput(cmd.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+
+	// Set batch size to iteration size if not set.
+	// Require that batch size can be evenly divided by the iteration count.
+	if options.BatchSize == 0 {
+		options.BatchSize = options.Iterations
+	} else if options.Iterations%options.BatchSize != 0 {
+		return nil, ErrNonDivisibleBatchSize
+	}
+
+	// Generate temp path if one is not passed in.
+	if options.Path == "" {
+		f, err := ioutil.TempFile("", "bolt-bench-")
+		if err != nil {
+			return nil, fmt.Errorf("temp file: %s", err)
+		}
+		f.Close()
+		os.Remove(f.Name())
+		options.Path = f.Name()
+	}
+
+	return &options, nil
+}
+
+// Writes to the database.
+func (cmd *BenchCommand) runWrites(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	// Start profiling for writes.
+	if options.ProfileMode == "rw" || options.ProfileMode == "w" {
+		cmd.startProfiling(options)
+	}
+
+	t := time.Now()
+
+	var err error
+	switch options.WriteMode {
+	case "seq":
+		err = cmd.runWritesSequential(db, options, results)
+	case "rnd":
+		err = cmd.runWritesRandom(db, options, results)
+	case "seq-nest":
+		err = cmd.runWritesSequentialNested(db, options, results)
+	case "rnd-nest":
+		err = cmd.runWritesRandomNested(db, options, results)
+	default:
+		return fmt.Errorf("invalid write mode: %s", options.WriteMode)
+	}
+
+	// Save time to write.
+	results.WriteDuration = time.Since(t)
+
+	// Stop profiling for writes only.
+	if options.ProfileMode == "w" {
+		cmd.stopProfiling()
+	}
+
+	return err
+}
+
+func (cmd *BenchCommand) runWritesSequential(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	var i = uint32(0)
+	return cmd.runWritesWithSource(db, options, results, func() uint32 { i++; return i })
+}
+
+func (cmd *BenchCommand) runWritesRandom(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return cmd.runWritesWithSource(db, options, results, func() uint32 { return r.Uint32() })
+}
+
+func (cmd *BenchCommand) runWritesSequentialNested(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	var i = uint32(0)
+	return cmd.runWritesNestedWithSource(db, options, results, func() uint32 { i++; return i })
+}
+
+func (cmd *BenchCommand) runWritesRandomNested(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return cmd.runWritesNestedWithSource(db, options, results, func() uint32 { return r.Uint32() })
+}
+
+func (cmd *BenchCommand) runWritesWithSource(db *bolt.DB, options *BenchOptions, results *BenchResults, keySource func() uint32) error {
+	results.WriteOps = options.Iterations
+
+	for i := 0; i < options.Iterations; i += options.BatchSize {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, _ := tx.CreateBucketIfNotExists(benchBucketName)
+			b.FillPercent = options.FillPercent
+
+			for j := 0; j < options.BatchSize; j++ {
+				key := make([]byte, options.KeySize)
+				value := make([]byte, options.ValueSize)
+
+				// Write key as uint32.
+				binary.BigEndian.PutUint32(key, keySource())
+
+				// Insert key/value.
+				if err := b.Put(key, value); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cmd *BenchCommand) runWritesNestedWithSource(db *bolt.DB, options *BenchOptions, results *BenchResults, keySource func() uint32) error {
+	results.WriteOps = options.Iterations
+
+	for i := 0; i < options.Iterations; i += options.BatchSize {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			top, err := tx.CreateBucketIfNotExists(benchBucketName)
+			if err != nil {
+				return err
+			}
+			top.FillPercent = options.FillPercent
+
+			// Create bucket key.
+			name := make([]byte, options.KeySize)
+			binary.BigEndian.PutUint32(name, keySource())
+
+			// Create bucket.
+			b, err := top.CreateBucketIfNotExists(name)
+			if err != nil {
+				return err
+			}
+			b.FillPercent = options.FillPercent
+
+			for j := 0; j < options.BatchSize; j++ {
+				var key = make([]byte, options.KeySize)
+				var value = make([]byte, options.ValueSize)
+
+				// Generate key as uint32.
+				binary.BigEndian.PutUint32(key, keySource())
+
+				// Insert value into subbucket.
+				if err := b.Put(key, value); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Reads from the database.
+func (cmd *BenchCommand) runReads(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	// Start profiling for reads.
+	if options.ProfileMode == "r" {
+		cmd.startProfiling(options)
+	}
+
+	t := time.Now()
+
+	var err error
+	switch options.ReadMode {
+	case "seq":
+		switch options.WriteMode {
+		case "seq-nest", "rnd-nest":
+			err = cmd.runReadsSequentialNested(db, options, results)
+		default:
+			err = cmd.runReadsSequential(db, options, results)
+		}
+	default:
+		return fmt.Errorf("invalid read mode: %s", options.ReadMode)
+	}
+
+	// Save read time.
+	results.ReadDuration = time.Since(t)
+
+	// Stop profiling for reads.
+	if options.ProfileMode == "rw" || options.ProfileMode == "r" {
+		cmd.stopProfiling()
+	}
+
+	return err
+}
+
+func (cmd *BenchCommand) runReadsSequential(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	return db.View(func(tx *bolt.Tx) error {
+		t := time.Now()
+
+		for {
+			var count int
+
+			c := tx.Bucket(benchBucketName).Cursor()
+			for k, v := c.First(); k != nil; k, v = c.Next() {
+				if v == nil {
+					return errors.New("invalid value")
+				}
+				count++
+			}
+
+			if options.WriteMode == "seq" && count != options.Iterations {
+				return fmt.Errorf("read seq: iter mismatch: expected %d, got %d", options.Iterations, count)
+			}
+
+			results.ReadOps += count
+
+			// Make sure we do this for at least a second.
+			if time.Since(t) >= time.Second {
+				break
+			}
+		}
+
+		return nil
+	})
+}
+
+func (cmd *BenchCommand) runReadsSequentialNested(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
+	return db.View(func(tx *bolt.Tx) error {
+		t := time.Now()
+
+		for {
+			var count int
+			var top = tx.Bucket(benchBucketName)
+			if err := top.ForEach(func(name, _ []byte) error {
+				if b := top.Bucket(name); b != nil {
+					c := b.Cursor()
+					for k, v := c.First(); k != nil; k, v = c.Next() {
+						if v == nil {
+							return ErrInvalidValue
+						}
+						count++
+					}
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			if options.WriteMode == "seq-nest" && count != options.Iterations {
+				return fmt.Errorf("read seq-nest: iter mismatch: expected %d, got %d", options.Iterations, count)
+			}
+
+			results.ReadOps += count
+
+			// Make sure we do this for at least a second.
+			if time.Since(t) >= time.Second {
+				break
+			}
+		}
+
+		return nil
+	})
+}
+
+// File handlers for the various profiles.
+var cpuprofile, memprofile, blockprofile *os.File
+
+// Starts all profiles set on the options.
+func (cmd *BenchCommand) startProfiling(options *BenchOptions) {
+	var err error
+
+	// Start CPU profiling.
+	if options.CPUProfile != "" {
+		cpuprofile, err = os.Create(options.CPUProfile)
+		if err != nil {
+			fmt.Fprintf(cmd.Stderr, "bench: could not create cpu profile %q: %v\n", options.CPUProfile, err)
+			os.Exit(1)
+		}
+		pprof.StartCPUProfile(cpuprofile)
+	}
+
+	// Start memory profiling.
+	if options.MemProfile != "" {
+		memprofile, err = os.Create(options.MemProfile)
+		if err != nil {
+			fmt.Fprintf(cmd.Stderr, "bench: could not create memory profile %q: %v\n", options.MemProfile, err)
+			os.Exit(1)
+		}
+		runtime.MemProfileRate = 4096
+	}
+
+	// Start fatal profiling.
+	if options.BlockProfile != "" {
+		blockprofile, err = os.Create(options.BlockProfile)
+		if err != nil {
+			fmt.Fprintf(cmd.Stderr, "bench: could not create block profile %q: %v\n", options.BlockProfile, err)
+			os.Exit(1)
+		}
+		runtime.SetBlockProfileRate(1)
+	}
+}
+
+// Stops all profiles.
+func (cmd *BenchCommand) stopProfiling() {
+	if cpuprofile != nil {
+		pprof.StopCPUProfile()
+		cpuprofile.Close()
+		cpuprofile = nil
+	}
+
+	if memprofile != nil {
+		pprof.Lookup("heap").WriteTo(memprofile, 0)
+		memprofile.Close()
+		memprofile = nil
+	}
+
+	if blockprofile != nil {
+		pprof.Lookup("block").WriteTo(blockprofile, 0)
+		blockprofile.Close()
+		blockprofile = nil
+		runtime.SetBlockProfileRate(0)
+	}
+}
+
+// BenchOptions represents the set of options that can be passed to "bolt bench".
+type BenchOptions struct {
+	ProfileMode   string
+	WriteMode     string
+	ReadMode      string
+	Iterations    int
+	BatchSize     int
+	KeySize       int
+	ValueSize     int
+	CPUProfile    string
+	MemProfile    string
+	BlockProfile  string
+	StatsInterval time.Duration
+	FillPercent   float64
+	NoSync        bool
+	Work          bool
+	Path          string
+}
+
+// BenchResults represents the performance results of the benchmark.
+type BenchResults struct {
+	WriteOps      int
+	WriteDuration time.Duration
+	ReadOps       int
+	ReadDuration  time.Duration
+}
+
+// Returns the duration for a single write operation.
+func (r *BenchResults) WriteOpDuration() time.Duration {
+	if r.WriteOps == 0 {
+		return 0
+	}
+	return r.WriteDuration / time.Duration(r.WriteOps)
+}
+
+// Returns average number of write operations that can be performed per second.
+func (r *BenchResults) WriteOpsPerSecond() int {
+	var op = r.WriteOpDuration()
+	if op == 0 {
+		return 0
+	}
+	return int(time.Second) / int(op)
+}
+
+// Returns the duration for a single read operation.
+func (r *BenchResults) ReadOpDuration() time.Duration {
+	if r.ReadOps == 0 {
+		return 0
+	}
+	return r.ReadDuration / time.Duration(r.ReadOps)
+}
+
+// Returns average number of read operations that can be performed per second.
+func (r *BenchResults) ReadOpsPerSecond() int {
+	var op = r.ReadOpDuration()
+	if op == 0 {
+		return 0
+	}
+	return int(time.Second) / int(op)
+}
+
+type PageError struct {
+	ID  int
+	Err error
+}
+
+func (e *PageError) Error() string {
+	return fmt.Sprintf("page error: id=%d, err=%s", e.ID, e.Err)
+}
+
+// isPrintable returns true if the string is valid unicode and contains only printable runes.
+func isPrintable(s string) bool {
+	if !utf8.ValidString(s) {
+		return false
+	}
+	for _, ch := range s {
+		if !unicode.IsPrint(ch) {
+			return false
+		}
+	}
+	return true
+}
+
+// ReadPage reads page info & full page data from a path.
+// This is not transactionally safe.
+func ReadPage(path string, pageID int) (*page, []byte, error) {
+	// Find page size.
+	pageSize, err := ReadPageSize(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read page size: %s", err)
+	}
+
+	// Open database file.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	// Read one block into buffer.
+	buf := make([]byte, pageSize)
+	if n, err := f.ReadAt(buf, int64(pageID*pageSize)); err != nil {
+		return nil, nil, err
+	} else if n != len(buf) {
+		return nil, nil, io.ErrUnexpectedEOF
+	}
+
+	// Determine total number of blocks.
+	p := (*page)(unsafe.Pointer(&buf[0]))
+	overflowN := p.overflow
+
+	// Re-read entire page (with overflow) into buffer.
+	buf = make([]byte, (int(overflowN)+1)*pageSize)
+	if n, err := f.ReadAt(buf, int64(pageID*pageSize)); err != nil {
+		return nil, nil, err
+	} else if n != len(buf) {
+		return nil, nil, io.ErrUnexpectedEOF
+	}
+	p = (*page)(unsafe.Pointer(&buf[0]))
+
+	return p, buf, nil
+}
+
+// ReadPageSize reads page size a path.
+// This is not transactionally safe.
+func ReadPageSize(path string) (int, error) {
+	// Open database file.
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	// Read 4KB chunk.
+	buf := make([]byte, 4096)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return 0, err
+	}
+
+	// Read page size from metadata.
+	m := (*meta)(unsafe.Pointer(&buf[PageHeaderSize]))
+	return int(m.pageSize), nil
+}
+
+// atois parses a slice of strings into integers.
+func atois(strs []string) ([]int, error) {
+	var a []int
+	for _, str := range strs {
+		i, err := strconv.Atoi(str)
+		if err != nil {
+			return nil, err
+		}
+		a = append(a, i)
+	}
+	return a, nil
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+const maxAllocSize = 0xFFFFFFF
+
+// DO NOT EDIT. Copied from the "bolt" package.
+const (
+	branchPageFlag   = 0x01
+	leafPageFlag     = 0x02
+	metaPageFlag     = 0x04
+	freelistPageFlag = 0x10
+)
+
+// DO NOT EDIT. Copied from the "bolt" package.
+const bucketLeafFlag = 0x01
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type pgid uint64
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type txid uint64
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type meta struct {
+	magic    uint32
+	version  uint32
+	pageSize uint32
+	flags    uint32
+	root     bucket
+	freelist pgid
+	pgid     pgid
+	txid     txid
+	checksum uint64
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type bucket struct {
+	root     pgid
+	sequence uint64
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type page struct {
+	id       pgid
+	flags    uint16
+	count    uint16
+	overflow uint32
+	ptr      uintptr
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (p *page) Type() string {
+	if (p.flags & branchPageFlag) != 0 {
+		return "branch"
+	} else if (p.flags & leafPageFlag) != 0 {
+		return "leaf"
+	} else if (p.flags & metaPageFlag) != 0 {
+		return "meta"
+	} else if (p.flags & freelistPageFlag) != 0 {
+		return "freelist"
+	}
+	return fmt.Sprintf("unknown<%02x>", p.flags)
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (p *page) leafPageElement(index uint16) *leafPageElement {
+	n := &((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	return n
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (p *page) branchPageElement(index uint16) *branchPageElement {
+	return &((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type branchPageElement struct {
+	pos   uint32
+	ksize uint32
+	pgid  pgid
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (n *branchPageElement) key() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return buf[n.pos : n.pos+n.ksize]
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type leafPageElement struct {
+	flags uint32
+	pos   uint32
+	ksize uint32
+	vsize uint32
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (n *leafPageElement) key() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return buf[n.pos : n.pos+n.ksize]
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (n *leafPageElement) value() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return buf[n.pos+n.ksize : n.pos+n.ksize+n.vsize]
+}
+
+// CompactCommand represents the "compact" command execution.
+type CompactCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	SrcPath   string
+	DstPath   string
+	TxMaxSize int64
+}
+
+// newCompactCommand returns a CompactCommand.
+func newCompactCommand(m *Main) *CompactCommand {
+	return &CompactCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *CompactCommand) Run(args ...string) (err error) {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.SetOutput(ioutil.Discard)
+	fs.StringVar(&cmd.DstPath, "o", "", "")
+	fs.Int64Var(&cmd.TxMaxSize, "tx-max-size", 65536, "")
+	if err := fs.Parse(args); err == flag.ErrHelp {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	} else if err != nil {
+		return err
+	} else if cmd.DstPath == "" {
+		return fmt.Errorf("output file required")
+	}
+
+	// Require database paths.
+	cmd.SrcPath = fs.Arg(0)
+	if cmd.SrcPath == "" {
+		return ErrPathRequired
+	}
+
+	// Ensure source file exists.
+	fi, err := os.Stat(cmd.SrcPath)
+	if os.IsNotExist(err) {
+		return ErrFileNotFound
+	} else if err != nil {
+		return err
+	}
+	initialSize := fi.Size()
+
+	// Open source database.
+	src, err := bolt.Open(cmd.SrcPath, 0444, nil)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	// Open destination database.
+	dst, err := bolt.Open(cmd.DstPath, fi.Mode(), nil)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	// Run compaction.
+	if err := cmd.compact(dst, src); err != nil {
+		return err
+	}
+
+	// Report stats on new size.
+	fi, err = os.Stat(cmd.DstPath)
+	if err != nil {
+		return err
+	} else if fi.Size() == 0 {
+		return fmt.Errorf("zero db size")
+	}
+	fmt.Fprintf(cmd.Stdout, "%d -> %d bytes (gain=%.2fx)\n", initialSize, fi.Size(), float64(initialSize)/float64(fi.Size()))
+
+	return nil
+}
+
+func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
+	// commit regularly, or we'll run out of memory for large datasets if using one transaction.
+	var size int64
+	tx, err := dst.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err := cmd.walk(src, func(keys [][]byte, k, v []byte, seq uint64) error {
+		// On each key/value, check if we have exceeded tx size.
+		sz := int64(len(k) + len(v))
+		if size+sz > cmd.TxMaxSize && cmd.TxMaxSize != 0 {
+			// Commit previous transaction.
+			if err := tx.Commit(); err != nil {
+				return err
+			}
+
+			// Start new transaction.
+			tx, err = dst.Begin(true)
+			if err != nil {
+				return err
+			}
+			size = 0
+		}
+		size += sz
+
+		// Create bucket on the root transaction if this is the first level.
+		nk := len(keys)
+		if nk == 0 {
+			bkt, err := tx.CreateBucket(k)
+			if err != nil {
+				return err
+			}
+			if err := bkt.SetSequence(seq); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Create buckets on subsequent levels, if necessary.
+		b := tx.Bucket(keys[0])
+		if nk > 1 {
+			for _, k := range keys[1:] {
+				b = b.Bucket(k)
+			}
+		}
+
+		// Fill the entire page for best compaction.
+		b.FillPercent = 1.0
+
+		// If there is no value then this is a bucket call.
+		if v == nil {
+			bkt, err := b.CreateBucket(k)
+			if err != nil {
+				return err
+			}
+			if err := bkt.SetSequence(seq); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Otherwise treat it as a key/value pair.
+		return b.Put(k, v)
+	}); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// walkFunc is the type of the function called for keys (buckets and "normal"
+// values) discovered by Walk. keys is the list of keys to descend to the bucket
+// owning the discovered key/value pair k/v.
+type walkFunc func(keys [][]byte, k, v []byte, seq uint64) error
+
+// walk walks recursively the bolt database db, calling walkFn for each key it finds.
+func (cmd *CompactCommand) walk(db *bolt.DB, walkFn walkFunc) error {
+	return db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return cmd.walkBucket(b, nil, name, nil, b.Sequence(), walkFn)
+		})
+	})
+}
+
+func (cmd *CompactCommand) walkBucket(b *bolt.Bucket, keypath [][]byte, k, v []byte, seq uint64, fn walkFunc) error {
+	// Execute callback.
+	if err := fn(keypath, k, v, seq); err != nil {
+		return err
+	}
+
+	// If this is not a bucket then stop.
+	if v != nil {
+		return nil
+	}
+
+	// Iterate over each child key/value.
+	keypath = append(keypath, k)
+	return b.ForEach(func(k, v []byte) error {
+		if v == nil {
+			bkt := b.Bucket(k)
+			return cmd.walkBucket(bkt, keypath, k, nil, bkt.Sequence(), fn)
+		}
+		return cmd.walkBucket(b, keypath, k, v, b.Sequence(), fn)
+	})
+}
+
+// Usage returns the help message.
+func (cmd *CompactCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt compact [options] -o DST SRC
+
+Compact opens a database at SRC path and walks it recursively, copying keys
+as they are found from all buckets, to a newly created database at DST path.
+
+The original database is left untouched.
+
+Additional options include:
+
+	-tx-max-size NUM
+		Specifies the maximum size of individual transactions.
+		Defaults to 64KB.
+`, "\n")
+}

--- a/vendor/github.com/coreos/bbolt/cmd/bolt/main_test.go
+++ b/vendor/github.com/coreos/bbolt/cmd/bolt/main_test.go
@@ -1,0 +1,456 @@
+package main_test
+
+import (
+	"bytes"
+	crypto "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/coreos/bbolt"
+	"github.com/coreos/bbolt/cmd/bolt"
+)
+
+// Ensure the "info" command can print information about a database.
+func TestInfoCommand_Run(t *testing.T) {
+	db := MustOpen(0666, nil)
+	db.DB.Close()
+	defer db.Close()
+
+	// Run the info command.
+	m := NewMain()
+	if err := m.Run("info", db.Path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure the "stats" command executes correctly with an empty database.
+func TestStatsCommand_Run_EmptyDatabase(t *testing.T) {
+	// Ignore
+	if os.Getpagesize() != 4096 {
+		t.Skip("system does not use 4KB page size")
+	}
+
+	db := MustOpen(0666, nil)
+	defer db.Close()
+	db.DB.Close()
+
+	// Generate expected result.
+	exp := "Aggregate statistics for 0 buckets\n\n" +
+		"Page count statistics\n" +
+		"\tNumber of logical branch pages: 0\n" +
+		"\tNumber of physical branch overflow pages: 0\n" +
+		"\tNumber of logical leaf pages: 0\n" +
+		"\tNumber of physical leaf overflow pages: 0\n" +
+		"Tree statistics\n" +
+		"\tNumber of keys/value pairs: 0\n" +
+		"\tNumber of levels in B+tree: 0\n" +
+		"Page size utilization\n" +
+		"\tBytes allocated for physical branch pages: 0\n" +
+		"\tBytes actually used for branch data: 0 (0%)\n" +
+		"\tBytes allocated for physical leaf pages: 0\n" +
+		"\tBytes actually used for leaf data: 0 (0%)\n" +
+		"Bucket statistics\n" +
+		"\tTotal number of buckets: 0\n" +
+		"\tTotal number on inlined buckets: 0 (0%)\n" +
+		"\tBytes used for inlined buckets: 0 (0%)\n"
+
+	// Run the command.
+	m := NewMain()
+	if err := m.Run("stats", db.Path); err != nil {
+		t.Fatal(err)
+	} else if m.Stdout.String() != exp {
+		t.Fatalf("unexpected stdout:\n\n%s", m.Stdout.String())
+	}
+}
+
+// Ensure the "stats" command can execute correctly.
+func TestStatsCommand_Run(t *testing.T) {
+	// Ignore
+	if os.Getpagesize() != 4096 {
+		t.Skip("system does not use 4KB page size")
+	}
+
+	db := MustOpen(0666, nil)
+	defer db.Close()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create "foo" bucket.
+		b, err := tx.CreateBucket([]byte("foo"))
+		if err != nil {
+			return err
+		}
+		for i := 0; i < 10; i++ {
+			if err := b.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i))); err != nil {
+				return err
+			}
+		}
+
+		// Create "bar" bucket.
+		b, err = tx.CreateBucket([]byte("bar"))
+		if err != nil {
+			return err
+		}
+		for i := 0; i < 100; i++ {
+			if err := b.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i))); err != nil {
+				return err
+			}
+		}
+
+		// Create "baz" bucket.
+		b, err = tx.CreateBucket([]byte("baz"))
+		if err != nil {
+			return err
+		}
+		if err := b.Put([]byte("key"), []byte("value")); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.DB.Close()
+
+	// Generate expected result.
+	exp := "Aggregate statistics for 3 buckets\n\n" +
+		"Page count statistics\n" +
+		"\tNumber of logical branch pages: 0\n" +
+		"\tNumber of physical branch overflow pages: 0\n" +
+		"\tNumber of logical leaf pages: 1\n" +
+		"\tNumber of physical leaf overflow pages: 0\n" +
+		"Tree statistics\n" +
+		"\tNumber of keys/value pairs: 111\n" +
+		"\tNumber of levels in B+tree: 1\n" +
+		"Page size utilization\n" +
+		"\tBytes allocated for physical branch pages: 0\n" +
+		"\tBytes actually used for branch data: 0 (0%)\n" +
+		"\tBytes allocated for physical leaf pages: 4096\n" +
+		"\tBytes actually used for leaf data: 1996 (48%)\n" +
+		"Bucket statistics\n" +
+		"\tTotal number of buckets: 3\n" +
+		"\tTotal number on inlined buckets: 2 (66%)\n" +
+		"\tBytes used for inlined buckets: 236 (11%)\n"
+
+	// Run the command.
+	m := NewMain()
+	if err := m.Run("stats", db.Path); err != nil {
+		t.Fatal(err)
+	} else if m.Stdout.String() != exp {
+		t.Fatalf("unexpected stdout:\n\n%s", m.Stdout.String())
+	}
+}
+
+// Ensure the "buckets" command can print a list of buckets.
+func TestBucketsCommand_Run(t *testing.T) {
+	db := MustOpen(0666, nil)
+	defer db.Close()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		for _, name := range []string{"foo", "bar", "baz"} {
+			_, err := tx.CreateBucket([]byte(name))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.DB.Close()
+
+	expected := "bar\nbaz\nfoo\n"
+
+	// Run the command.
+	m := NewMain()
+	if err := m.Run("buckets", db.Path); err != nil {
+		t.Fatal(err)
+	} else if actual := m.Stdout.String(); actual != expected {
+		t.Fatalf("unexpected stdout:\n\n%s", actual)
+	}
+}
+
+// Ensure the "keys" command can print a list of keys for a bucket.
+func TestKeysCommand_Run(t *testing.T) {
+	db := MustOpen(0666, nil)
+	defer db.Close()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		for _, name := range []string{"foo", "bar"} {
+			b, err := tx.CreateBucket([]byte(name))
+			if err != nil {
+				return err
+			}
+			for i := 0; i < 3; i++ {
+				key := fmt.Sprintf("%s-%d", name, i)
+				if err := b.Put([]byte(key), []byte{0}); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.DB.Close()
+
+	expected := "foo-0\nfoo-1\nfoo-2\n"
+
+	// Run the command.
+	m := NewMain()
+	if err := m.Run("keys", db.Path, "foo"); err != nil {
+		t.Fatal(err)
+	} else if actual := m.Stdout.String(); actual != expected {
+		t.Fatalf("unexpected stdout:\n\n%s", actual)
+	}
+}
+
+// Ensure the "get" command can print the value of a key in a bucket.
+func TestGetCommand_Run(t *testing.T) {
+	db := MustOpen(0666, nil)
+	defer db.Close()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		for _, name := range []string{"foo", "bar"} {
+			b, err := tx.CreateBucket([]byte(name))
+			if err != nil {
+				return err
+			}
+			for i := 0; i < 3; i++ {
+				key := fmt.Sprintf("%s-%d", name, i)
+				val := fmt.Sprintf("val-%s-%d", name, i)
+				if err := b.Put([]byte(key), []byte(val)); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.DB.Close()
+
+	expected := "val-foo-1\n"
+
+	// Run the command.
+	m := NewMain()
+	if err := m.Run("get", db.Path, "foo", "foo-1"); err != nil {
+		t.Fatal(err)
+	} else if actual := m.Stdout.String(); actual != expected {
+		t.Fatalf("unexpected stdout:\n\n%s", actual)
+	}
+}
+
+// Main represents a test wrapper for main.Main that records output.
+type Main struct {
+	*main.Main
+	Stdin  bytes.Buffer
+	Stdout bytes.Buffer
+	Stderr bytes.Buffer
+}
+
+// NewMain returns a new instance of Main.
+func NewMain() *Main {
+	m := &Main{Main: main.NewMain()}
+	m.Main.Stdin = &m.Stdin
+	m.Main.Stdout = &m.Stdout
+	m.Main.Stderr = &m.Stderr
+	return m
+}
+
+// MustOpen creates a Bolt database in a temporary location.
+func MustOpen(mode os.FileMode, options *bolt.Options) *DB {
+	// Create temporary path.
+	f, _ := ioutil.TempFile("", "bolt-")
+	f.Close()
+	os.Remove(f.Name())
+
+	db, err := bolt.Open(f.Name(), mode, options)
+	if err != nil {
+		panic(err.Error())
+	}
+	return &DB{DB: db, Path: f.Name()}
+}
+
+// DB is a test wrapper for bolt.DB.
+type DB struct {
+	*bolt.DB
+	Path string
+}
+
+// Close closes and removes the database.
+func (db *DB) Close() error {
+	defer os.Remove(db.Path)
+	return db.DB.Close()
+}
+
+func TestCompactCommand_Run(t *testing.T) {
+	var s int64
+	if err := binary.Read(crypto.Reader, binary.BigEndian, &s); err != nil {
+		t.Fatal(err)
+	}
+	rand.Seed(s)
+
+	dstdb := MustOpen(0666, nil)
+	dstdb.Close()
+
+	// fill the db
+	db := MustOpen(0666, nil)
+	if err := db.Update(func(tx *bolt.Tx) error {
+		n := 2 + rand.Intn(5)
+		for i := 0; i < n; i++ {
+			k := []byte(fmt.Sprintf("b%d", i))
+			b, err := tx.CreateBucketIfNotExists(k)
+			if err != nil {
+				return err
+			}
+			if err := b.SetSequence(uint64(i)); err != nil {
+				return err
+			}
+			if err := fillBucket(b, append(k, '.')); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+
+	// make the db grow by adding large values, and delete them.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("large_vals"))
+		if err != nil {
+			return err
+		}
+		n := 5 + rand.Intn(5)
+		for i := 0; i < n; i++ {
+			v := make([]byte, 1000*1000*(1+rand.Intn(5)))
+			_, err := crypto.Read(v)
+			if err != nil {
+				return err
+			}
+			if err := b.Put([]byte(fmt.Sprintf("l%d", i)), v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("large_vals")).Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if err := c.Delete(); err != nil {
+				return err
+			}
+		}
+		return tx.DeleteBucket([]byte("large_vals"))
+	}); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.DB.Close()
+	defer db.Close()
+	defer dstdb.Close()
+
+	dbChk, err := chkdb(db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewMain()
+	if err := m.Run("compact", "-o", dstdb.Path, db.Path); err != nil {
+		t.Fatal(err)
+	}
+
+	dbChkAfterCompact, err := chkdb(db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstdbChk, err := chkdb(dstdb.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(dbChk, dbChkAfterCompact) {
+		t.Error("the original db has been touched")
+	}
+	if !bytes.Equal(dbChk, dstdbChk) {
+		t.Error("the compacted db data isn't the same than the original db")
+	}
+}
+
+func fillBucket(b *bolt.Bucket, prefix []byte) error {
+	n := 10 + rand.Intn(50)
+	for i := 0; i < n; i++ {
+		v := make([]byte, 10*(1+rand.Intn(4)))
+		_, err := crypto.Read(v)
+		if err != nil {
+			return err
+		}
+		k := append(prefix, []byte(fmt.Sprintf("k%d", i))...)
+		if err := b.Put(k, v); err != nil {
+			return err
+		}
+	}
+	// limit depth of subbuckets
+	s := 2 + rand.Intn(4)
+	if len(prefix) > (2*s + 1) {
+		return nil
+	}
+	n = 1 + rand.Intn(3)
+	for i := 0; i < n; i++ {
+		k := append(prefix, []byte(fmt.Sprintf("b%d", i))...)
+		sb, err := b.CreateBucket(k)
+		if err != nil {
+			return err
+		}
+		if err := fillBucket(sb, append(k, '.')); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func chkdb(path string) ([]byte, error) {
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	var buf bytes.Buffer
+	err = db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return walkBucket(b, name, nil, &buf)
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func walkBucket(parent *bolt.Bucket, k []byte, v []byte, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%d:%x=%x\n", parent.Sequence(), k, v); err != nil {
+		return err
+	}
+
+	// not a bucket, exit.
+	if v != nil {
+		return nil
+	}
+	return parent.ForEach(func(k, v []byte) error {
+		if v == nil {
+			return walkBucket(parent.Bucket(k), k, nil, w)
+		}
+		return walkBucket(parent, k, v, w)
+	})
+}

--- a/vendor/github.com/coreos/bbolt/cursor.go
+++ b/vendor/github.com/coreos/bbolt/cursor.go
@@ -1,0 +1,400 @@
+package bolt
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+// Cursor represents an iterator that can traverse over all key/value pairs in a bucket in sorted order.
+// Cursors see nested buckets with value == nil.
+// Cursors can be obtained from a transaction and are valid as long as the transaction is open.
+//
+// Keys and values returned from the cursor are only valid for the life of the transaction.
+//
+// Changing data while traversing with a cursor may cause it to be invalidated
+// and return unexpected keys and/or values. You must reposition your cursor
+// after mutating data.
+type Cursor struct {
+	bucket *Bucket
+	stack  []elemRef
+}
+
+// Bucket returns the bucket that this cursor was created from.
+func (c *Cursor) Bucket() *Bucket {
+	return c.bucket
+}
+
+// First moves the cursor to the first item in the bucket and returns its key and value.
+// If the bucket is empty then a nil key and value are returned.
+// The returned key and value are only valid for the life of the transaction.
+func (c *Cursor) First() (key []byte, value []byte) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+	c.stack = c.stack[:0]
+	p, n := c.bucket.pageNode(c.bucket.root)
+	c.stack = append(c.stack, elemRef{page: p, node: n, index: 0})
+	c.first()
+
+	// If we land on an empty page then move to the next value.
+	// https://github.com/boltdb/bolt/issues/450
+	if c.stack[len(c.stack)-1].count() == 0 {
+		c.next()
+	}
+
+	k, v, flags := c.keyValue()
+	if (flags & uint32(bucketLeafFlag)) != 0 {
+		return k, nil
+	}
+	return k, v
+
+}
+
+// Last moves the cursor to the last item in the bucket and returns its key and value.
+// If the bucket is empty then a nil key and value are returned.
+// The returned key and value are only valid for the life of the transaction.
+func (c *Cursor) Last() (key []byte, value []byte) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+	c.stack = c.stack[:0]
+	p, n := c.bucket.pageNode(c.bucket.root)
+	ref := elemRef{page: p, node: n}
+	ref.index = ref.count() - 1
+	c.stack = append(c.stack, ref)
+	c.last()
+	k, v, flags := c.keyValue()
+	if (flags & uint32(bucketLeafFlag)) != 0 {
+		return k, nil
+	}
+	return k, v
+}
+
+// Next moves the cursor to the next item in the bucket and returns its key and value.
+// If the cursor is at the end of the bucket then a nil key and value are returned.
+// The returned key and value are only valid for the life of the transaction.
+func (c *Cursor) Next() (key []byte, value []byte) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+	k, v, flags := c.next()
+	if (flags & uint32(bucketLeafFlag)) != 0 {
+		return k, nil
+	}
+	return k, v
+}
+
+// Prev moves the cursor to the previous item in the bucket and returns its key and value.
+// If the cursor is at the beginning of the bucket then a nil key and value are returned.
+// The returned key and value are only valid for the life of the transaction.
+func (c *Cursor) Prev() (key []byte, value []byte) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+
+	// Attempt to move back one element until we're successful.
+	// Move up the stack as we hit the beginning of each page in our stack.
+	for i := len(c.stack) - 1; i >= 0; i-- {
+		elem := &c.stack[i]
+		if elem.index > 0 {
+			elem.index--
+			break
+		}
+		c.stack = c.stack[:i]
+	}
+
+	// If we've hit the end then return nil.
+	if len(c.stack) == 0 {
+		return nil, nil
+	}
+
+	// Move down the stack to find the last element of the last leaf under this branch.
+	c.last()
+	k, v, flags := c.keyValue()
+	if (flags & uint32(bucketLeafFlag)) != 0 {
+		return k, nil
+	}
+	return k, v
+}
+
+// Seek moves the cursor to a given key and returns it.
+// If the key does not exist then the next key is used. If no keys
+// follow, a nil key is returned.
+// The returned key and value are only valid for the life of the transaction.
+func (c *Cursor) Seek(seek []byte) (key []byte, value []byte) {
+	k, v, flags := c.seek(seek)
+
+	// If we ended up after the last element of a page then move to the next one.
+	if ref := &c.stack[len(c.stack)-1]; ref.index >= ref.count() {
+		k, v, flags = c.next()
+	}
+
+	if k == nil {
+		return nil, nil
+	} else if (flags & uint32(bucketLeafFlag)) != 0 {
+		return k, nil
+	}
+	return k, v
+}
+
+// Delete removes the current key/value under the cursor from the bucket.
+// Delete fails if current key/value is a bucket or if the transaction is not writable.
+func (c *Cursor) Delete() error {
+	if c.bucket.tx.db == nil {
+		return ErrTxClosed
+	} else if !c.bucket.Writable() {
+		return ErrTxNotWritable
+	}
+
+	key, _, flags := c.keyValue()
+	// Return an error if current value is a bucket.
+	if (flags & bucketLeafFlag) != 0 {
+		return ErrIncompatibleValue
+	}
+	c.node().del(key)
+
+	return nil
+}
+
+// seek moves the cursor to a given key and returns it.
+// If the key does not exist then the next key is used.
+func (c *Cursor) seek(seek []byte) (key []byte, value []byte, flags uint32) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+
+	// Start from root page/node and traverse to correct page.
+	c.stack = c.stack[:0]
+	c.search(seek, c.bucket.root)
+	ref := &c.stack[len(c.stack)-1]
+
+	// If the cursor is pointing to the end of page/node then return nil.
+	if ref.index >= ref.count() {
+		return nil, nil, 0
+	}
+
+	// If this is a bucket then return a nil value.
+	return c.keyValue()
+}
+
+// first moves the cursor to the first leaf element under the last page in the stack.
+func (c *Cursor) first() {
+	for {
+		// Exit when we hit a leaf page.
+		var ref = &c.stack[len(c.stack)-1]
+		if ref.isLeaf() {
+			break
+		}
+
+		// Keep adding pages pointing to the first element to the stack.
+		var pgid pgid
+		if ref.node != nil {
+			pgid = ref.node.inodes[ref.index].pgid
+		} else {
+			pgid = ref.page.branchPageElement(uint16(ref.index)).pgid
+		}
+		p, n := c.bucket.pageNode(pgid)
+		c.stack = append(c.stack, elemRef{page: p, node: n, index: 0})
+	}
+}
+
+// last moves the cursor to the last leaf element under the last page in the stack.
+func (c *Cursor) last() {
+	for {
+		// Exit when we hit a leaf page.
+		ref := &c.stack[len(c.stack)-1]
+		if ref.isLeaf() {
+			break
+		}
+
+		// Keep adding pages pointing to the last element in the stack.
+		var pgid pgid
+		if ref.node != nil {
+			pgid = ref.node.inodes[ref.index].pgid
+		} else {
+			pgid = ref.page.branchPageElement(uint16(ref.index)).pgid
+		}
+		p, n := c.bucket.pageNode(pgid)
+
+		var nextRef = elemRef{page: p, node: n}
+		nextRef.index = nextRef.count() - 1
+		c.stack = append(c.stack, nextRef)
+	}
+}
+
+// next moves to the next leaf element and returns the key and value.
+// If the cursor is at the last leaf element then it stays there and returns nil.
+func (c *Cursor) next() (key []byte, value []byte, flags uint32) {
+	for {
+		// Attempt to move over one element until we're successful.
+		// Move up the stack as we hit the end of each page in our stack.
+		var i int
+		for i = len(c.stack) - 1; i >= 0; i-- {
+			elem := &c.stack[i]
+			if elem.index < elem.count()-1 {
+				elem.index++
+				break
+			}
+		}
+
+		// If we've hit the root page then stop and return. This will leave the
+		// cursor on the last element of the last page.
+		if i == -1 {
+			return nil, nil, 0
+		}
+
+		// Otherwise start from where we left off in the stack and find the
+		// first element of the first leaf page.
+		c.stack = c.stack[:i+1]
+		c.first()
+
+		// If this is an empty page then restart and move back up the stack.
+		// https://github.com/boltdb/bolt/issues/450
+		if c.stack[len(c.stack)-1].count() == 0 {
+			continue
+		}
+
+		return c.keyValue()
+	}
+}
+
+// search recursively performs a binary search against a given page/node until it finds a given key.
+func (c *Cursor) search(key []byte, pgid pgid) {
+	p, n := c.bucket.pageNode(pgid)
+	if p != nil && (p.flags&(branchPageFlag|leafPageFlag)) == 0 {
+		panic(fmt.Sprintf("invalid page type: %d: %x", p.id, p.flags))
+	}
+	e := elemRef{page: p, node: n}
+	c.stack = append(c.stack, e)
+
+	// If we're on a leaf page/node then find the specific node.
+	if e.isLeaf() {
+		c.nsearch(key)
+		return
+	}
+
+	if n != nil {
+		c.searchNode(key, n)
+		return
+	}
+	c.searchPage(key, p)
+}
+
+func (c *Cursor) searchNode(key []byte, n *node) {
+	var exact bool
+	index := sort.Search(len(n.inodes), func(i int) bool {
+		// TODO(benbjohnson): Optimize this range search. It's a bit hacky right now.
+		// sort.Search() finds the lowest index where f() != -1 but we need the highest index.
+		ret := bytes.Compare(n.inodes[i].key, key)
+		if ret == 0 {
+			exact = true
+		}
+		return ret != -1
+	})
+	if !exact && index > 0 {
+		index--
+	}
+	c.stack[len(c.stack)-1].index = index
+
+	// Recursively search to the next page.
+	c.search(key, n.inodes[index].pgid)
+}
+
+func (c *Cursor) searchPage(key []byte, p *page) {
+	// Binary search for the correct range.
+	inodes := p.branchPageElements()
+
+	var exact bool
+	index := sort.Search(int(p.count), func(i int) bool {
+		// TODO(benbjohnson): Optimize this range search. It's a bit hacky right now.
+		// sort.Search() finds the lowest index where f() != -1 but we need the highest index.
+		ret := bytes.Compare(inodes[i].key(), key)
+		if ret == 0 {
+			exact = true
+		}
+		return ret != -1
+	})
+	if !exact && index > 0 {
+		index--
+	}
+	c.stack[len(c.stack)-1].index = index
+
+	// Recursively search to the next page.
+	c.search(key, inodes[index].pgid)
+}
+
+// nsearch searches the leaf node on the top of the stack for a key.
+func (c *Cursor) nsearch(key []byte) {
+	e := &c.stack[len(c.stack)-1]
+	p, n := e.page, e.node
+
+	// If we have a node then search its inodes.
+	if n != nil {
+		index := sort.Search(len(n.inodes), func(i int) bool {
+			return bytes.Compare(n.inodes[i].key, key) != -1
+		})
+		e.index = index
+		return
+	}
+
+	// If we have a page then search its leaf elements.
+	inodes := p.leafPageElements()
+	index := sort.Search(int(p.count), func(i int) bool {
+		return bytes.Compare(inodes[i].key(), key) != -1
+	})
+	e.index = index
+}
+
+// keyValue returns the key and value of the current leaf element.
+func (c *Cursor) keyValue() ([]byte, []byte, uint32) {
+	ref := &c.stack[len(c.stack)-1]
+	if ref.count() == 0 || ref.index >= ref.count() {
+		return nil, nil, 0
+	}
+
+	// Retrieve value from node.
+	if ref.node != nil {
+		inode := &ref.node.inodes[ref.index]
+		return inode.key, inode.value, inode.flags
+	}
+
+	// Or retrieve value from page.
+	elem := ref.page.leafPageElement(uint16(ref.index))
+	return elem.key(), elem.value(), elem.flags
+}
+
+// node returns the node that the cursor is currently positioned on.
+func (c *Cursor) node() *node {
+	_assert(len(c.stack) > 0, "accessing a node with a zero-length cursor stack")
+
+	// If the top of the stack is a leaf node then just return it.
+	if ref := &c.stack[len(c.stack)-1]; ref.node != nil && ref.isLeaf() {
+		return ref.node
+	}
+
+	// Start from root and traverse down the hierarchy.
+	var n = c.stack[0].node
+	if n == nil {
+		n = c.bucket.node(c.stack[0].page.id, nil)
+	}
+	for _, ref := range c.stack[:len(c.stack)-1] {
+		_assert(!n.isLeaf, "expected branch node")
+		n = n.childAt(int(ref.index))
+	}
+	_assert(n.isLeaf, "expected leaf node")
+	return n
+}
+
+// elemRef represents a reference to an element on a given page/node.
+type elemRef struct {
+	page  *page
+	node  *node
+	index int
+}
+
+// isLeaf returns whether the ref is pointing at a leaf page/node.
+func (r *elemRef) isLeaf() bool {
+	if r.node != nil {
+		return r.node.isLeaf
+	}
+	return (r.page.flags & leafPageFlag) != 0
+}
+
+// count returns the number of inodes or page elements.
+func (r *elemRef) count() int {
+	if r.node != nil {
+		return len(r.node.inodes)
+	}
+	return int(r.page.count)
+}

--- a/vendor/github.com/coreos/bbolt/cursor_test.go
+++ b/vendor/github.com/coreos/bbolt/cursor_test.go
@@ -1,0 +1,817 @@
+package bolt_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+	"testing/quick"
+
+	"github.com/coreos/bbolt"
+)
+
+// Ensure that a cursor can return a reference to the bucket that created it.
+func TestCursor_Bucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cb := b.Cursor().Bucket(); !reflect.DeepEqual(cb, b) {
+			t.Fatal("cursor bucket mismatch")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can seek to the appropriate keys.
+func TestCursor_Seek(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("0001")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("bar"), []byte("0002")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("0003")); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := b.CreateBucket([]byte("bkt")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("widgets")).Cursor()
+
+		// Exact match should go to the key.
+		if k, v := c.Seek([]byte("bar")); !bytes.Equal(k, []byte("bar")) {
+			t.Fatalf("unexpected key: %v", k)
+		} else if !bytes.Equal(v, []byte("0002")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+
+		// Inexact match should go to the next key.
+		if k, v := c.Seek([]byte("bas")); !bytes.Equal(k, []byte("baz")) {
+			t.Fatalf("unexpected key: %v", k)
+		} else if !bytes.Equal(v, []byte("0003")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+
+		// Low key should go to the first key.
+		if k, v := c.Seek([]byte("")); !bytes.Equal(k, []byte("bar")) {
+			t.Fatalf("unexpected key: %v", k)
+		} else if !bytes.Equal(v, []byte("0002")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+
+		// High key should return no key.
+		if k, v := c.Seek([]byte("zzz")); k != nil {
+			t.Fatalf("expected nil key: %v", k)
+		} else if v != nil {
+			t.Fatalf("expected nil value: %v", v)
+		}
+
+		// Buckets should return their key but no value.
+		if k, v := c.Seek([]byte("bkt")); !bytes.Equal(k, []byte("bkt")) {
+			t.Fatalf("unexpected key: %v", k)
+		} else if v != nil {
+			t.Fatalf("expected nil value: %v", v)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCursor_Delete(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	const count = 1000
+
+	// Insert every other key between 0 and $count.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < count; i += 1 {
+			k := make([]byte, 8)
+			binary.BigEndian.PutUint64(k, uint64(i))
+			if err := b.Put(k, make([]byte, 100)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := b.CreateBucket([]byte("sub")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		bound := make([]byte, 8)
+		binary.BigEndian.PutUint64(bound, uint64(count/2))
+		for key, _ := c.First(); bytes.Compare(key, bound) < 0; key, _ = c.Next() {
+			if err := c.Delete(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		c.Seek([]byte("sub"))
+		if err := c.Delete(); err != bolt.ErrIncompatibleValue {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		stats := tx.Bucket([]byte("widgets")).Stats()
+		if stats.KeyN != count/2+1 {
+			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can seek to the appropriate keys when there are a
+// large number of keys. This test also checks that seek will always move
+// forward to the next key.
+//
+// Related: https://github.com/boltdb/bolt/pull/187
+func TestCursor_Seek_Large(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var count = 10000
+
+	// Insert every other key between 0 and $count.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < count; i += 100 {
+			for j := i; j < i+100; j += 2 {
+				k := make([]byte, 8)
+				binary.BigEndian.PutUint64(k, uint64(j))
+				if err := b.Put(k, make([]byte, 100)); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		for i := 0; i < count; i++ {
+			seek := make([]byte, 8)
+			binary.BigEndian.PutUint64(seek, uint64(i))
+
+			k, _ := c.Seek(seek)
+
+			// The last seek is beyond the end of the the range so
+			// it should return nil.
+			if i == count-1 {
+				if k != nil {
+					t.Fatal("expected nil key")
+				}
+				continue
+			}
+
+			// Otherwise we should seek to the exact key or the next key.
+			num := binary.BigEndian.Uint64(k)
+			if i%2 == 0 {
+				if num != uint64(i) {
+					t.Fatalf("unexpected num: %d", num)
+				}
+			} else {
+				if num != uint64(i+1) {
+					t.Fatalf("unexpected num: %d", num)
+				}
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a cursor can iterate over an empty bucket without error.
+func TestCursor_EmptyBucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		k, v := c.First()
+		if k != nil {
+			t.Fatalf("unexpected key: %v", k)
+		} else if v != nil {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can reverse iterate over an empty bucket without error.
+func TestCursor_EmptyBucketReverse(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		k, v := c.Last()
+		if k != nil {
+			t.Fatalf("unexpected key: %v", k)
+		} else if v != nil {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can iterate over a single root with a couple elements.
+func TestCursor_Iterate_Leaf(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte{0}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("bar"), []byte{1}); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.Begin(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	c := tx.Bucket([]byte("widgets")).Cursor()
+
+	k, v := c.First()
+	if !bytes.Equal(k, []byte("bar")) {
+		t.Fatalf("unexpected key: %v", k)
+	} else if !bytes.Equal(v, []byte{1}) {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	k, v = c.Next()
+	if !bytes.Equal(k, []byte("baz")) {
+		t.Fatalf("unexpected key: %v", k)
+	} else if !bytes.Equal(v, []byte{}) {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	k, v = c.Next()
+	if !bytes.Equal(k, []byte("foo")) {
+		t.Fatalf("unexpected key: %v", k)
+	} else if !bytes.Equal(v, []byte{0}) {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	k, v = c.Next()
+	if k != nil {
+		t.Fatalf("expected nil key: %v", k)
+	} else if v != nil {
+		t.Fatalf("expected nil value: %v", v)
+	}
+
+	k, v = c.Next()
+	if k != nil {
+		t.Fatalf("expected nil key: %v", k)
+	} else if v != nil {
+		t.Fatalf("expected nil value: %v", v)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can iterate in reverse over a single root with a couple elements.
+func TestCursor_LeafRootReverse(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte{0}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("bar"), []byte{1}); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.Begin(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := tx.Bucket([]byte("widgets")).Cursor()
+
+	if k, v := c.Last(); !bytes.Equal(k, []byte("foo")) {
+		t.Fatalf("unexpected key: %v", k)
+	} else if !bytes.Equal(v, []byte{0}) {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	if k, v := c.Prev(); !bytes.Equal(k, []byte("baz")) {
+		t.Fatalf("unexpected key: %v", k)
+	} else if !bytes.Equal(v, []byte{}) {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	if k, v := c.Prev(); !bytes.Equal(k, []byte("bar")) {
+		t.Fatalf("unexpected key: %v", k)
+	} else if !bytes.Equal(v, []byte{1}) {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	if k, v := c.Prev(); k != nil {
+		t.Fatalf("expected nil key: %v", k)
+	} else if v != nil {
+		t.Fatalf("expected nil value: %v", v)
+	}
+
+	if k, v := c.Prev(); k != nil {
+		t.Fatalf("expected nil key: %v", k)
+	} else if v != nil {
+		t.Fatalf("expected nil value: %v", v)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can restart from the beginning.
+func TestCursor_Restart(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("bar"), []byte{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte{}); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := db.Begin(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := tx.Bucket([]byte("widgets")).Cursor()
+
+	if k, _ := c.First(); !bytes.Equal(k, []byte("bar")) {
+		t.Fatalf("unexpected key: %v", k)
+	}
+	if k, _ := c.Next(); !bytes.Equal(k, []byte("foo")) {
+		t.Fatalf("unexpected key: %v", k)
+	}
+
+	if k, _ := c.First(); !bytes.Equal(k, []byte("bar")) {
+		t.Fatalf("unexpected key: %v", k)
+	}
+	if k, _ := c.Next(); !bytes.Equal(k, []byte("foo")) {
+		t.Fatalf("unexpected key: %v", k)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a cursor can skip over empty pages that have been deleted.
+func TestCursor_First_EmptyPages(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Create 1000 keys in the "widgets" bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < 1000; i++ {
+			if err := b.Put(u64tob(uint64(i)), []byte{}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete half the keys and then try to iterate.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 0; i < 600; i++ {
+			if err := b.Delete(u64tob(uint64(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		c := b.Cursor()
+		var n int
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			n++
+		}
+		if n != 400 {
+			t.Fatalf("unexpected key count: %d", n)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx can iterate over all elements in a bucket.
+func TestCursor_QuickCheck(t *testing.T) {
+	f := func(items testdata) bool {
+		db := MustOpenDB()
+		defer db.MustClose()
+
+		// Bulk insert all values.
+		tx, err := db.Begin(true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range items {
+			if err := b.Put(item.Key, item.Value); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Sort test data.
+		sort.Sort(items)
+
+		// Iterate over all items and check consistency.
+		var index = 0
+		tx, err = db.Begin(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		for k, v := c.First(); k != nil && index < len(items); k, v = c.Next() {
+			if !bytes.Equal(k, items[index].Key) {
+				t.Fatalf("unexpected key: %v", k)
+			} else if !bytes.Equal(v, items[index].Value) {
+				t.Fatalf("unexpected value: %v", v)
+			}
+			index++
+		}
+		if len(items) != index {
+			t.Fatalf("unexpected item count: %v, expected %v", len(items), index)
+		}
+
+		if err := tx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+
+		return true
+	}
+	if err := quick.Check(f, qconfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+// Ensure that a transaction can iterate over all elements in a bucket in reverse.
+func TestCursor_QuickCheck_Reverse(t *testing.T) {
+	f := func(items testdata) bool {
+		db := MustOpenDB()
+		defer db.MustClose()
+
+		// Bulk insert all values.
+		tx, err := db.Begin(true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range items {
+			if err := b.Put(item.Key, item.Value); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Sort test data.
+		sort.Sort(revtestdata(items))
+
+		// Iterate over all items and check consistency.
+		var index = 0
+		tx, err = db.Begin(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		for k, v := c.Last(); k != nil && index < len(items); k, v = c.Prev() {
+			if !bytes.Equal(k, items[index].Key) {
+				t.Fatalf("unexpected key: %v", k)
+			} else if !bytes.Equal(v, items[index].Value) {
+				t.Fatalf("unexpected value: %v", v)
+			}
+			index++
+		}
+		if len(items) != index {
+			t.Fatalf("unexpected item count: %v, expected %v", len(items), index)
+		}
+
+		if err := tx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+
+		return true
+	}
+	if err := quick.Check(f, qconfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+// Ensure that a Tx cursor can iterate over subbuckets.
+func TestCursor_QuickCheck_BucketsOnly(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("baz")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		var names []string
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			names = append(names, string(k))
+			if v != nil {
+				t.Fatalf("unexpected value: %v", v)
+			}
+		}
+		if !reflect.DeepEqual(names, []string{"bar", "baz", "foo"}) {
+			t.Fatalf("unexpected names: %+v", names)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx cursor can reverse iterate over subbuckets.
+func TestCursor_QuickCheck_BucketsOnly_Reverse(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.CreateBucket([]byte("baz")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		var names []string
+		c := tx.Bucket([]byte("widgets")).Cursor()
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			names = append(names, string(k))
+			if v != nil {
+				t.Fatalf("unexpected value: %v", v)
+			}
+		}
+		if !reflect.DeepEqual(names, []string{"foo", "baz", "bar"}) {
+			t.Fatalf("unexpected names: %+v", names)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ExampleCursor() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Start a read-write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create a new bucket.
+		b, err := tx.CreateBucket([]byte("animals"))
+		if err != nil {
+			return err
+		}
+
+		// Insert data into a bucket.
+		if err := b.Put([]byte("dog"), []byte("fun")); err != nil {
+			log.Fatal(err)
+		}
+		if err := b.Put([]byte("cat"), []byte("lame")); err != nil {
+			log.Fatal(err)
+		}
+		if err := b.Put([]byte("liger"), []byte("awesome")); err != nil {
+			log.Fatal(err)
+		}
+
+		// Create a cursor for iteration.
+		c := b.Cursor()
+
+		// Iterate over items in sorted key order. This starts from the
+		// first key/value pair and updates the k/v variables to the
+		// next key/value on each iteration.
+		//
+		// The loop finishes at the end of the cursor when a nil key is returned.
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			fmt.Printf("A %s is %s.\n", k, v)
+		}
+
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// A cat is lame.
+	// A dog is fun.
+	// A liger is awesome.
+}
+
+func ExampleCursor_reverse() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Start a read-write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create a new bucket.
+		b, err := tx.CreateBucket([]byte("animals"))
+		if err != nil {
+			return err
+		}
+
+		// Insert data into a bucket.
+		if err := b.Put([]byte("dog"), []byte("fun")); err != nil {
+			log.Fatal(err)
+		}
+		if err := b.Put([]byte("cat"), []byte("lame")); err != nil {
+			log.Fatal(err)
+		}
+		if err := b.Put([]byte("liger"), []byte("awesome")); err != nil {
+			log.Fatal(err)
+		}
+
+		// Create a cursor for iteration.
+		c := b.Cursor()
+
+		// Iterate over items in reverse sorted key order. This starts
+		// from the last key/value pair and updates the k/v variables to
+		// the previous key/value on each iteration.
+		//
+		// The loop finishes at the beginning of the cursor when a nil key
+		// is returned.
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			fmt.Printf("A %s is %s.\n", k, v)
+		}
+
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close the database to release the file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// A liger is awesome.
+	// A dog is fun.
+	// A cat is lame.
+}

--- a/vendor/github.com/coreos/bbolt/db.go
+++ b/vendor/github.com/coreos/bbolt/db.go
@@ -1,0 +1,1123 @@
+package bolt
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log"
+	"os"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+// The largest step that can be taken when remapping the mmap.
+const maxMmapStep = 1 << 30 // 1GB
+
+// The data file format version.
+const version = 2
+
+// Represents a marker value to indicate that a file is a Bolt DB.
+const magic uint32 = 0xED0CDAED
+
+const pgidNoFreelist pgid = 0xffffffffffffffff
+
+// IgnoreNoSync specifies whether the NoSync field of a DB is ignored when
+// syncing changes to a file.  This is required as some operating systems,
+// such as OpenBSD, do not have a unified buffer cache (UBC) and writes
+// must be synchronized using the msync(2) syscall.
+const IgnoreNoSync = runtime.GOOS == "openbsd"
+
+// Default values if not set in a DB instance.
+const (
+	DefaultMaxBatchSize  int = 1000
+	DefaultMaxBatchDelay     = 10 * time.Millisecond
+	DefaultAllocSize         = 16 * 1024 * 1024
+)
+
+// default page size for db is set to the OS page size.
+var defaultPageSize = os.Getpagesize()
+
+// DB represents a collection of buckets persisted to a file on disk.
+// All data access is performed through transactions which can be obtained through the DB.
+// All the functions on DB will return a ErrDatabaseNotOpen if accessed before Open() is called.
+type DB struct {
+	// When enabled, the database will perform a Check() after every commit.
+	// A panic is issued if the database is in an inconsistent state. This
+	// flag has a large performance impact so it should only be used for
+	// debugging purposes.
+	StrictMode bool
+
+	// Setting the NoSync flag will cause the database to skip fsync()
+	// calls after each commit. This can be useful when bulk loading data
+	// into a database and you can restart the bulk load in the event of
+	// a system failure or database corruption. Do not set this flag for
+	// normal use.
+	//
+	// If the package global IgnoreNoSync constant is true, this value is
+	// ignored.  See the comment on that constant for more details.
+	//
+	// THIS IS UNSAFE. PLEASE USE WITH CAUTION.
+	NoSync bool
+
+	// When true, skips syncing freelist to disk. This improves the database
+	// write performance under normal operation, but requires a full database
+	// re-sync during recovery.
+	NoFreelistSync bool
+
+	// When true, skips the truncate call when growing the database.
+	// Setting this to true is only safe on non-ext3/ext4 systems.
+	// Skipping truncation avoids preallocation of hard drive space and
+	// bypasses a truncate() and fsync() syscall on remapping.
+	//
+	// https://github.com/boltdb/bolt/issues/284
+	NoGrowSync bool
+
+	// If you want to read the entire database fast, you can set MmapFlag to
+	// syscall.MAP_POPULATE on Linux 2.6.23+ for sequential read-ahead.
+	MmapFlags int
+
+	// MaxBatchSize is the maximum size of a batch. Default value is
+	// copied from DefaultMaxBatchSize in Open.
+	//
+	// If <=0, disables batching.
+	//
+	// Do not change concurrently with calls to Batch.
+	MaxBatchSize int
+
+	// MaxBatchDelay is the maximum delay before a batch starts.
+	// Default value is copied from DefaultMaxBatchDelay in Open.
+	//
+	// If <=0, effectively disables batching.
+	//
+	// Do not change concurrently with calls to Batch.
+	MaxBatchDelay time.Duration
+
+	// AllocSize is the amount of space allocated when the database
+	// needs to create new pages. This is done to amortize the cost
+	// of truncate() and fsync() when growing the data file.
+	AllocSize int
+
+	path     string
+	file     *os.File
+	lockfile *os.File // windows only
+	dataref  []byte   // mmap'ed readonly, write throws SEGV
+	data     *[maxMapSize]byte
+	datasz   int
+	filesz   int // current on disk file size
+	meta0    *meta
+	meta1    *meta
+	pageSize int
+	opened   bool
+	rwtx     *Tx
+	txs      []*Tx
+	freelist *freelist
+	stats    Stats
+
+	pagePool sync.Pool
+
+	batchMu sync.Mutex
+	batch   *batch
+
+	rwlock   sync.Mutex   // Allows only one writer at a time.
+	metalock sync.Mutex   // Protects meta page access.
+	mmaplock sync.RWMutex // Protects mmap access during remapping.
+	statlock sync.RWMutex // Protects stats access.
+
+	ops struct {
+		writeAt func(b []byte, off int64) (n int, err error)
+	}
+
+	// Read only mode.
+	// When true, Update() and Begin(true) return ErrDatabaseReadOnly immediately.
+	readOnly bool
+}
+
+// Path returns the path to currently open database file.
+func (db *DB) Path() string {
+	return db.path
+}
+
+// GoString returns the Go string representation of the database.
+func (db *DB) GoString() string {
+	return fmt.Sprintf("bolt.DB{path:%q}", db.path)
+}
+
+// String returns the string representation of the database.
+func (db *DB) String() string {
+	return fmt.Sprintf("DB<%q>", db.path)
+}
+
+// Open creates and opens a database at the given path.
+// If the file does not exist then it will be created automatically.
+// Passing in nil options will cause Bolt to open the database with the default options.
+func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
+	var db = &DB{opened: true}
+
+	// Set default options if no options are provided.
+	if options == nil {
+		options = DefaultOptions
+	}
+	db.NoSync = options.NoSync
+	db.NoGrowSync = options.NoGrowSync
+	db.MmapFlags = options.MmapFlags
+	db.NoFreelistSync = options.NoFreelistSync
+
+	// Set default values for later DB operations.
+	db.MaxBatchSize = DefaultMaxBatchSize
+	db.MaxBatchDelay = DefaultMaxBatchDelay
+	db.AllocSize = DefaultAllocSize
+
+	flag := os.O_RDWR
+	if options.ReadOnly {
+		flag = os.O_RDONLY
+		db.readOnly = true
+	}
+
+	// Open data file and separate sync handler for metadata writes.
+	db.path = path
+	var err error
+	if db.file, err = os.OpenFile(db.path, flag|os.O_CREATE, mode); err != nil {
+		_ = db.close()
+		return nil, err
+	}
+
+	// Lock file so that other processes using Bolt in read-write mode cannot
+	// use the database  at the same time. This would cause corruption since
+	// the two processes would write meta pages and free pages separately.
+	// The database file is locked exclusively (only one process can grab the lock)
+	// if !options.ReadOnly.
+	// The database file is locked using the shared lock (more than one process may
+	// hold a lock at the same time) otherwise (options.ReadOnly is set).
+	if err := flock(db, mode, !db.readOnly, options.Timeout); err != nil {
+		db.lockfile = nil // make 'unused' happy. TODO: rework locks
+		_ = db.close()
+		return nil, err
+	}
+
+	// Default values for test hooks
+	db.ops.writeAt = db.file.WriteAt
+
+	if db.pageSize = options.PageSize; db.pageSize == 0 {
+		// Set the default page size to the OS page size.
+		db.pageSize = defaultPageSize
+	}
+
+	// Initialize the database if it doesn't exist.
+	if info, err := db.file.Stat(); err != nil {
+		return nil, err
+	} else if info.Size() == 0 {
+		// Initialize new files with meta pages.
+		if err := db.init(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Read the first meta page to determine the page size.
+		var buf [0x1000]byte
+		// If we can't read the page size, but can read a page, assume
+		// it's the same as the OS or one given -- since that's how the
+		// page size was chosen in the first place.
+		//
+		// If the first page is invalid and this OS uses a different
+		// page size than what the database was created with then we
+		// are out of luck and cannot access the database.
+		//
+		// TODO: scan for next page
+		if bw, err := db.file.ReadAt(buf[:], 0); err == nil && bw == len(buf) {
+			if m := db.pageInBuffer(buf[:], 0).meta(); m.validate() == nil {
+				db.pageSize = int(m.pageSize)
+			}
+		} else {
+			return nil, ErrInvalid
+		}
+	}
+
+	// Initialize page pool.
+	db.pagePool = sync.Pool{
+		New: func() interface{} {
+			return make([]byte, db.pageSize)
+		},
+	}
+
+	// Memory map the data file.
+	if err := db.mmap(options.InitialMmapSize); err != nil {
+		_ = db.close()
+		return nil, err
+	}
+
+	if db.readOnly {
+		return db, nil
+	}
+
+	db.freelist = newFreelist()
+	noFreeList := db.meta().freelist == pgidNoFreelist
+	if noFreeList {
+		// Reconstruct free list by scanning the DB.
+		db.freelist.readIDs(db.freepages())
+	} else {
+		// Read free list from freelist page.
+		db.freelist.read(db.page(db.meta().freelist))
+	}
+	db.stats.FreePageN = len(db.freelist.ids)
+
+	// Flush freelist when transitioning from no sync to sync so
+	// NoFreelistSync unaware boltdb can open the db later.
+	if !db.NoFreelistSync && noFreeList {
+		tx, err := db.Begin(true)
+		if tx != nil {
+			err = tx.Commit()
+		}
+		if err != nil {
+			_ = db.close()
+			return nil, err
+		}
+	}
+
+	// Mark the database as opened and return.
+	return db, nil
+}
+
+// mmap opens the underlying memory-mapped file and initializes the meta references.
+// minsz is the minimum size that the new mmap can be.
+func (db *DB) mmap(minsz int) error {
+	db.mmaplock.Lock()
+	defer db.mmaplock.Unlock()
+
+	info, err := db.file.Stat()
+	if err != nil {
+		return fmt.Errorf("mmap stat error: %s", err)
+	} else if int(info.Size()) < db.pageSize*2 {
+		return fmt.Errorf("file size too small")
+	}
+
+	// Ensure the size is at least the minimum size.
+	var size = int(info.Size())
+	if size < minsz {
+		size = minsz
+	}
+	size, err = db.mmapSize(size)
+	if err != nil {
+		return err
+	}
+
+	// Dereference all mmap references before unmapping.
+	if db.rwtx != nil {
+		db.rwtx.root.dereference()
+	}
+
+	// Unmap existing data before continuing.
+	if err := db.munmap(); err != nil {
+		return err
+	}
+
+	// Memory-map the data file as a byte slice.
+	if err := mmap(db, size); err != nil {
+		return err
+	}
+
+	// Save references to the meta pages.
+	db.meta0 = db.page(0).meta()
+	db.meta1 = db.page(1).meta()
+
+	// Validate the meta pages. We only return an error if both meta pages fail
+	// validation, since meta0 failing validation means that it wasn't saved
+	// properly -- but we can recover using meta1. And vice-versa.
+	err0 := db.meta0.validate()
+	err1 := db.meta1.validate()
+	if err0 != nil && err1 != nil {
+		return err0
+	}
+
+	return nil
+}
+
+// munmap unmaps the data file from memory.
+func (db *DB) munmap() error {
+	if err := munmap(db); err != nil {
+		return fmt.Errorf("unmap error: " + err.Error())
+	}
+	return nil
+}
+
+// mmapSize determines the appropriate size for the mmap given the current size
+// of the database. The minimum size is 32KB and doubles until it reaches 1GB.
+// Returns an error if the new mmap size is greater than the max allowed.
+func (db *DB) mmapSize(size int) (int, error) {
+	// Double the size from 32KB until 1GB.
+	for i := uint(15); i <= 30; i++ {
+		if size <= 1<<i {
+			return 1 << i, nil
+		}
+	}
+
+	// Verify the requested size is not above the maximum allowed.
+	if size > maxMapSize {
+		return 0, fmt.Errorf("mmap too large")
+	}
+
+	// If larger than 1GB then grow by 1GB at a time.
+	sz := int64(size)
+	if remainder := sz % int64(maxMmapStep); remainder > 0 {
+		sz += int64(maxMmapStep) - remainder
+	}
+
+	// Ensure that the mmap size is a multiple of the page size.
+	// This should always be true since we're incrementing in MBs.
+	pageSize := int64(db.pageSize)
+	if (sz % pageSize) != 0 {
+		sz = ((sz / pageSize) + 1) * pageSize
+	}
+
+	// If we've exceeded the max size then only grow up to the max size.
+	if sz > maxMapSize {
+		sz = maxMapSize
+	}
+
+	return int(sz), nil
+}
+
+// init creates a new database file and initializes its meta pages.
+func (db *DB) init() error {
+	// Create two meta pages on a buffer.
+	buf := make([]byte, db.pageSize*4)
+	for i := 0; i < 2; i++ {
+		p := db.pageInBuffer(buf[:], pgid(i))
+		p.id = pgid(i)
+		p.flags = metaPageFlag
+
+		// Initialize the meta page.
+		m := p.meta()
+		m.magic = magic
+		m.version = version
+		m.pageSize = uint32(db.pageSize)
+		m.freelist = 2
+		m.root = bucket{root: 3}
+		m.pgid = 4
+		m.txid = txid(i)
+		m.checksum = m.sum64()
+	}
+
+	// Write an empty freelist at page 3.
+	p := db.pageInBuffer(buf[:], pgid(2))
+	p.id = pgid(2)
+	p.flags = freelistPageFlag
+	p.count = 0
+
+	// Write an empty leaf page at page 4.
+	p = db.pageInBuffer(buf[:], pgid(3))
+	p.id = pgid(3)
+	p.flags = leafPageFlag
+	p.count = 0
+
+	// Write the buffer to our data file.
+	if _, err := db.ops.writeAt(buf, 0); err != nil {
+		return err
+	}
+	if err := fdatasync(db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close releases all database resources.
+// All transactions must be closed before closing the database.
+func (db *DB) Close() error {
+	db.rwlock.Lock()
+	defer db.rwlock.Unlock()
+
+	db.metalock.Lock()
+	defer db.metalock.Unlock()
+
+	db.mmaplock.RLock()
+	defer db.mmaplock.RUnlock()
+
+	return db.close()
+}
+
+func (db *DB) close() error {
+	if !db.opened {
+		return nil
+	}
+
+	db.opened = false
+
+	db.freelist = nil
+
+	// Clear ops.
+	db.ops.writeAt = nil
+
+	// Close the mmap.
+	if err := db.munmap(); err != nil {
+		return err
+	}
+
+	// Close file handles.
+	if db.file != nil {
+		// No need to unlock read-only file.
+		if !db.readOnly {
+			// Unlock the file.
+			if err := funlock(db); err != nil {
+				log.Printf("bolt.Close(): funlock error: %s", err)
+			}
+		}
+
+		// Close the file descriptor.
+		if err := db.file.Close(); err != nil {
+			return fmt.Errorf("db file close: %s", err)
+		}
+		db.file = nil
+	}
+
+	db.path = ""
+	return nil
+}
+
+// Begin starts a new transaction.
+// Multiple read-only transactions can be used concurrently but only one
+// write transaction can be used at a time. Starting multiple write transactions
+// will cause the calls to block and be serialized until the current write
+// transaction finishes.
+//
+// Transactions should not be dependent on one another. Opening a read
+// transaction and a write transaction in the same goroutine can cause the
+// writer to deadlock because the database periodically needs to re-mmap itself
+// as it grows and it cannot do that while a read transaction is open.
+//
+// If a long running read transaction (for example, a snapshot transaction) is
+// needed, you might want to set DB.InitialMmapSize to a large enough value
+// to avoid potential blocking of write transaction.
+//
+// IMPORTANT: You must close read-only transactions after you are finished or
+// else the database will not reclaim old pages.
+func (db *DB) Begin(writable bool) (*Tx, error) {
+	if writable {
+		return db.beginRWTx()
+	}
+	return db.beginTx()
+}
+
+func (db *DB) beginTx() (*Tx, error) {
+	// Lock the meta pages while we initialize the transaction. We obtain
+	// the meta lock before the mmap lock because that's the order that the
+	// write transaction will obtain them.
+	db.metalock.Lock()
+
+	// Obtain a read-only lock on the mmap. When the mmap is remapped it will
+	// obtain a write lock so all transactions must finish before it can be
+	// remapped.
+	db.mmaplock.RLock()
+
+	// Exit if the database is not open yet.
+	if !db.opened {
+		db.mmaplock.RUnlock()
+		db.metalock.Unlock()
+		return nil, ErrDatabaseNotOpen
+	}
+
+	// Create a transaction associated with the database.
+	t := &Tx{}
+	t.init(db)
+
+	// Keep track of transaction until it closes.
+	db.txs = append(db.txs, t)
+	n := len(db.txs)
+
+	// Unlock the meta pages.
+	db.metalock.Unlock()
+
+	// Update the transaction stats.
+	db.statlock.Lock()
+	db.stats.TxN++
+	db.stats.OpenTxN = n
+	db.statlock.Unlock()
+
+	return t, nil
+}
+
+func (db *DB) beginRWTx() (*Tx, error) {
+	// If the database was opened with Options.ReadOnly, return an error.
+	if db.readOnly {
+		return nil, ErrDatabaseReadOnly
+	}
+
+	// Obtain writer lock. This is released by the transaction when it closes.
+	// This enforces only one writer transaction at a time.
+	db.rwlock.Lock()
+
+	// Once we have the writer lock then we can lock the meta pages so that
+	// we can set up the transaction.
+	db.metalock.Lock()
+	defer db.metalock.Unlock()
+
+	// Exit if the database is not open yet.
+	if !db.opened {
+		db.rwlock.Unlock()
+		return nil, ErrDatabaseNotOpen
+	}
+
+	// Create a transaction associated with the database.
+	t := &Tx{writable: true}
+	t.init(db)
+	db.rwtx = t
+	db.freePages()
+	return t, nil
+}
+
+// freePages releases any pages associated with closed read-only transactions.
+func (db *DB) freePages() {
+	// Free all pending pages prior to earliest open transaction.
+	sort.Sort(txsById(db.txs))
+	minid := txid(0xFFFFFFFFFFFFFFFF)
+	if len(db.txs) > 0 {
+		minid = db.txs[0].meta.txid
+	}
+	if minid > 0 {
+		db.freelist.release(minid - 1)
+	}
+	// Release unused txid extents.
+	for _, t := range db.txs {
+		db.freelist.releaseRange(minid, t.meta.txid-1)
+		minid = t.meta.txid + 1
+	}
+	db.freelist.releaseRange(minid, txid(0xFFFFFFFFFFFFFFFF))
+	// Any page both allocated and freed in an extent is safe to release.
+}
+
+type txsById []*Tx
+
+func (t txsById) Len() int           { return len(t) }
+func (t txsById) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t txsById) Less(i, j int) bool { return t[i].meta.txid < t[j].meta.txid }
+
+// removeTx removes a transaction from the database.
+func (db *DB) removeTx(tx *Tx) {
+	// Release the read lock on the mmap.
+	db.mmaplock.RUnlock()
+
+	// Use the meta lock to restrict access to the DB object.
+	db.metalock.Lock()
+
+	// Remove the transaction.
+	for i, t := range db.txs {
+		if t == tx {
+			last := len(db.txs) - 1
+			db.txs[i] = db.txs[last]
+			db.txs[last] = nil
+			db.txs = db.txs[:last]
+			break
+		}
+	}
+	n := len(db.txs)
+
+	// Unlock the meta pages.
+	db.metalock.Unlock()
+
+	// Merge statistics.
+	db.statlock.Lock()
+	db.stats.OpenTxN = n
+	db.stats.TxStats.add(&tx.stats)
+	db.statlock.Unlock()
+}
+
+// Update executes a function within the context of a read-write managed transaction.
+// If no error is returned from the function then the transaction is committed.
+// If an error is returned then the entire transaction is rolled back.
+// Any error that is returned from the function or returned from the commit is
+// returned from the Update() method.
+//
+// Attempting to manually commit or rollback within the function will cause a panic.
+func (db *DB) Update(fn func(*Tx) error) error {
+	t, err := db.Begin(true)
+	if err != nil {
+		return err
+	}
+
+	// Make sure the transaction rolls back in the event of a panic.
+	defer func() {
+		if t.db != nil {
+			t.rollback()
+		}
+	}()
+
+	// Mark as a managed tx so that the inner function cannot manually commit.
+	t.managed = true
+
+	// If an error is returned from the function then rollback and return error.
+	err = fn(t)
+	t.managed = false
+	if err != nil {
+		_ = t.Rollback()
+		return err
+	}
+
+	return t.Commit()
+}
+
+// View executes a function within the context of a managed read-only transaction.
+// Any error that is returned from the function is returned from the View() method.
+//
+// Attempting to manually rollback within the function will cause a panic.
+func (db *DB) View(fn func(*Tx) error) error {
+	t, err := db.Begin(false)
+	if err != nil {
+		return err
+	}
+
+	// Make sure the transaction rolls back in the event of a panic.
+	defer func() {
+		if t.db != nil {
+			t.rollback()
+		}
+	}()
+
+	// Mark as a managed tx so that the inner function cannot manually rollback.
+	t.managed = true
+
+	// If an error is returned from the function then pass it through.
+	err = fn(t)
+	t.managed = false
+	if err != nil {
+		_ = t.Rollback()
+		return err
+	}
+
+	if err := t.Rollback(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Batch calls fn as part of a batch. It behaves similar to Update,
+// except:
+//
+// 1. concurrent Batch calls can be combined into a single Bolt
+// transaction.
+//
+// 2. the function passed to Batch may be called multiple times,
+// regardless of whether it returns error or not.
+//
+// This means that Batch function side effects must be idempotent and
+// take permanent effect only after a successful return is seen in
+// caller.
+//
+// The maximum batch size and delay can be adjusted with DB.MaxBatchSize
+// and DB.MaxBatchDelay, respectively.
+//
+// Batch is only useful when there are multiple goroutines calling it.
+func (db *DB) Batch(fn func(*Tx) error) error {
+	errCh := make(chan error, 1)
+
+	db.batchMu.Lock()
+	if (db.batch == nil) || (db.batch != nil && len(db.batch.calls) >= db.MaxBatchSize) {
+		// There is no existing batch, or the existing batch is full; start a new one.
+		db.batch = &batch{
+			db: db,
+		}
+		db.batch.timer = time.AfterFunc(db.MaxBatchDelay, db.batch.trigger)
+	}
+	db.batch.calls = append(db.batch.calls, call{fn: fn, err: errCh})
+	if len(db.batch.calls) >= db.MaxBatchSize {
+		// wake up batch, it's ready to run
+		go db.batch.trigger()
+	}
+	db.batchMu.Unlock()
+
+	err := <-errCh
+	if err == trySolo {
+		err = db.Update(fn)
+	}
+	return err
+}
+
+type call struct {
+	fn  func(*Tx) error
+	err chan<- error
+}
+
+type batch struct {
+	db    *DB
+	timer *time.Timer
+	start sync.Once
+	calls []call
+}
+
+// trigger runs the batch if it hasn't already been run.
+func (b *batch) trigger() {
+	b.start.Do(b.run)
+}
+
+// run performs the transactions in the batch and communicates results
+// back to DB.Batch.
+func (b *batch) run() {
+	b.db.batchMu.Lock()
+	b.timer.Stop()
+	// Make sure no new work is added to this batch, but don't break
+	// other batches.
+	if b.db.batch == b {
+		b.db.batch = nil
+	}
+	b.db.batchMu.Unlock()
+
+retry:
+	for len(b.calls) > 0 {
+		var failIdx = -1
+		err := b.db.Update(func(tx *Tx) error {
+			for i, c := range b.calls {
+				if err := safelyCall(c.fn, tx); err != nil {
+					failIdx = i
+					return err
+				}
+			}
+			return nil
+		})
+
+		if failIdx >= 0 {
+			// take the failing transaction out of the batch. it's
+			// safe to shorten b.calls here because db.batch no longer
+			// points to us, and we hold the mutex anyway.
+			c := b.calls[failIdx]
+			b.calls[failIdx], b.calls = b.calls[len(b.calls)-1], b.calls[:len(b.calls)-1]
+			// tell the submitter re-run it solo, continue with the rest of the batch
+			c.err <- trySolo
+			continue retry
+		}
+
+		// pass success, or bolt internal errors, to all callers
+		for _, c := range b.calls {
+			if c.err != nil {
+				c.err <- err
+			}
+		}
+		break retry
+	}
+}
+
+// trySolo is a special sentinel error value used for signaling that a
+// transaction function should be re-run. It should never be seen by
+// callers.
+var trySolo = errors.New("batch function returned an error and should be re-run solo")
+
+type panicked struct {
+	reason interface{}
+}
+
+func (p panicked) Error() string {
+	if err, ok := p.reason.(error); ok {
+		return err.Error()
+	}
+	return fmt.Sprintf("panic: %v", p.reason)
+}
+
+func safelyCall(fn func(*Tx) error, tx *Tx) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = panicked{p}
+		}
+	}()
+	return fn(tx)
+}
+
+// Sync executes fdatasync() against the database file handle.
+//
+// This is not necessary under normal operation, however, if you use NoSync
+// then it allows you to force the database file to sync against the disk.
+func (db *DB) Sync() error { return fdatasync(db) }
+
+// Stats retrieves ongoing performance stats for the database.
+// This is only updated when a transaction closes.
+func (db *DB) Stats() Stats {
+	db.statlock.RLock()
+	defer db.statlock.RUnlock()
+	return db.stats
+}
+
+// This is for internal access to the raw data bytes from the C cursor, use
+// carefully, or not at all.
+func (db *DB) Info() *Info {
+	return &Info{uintptr(unsafe.Pointer(&db.data[0])), db.pageSize}
+}
+
+// page retrieves a page reference from the mmap based on the current page size.
+func (db *DB) page(id pgid) *page {
+	pos := id * pgid(db.pageSize)
+	return (*page)(unsafe.Pointer(&db.data[pos]))
+}
+
+// pageInBuffer retrieves a page reference from a given byte array based on the current page size.
+func (db *DB) pageInBuffer(b []byte, id pgid) *page {
+	return (*page)(unsafe.Pointer(&b[id*pgid(db.pageSize)]))
+}
+
+// meta retrieves the current meta page reference.
+func (db *DB) meta() *meta {
+	// We have to return the meta with the highest txid which doesn't fail
+	// validation. Otherwise, we can cause errors when in fact the database is
+	// in a consistent state. metaA is the one with the higher txid.
+	metaA := db.meta0
+	metaB := db.meta1
+	if db.meta1.txid > db.meta0.txid {
+		metaA = db.meta1
+		metaB = db.meta0
+	}
+
+	// Use higher meta page if valid. Otherwise fallback to previous, if valid.
+	if err := metaA.validate(); err == nil {
+		return metaA
+	} else if err := metaB.validate(); err == nil {
+		return metaB
+	}
+
+	// This should never be reached, because both meta1 and meta0 were validated
+	// on mmap() and we do fsync() on every write.
+	panic("bolt.DB.meta(): invalid meta pages")
+}
+
+// allocate returns a contiguous block of memory starting at a given page.
+func (db *DB) allocate(txid txid, count int) (*page, error) {
+	// Allocate a temporary buffer for the page.
+	var buf []byte
+	if count == 1 {
+		buf = db.pagePool.Get().([]byte)
+	} else {
+		buf = make([]byte, count*db.pageSize)
+	}
+	p := (*page)(unsafe.Pointer(&buf[0]))
+	p.overflow = uint32(count - 1)
+
+	// Use pages from the freelist if they are available.
+	if p.id = db.freelist.allocate(txid, count); p.id != 0 {
+		return p, nil
+	}
+
+	// Resize mmap() if we're at the end.
+	p.id = db.rwtx.meta.pgid
+	var minsz = int((p.id+pgid(count))+1) * db.pageSize
+	if minsz >= db.datasz {
+		if err := db.mmap(minsz); err != nil {
+			return nil, fmt.Errorf("mmap allocate error: %s", err)
+		}
+	}
+
+	// Move the page id high water mark.
+	db.rwtx.meta.pgid += pgid(count)
+
+	return p, nil
+}
+
+// grow grows the size of the database to the given sz.
+func (db *DB) grow(sz int) error {
+	// Ignore if the new size is less than available file size.
+	if sz <= db.filesz {
+		return nil
+	}
+
+	// If the data is smaller than the alloc size then only allocate what's needed.
+	// Once it goes over the allocation size then allocate in chunks.
+	if db.datasz < db.AllocSize {
+		sz = db.datasz
+	} else {
+		sz += db.AllocSize
+	}
+
+	// Truncate and fsync to ensure file size metadata is flushed.
+	// https://github.com/boltdb/bolt/issues/284
+	if !db.NoGrowSync && !db.readOnly {
+		if runtime.GOOS != "windows" {
+			if err := db.file.Truncate(int64(sz)); err != nil {
+				return fmt.Errorf("file resize error: %s", err)
+			}
+		}
+		if err := db.file.Sync(); err != nil {
+			return fmt.Errorf("file sync error: %s", err)
+		}
+	}
+
+	db.filesz = sz
+	return nil
+}
+
+func (db *DB) IsReadOnly() bool {
+	return db.readOnly
+}
+
+func (db *DB) freepages() []pgid {
+	tx, err := db.beginTx()
+	defer func() {
+		err = tx.Rollback()
+		if err != nil {
+			panic("freepages: failed to rollback tx")
+		}
+	}()
+	if err != nil {
+		panic("freepages: failed to open read only tx")
+	}
+
+	reachable := make(map[pgid]*page)
+	nofreed := make(map[pgid]bool)
+	ech := make(chan error)
+	go func() {
+		for e := range ech {
+			panic(fmt.Sprintf("freepages: failed to get all reachable pages (%v)", e))
+		}
+	}()
+	tx.checkBucket(&tx.root, reachable, nofreed, ech)
+	close(ech)
+
+	var fids []pgid
+	for i := pgid(2); i < db.meta().pgid; i++ {
+		if _, ok := reachable[i]; !ok {
+			fids = append(fids, i)
+		}
+	}
+	return fids
+}
+
+// Options represents the options that can be set when opening a database.
+type Options struct {
+	// Timeout is the amount of time to wait to obtain a file lock.
+	// When set to zero it will wait indefinitely. This option is only
+	// available on Darwin and Linux.
+	Timeout time.Duration
+
+	// Sets the DB.NoGrowSync flag before memory mapping the file.
+	NoGrowSync bool
+
+	// Do not sync freelist to disk. This improves the database write performance
+	// under normal operation, but requires a full database re-sync during recovery.
+	NoFreelistSync bool
+
+	// Open database in read-only mode. Uses flock(..., LOCK_SH |LOCK_NB) to
+	// grab a shared lock (UNIX).
+	ReadOnly bool
+
+	// Sets the DB.MmapFlags flag before memory mapping the file.
+	MmapFlags int
+
+	// InitialMmapSize is the initial mmap size of the database
+	// in bytes. Read transactions won't block write transaction
+	// if the InitialMmapSize is large enough to hold database mmap
+	// size. (See DB.Begin for more information)
+	//
+	// If <=0, the initial map size is 0.
+	// If initialMmapSize is smaller than the previous database size,
+	// it takes no effect.
+	InitialMmapSize int
+
+	// PageSize overrides the default OS page size.
+	PageSize int
+
+	// NoSync sets the initial value of DB.NoSync. Normally this can just be
+	// set directly on the DB itself when returned from Open(), but this option
+	// is useful in APIs which expose Options but not the underlying DB.
+	NoSync bool
+}
+
+// DefaultOptions represent the options used if nil options are passed into Open().
+// No timeout is used which will cause Bolt to wait indefinitely for a lock.
+var DefaultOptions = &Options{
+	Timeout:    0,
+	NoGrowSync: false,
+}
+
+// Stats represents statistics about the database.
+type Stats struct {
+	// Freelist stats
+	FreePageN     int // total number of free pages on the freelist
+	PendingPageN  int // total number of pending pages on the freelist
+	FreeAlloc     int // total bytes allocated in free pages
+	FreelistInuse int // total bytes used by the freelist
+
+	// Transaction stats
+	TxN     int // total number of started read transactions
+	OpenTxN int // number of currently open read transactions
+
+	TxStats TxStats // global, ongoing stats.
+}
+
+// Sub calculates and returns the difference between two sets of database stats.
+// This is useful when obtaining stats at two different points and time and
+// you need the performance counters that occurred within that time span.
+func (s *Stats) Sub(other *Stats) Stats {
+	if other == nil {
+		return *s
+	}
+	var diff Stats
+	diff.FreePageN = s.FreePageN
+	diff.PendingPageN = s.PendingPageN
+	diff.FreeAlloc = s.FreeAlloc
+	diff.FreelistInuse = s.FreelistInuse
+	diff.TxN = s.TxN - other.TxN
+	diff.TxStats = s.TxStats.Sub(&other.TxStats)
+	return diff
+}
+
+type Info struct {
+	Data     uintptr
+	PageSize int
+}
+
+type meta struct {
+	magic    uint32
+	version  uint32
+	pageSize uint32
+	flags    uint32
+	root     bucket
+	freelist pgid
+	pgid     pgid
+	txid     txid
+	checksum uint64
+}
+
+// validate checks the marker bytes and version of the meta page to ensure it matches this binary.
+func (m *meta) validate() error {
+	if m.magic != magic {
+		return ErrInvalid
+	} else if m.version != version {
+		return ErrVersionMismatch
+	} else if m.checksum != 0 && m.checksum != m.sum64() {
+		return ErrChecksum
+	}
+	return nil
+}
+
+// copy copies one meta object to another.
+func (m *meta) copy(dest *meta) {
+	*dest = *m
+}
+
+// write writes the meta onto a page.
+func (m *meta) write(p *page) {
+	if m.root.root >= m.pgid {
+		panic(fmt.Sprintf("root bucket pgid (%d) above high water mark (%d)", m.root.root, m.pgid))
+	} else if m.freelist >= m.pgid && m.freelist != pgidNoFreelist {
+		// TODO: reject pgidNoFreeList if !NoFreelistSync
+		panic(fmt.Sprintf("freelist pgid (%d) above high water mark (%d)", m.freelist, m.pgid))
+	}
+
+	// Page id is either going to be 0 or 1 which we can determine by the transaction ID.
+	p.id = pgid(m.txid % 2)
+	p.flags |= metaPageFlag
+
+	// Calculate the checksum.
+	m.checksum = m.sum64()
+
+	m.copy(p.meta())
+}
+
+// generates the checksum for the meta.
+func (m *meta) sum64() uint64 {
+	var h = fnv.New64a()
+	_, _ = h.Write((*[unsafe.Offsetof(meta{}.checksum)]byte)(unsafe.Pointer(m))[:])
+	return h.Sum64()
+}
+
+// _assert will panic with a given formatted message if the given condition is false.
+func _assert(condition bool, msg string, v ...interface{}) {
+	if !condition {
+		panic(fmt.Sprintf("assertion failed: "+msg, v...))
+	}
+}

--- a/vendor/github.com/coreos/bbolt/db_test.go
+++ b/vendor/github.com/coreos/bbolt/db_test.go
@@ -1,0 +1,1611 @@
+package bolt_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/coreos/bbolt"
+)
+
+var statsFlag = flag.Bool("stats", false, "show performance stats")
+
+// pageSize is the size of one page in the data file.
+const pageSize = 4096
+
+// pageHeaderSize is the size of a page header.
+const pageHeaderSize = 16
+
+// meta represents a simplified version of a database meta page for testing.
+type meta struct {
+	magic    uint32
+	version  uint32
+	_        uint32
+	_        uint32
+	_        [16]byte
+	_        uint64
+	pgid     uint64
+	_        uint64
+	checksum uint64
+}
+
+// Ensure that a database can be opened without error.
+func TestOpen(t *testing.T) {
+	path := tempfile()
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if db == nil {
+		t.Fatal("expected db")
+	}
+
+	if s := db.Path(); s != path {
+		t.Fatalf("unexpected path: %s", s)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that opening a database with a blank path returns an error.
+func TestOpen_ErrPathRequired(t *testing.T) {
+	_, err := bolt.Open("", 0666, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+// Ensure that opening a database with a bad path returns an error.
+func TestOpen_ErrNotExists(t *testing.T) {
+	_, err := bolt.Open(filepath.Join(tempfile(), "bad-path"), 0666, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// Ensure that opening a file that is not a Bolt database returns ErrInvalid.
+func TestOpen_ErrInvalid(t *testing.T) {
+	path := tempfile()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintln(f, "this is not a bolt database"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	if _, err := bolt.Open(path, 0666, nil); err != bolt.ErrInvalid {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that opening a file with two invalid versions returns ErrVersionMismatch.
+func TestOpen_ErrVersionMismatch(t *testing.T) {
+	if pageSize != os.Getpagesize() {
+		t.Skip("page size mismatch")
+	}
+
+	// Create empty database.
+	db := MustOpenDB()
+	path := db.Path()
+	defer db.MustClose()
+
+	// Close database.
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read data file.
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite meta pages.
+	meta0 := (*meta)(unsafe.Pointer(&buf[pageHeaderSize]))
+	meta0.version++
+	meta1 := (*meta)(unsafe.Pointer(&buf[pageSize+pageHeaderSize]))
+	meta1.version++
+	if err := ioutil.WriteFile(path, buf, 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen data file.
+	if _, err := bolt.Open(path, 0666, nil); err != bolt.ErrVersionMismatch {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that opening a file with two invalid checksums returns ErrChecksum.
+func TestOpen_ErrChecksum(t *testing.T) {
+	if pageSize != os.Getpagesize() {
+		t.Skip("page size mismatch")
+	}
+
+	// Create empty database.
+	db := MustOpenDB()
+	path := db.Path()
+	defer db.MustClose()
+
+	// Close database.
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read data file.
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite meta pages.
+	meta0 := (*meta)(unsafe.Pointer(&buf[pageHeaderSize]))
+	meta0.pgid++
+	meta1 := (*meta)(unsafe.Pointer(&buf[pageSize+pageHeaderSize]))
+	meta1.pgid++
+	if err := ioutil.WriteFile(path, buf, 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen data file.
+	if _, err := bolt.Open(path, 0666, nil); err != bolt.ErrChecksum {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that opening a database does not increase its size.
+// https://github.com/boltdb/bolt/issues/291
+func TestOpen_Size(t *testing.T) {
+	// Open a data file.
+	db := MustOpenDB()
+	path := db.Path()
+	defer db.MustClose()
+
+	pagesize := db.Info().PageSize
+
+	// Insert until we get above the minimum 4MB size.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, _ := tx.CreateBucketIfNotExists([]byte("data"))
+		for i := 0; i < 10000; i++ {
+			if err := b.Put([]byte(fmt.Sprintf("%04d", i)), make([]byte, 1000)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Close database and grab the size.
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sz := fileSize(path)
+	if sz == 0 {
+		t.Fatalf("unexpected new file size: %d", sz)
+	}
+
+	// Reopen database, update, and check size again.
+	db0, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db0.Update(func(tx *bolt.Tx) error {
+		if err := tx.Bucket([]byte("data")).Put([]byte{0}, []byte{0}); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db0.Close(); err != nil {
+		t.Fatal(err)
+	}
+	newSz := fileSize(path)
+	if newSz == 0 {
+		t.Fatalf("unexpected new file size: %d", newSz)
+	}
+
+	// Compare the original size with the new size.
+	// db size might increase by a few page sizes due to the new small update.
+	if sz < newSz-5*int64(pagesize) {
+		t.Fatalf("unexpected file growth: %d => %d", sz, newSz)
+	}
+}
+
+// Ensure that opening a database beyond the max step size does not increase its size.
+// https://github.com/boltdb/bolt/issues/303
+func TestOpen_Size_Large(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode")
+	}
+
+	// Open a data file.
+	db := MustOpenDB()
+	path := db.Path()
+	defer db.MustClose()
+
+	pagesize := db.Info().PageSize
+
+	// Insert until we get above the minimum 4MB size.
+	var index uint64
+	for i := 0; i < 10000; i++ {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			b, _ := tx.CreateBucketIfNotExists([]byte("data"))
+			for j := 0; j < 1000; j++ {
+				if err := b.Put(u64tob(index), make([]byte, 50)); err != nil {
+					t.Fatal(err)
+				}
+				index++
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Close database and grab the size.
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sz := fileSize(path)
+	if sz == 0 {
+		t.Fatalf("unexpected new file size: %d", sz)
+	} else if sz < (1 << 30) {
+		t.Fatalf("expected larger initial size: %d", sz)
+	}
+
+	// Reopen database, update, and check size again.
+	db0, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db0.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("data")).Put([]byte{0}, []byte{0})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db0.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	newSz := fileSize(path)
+	if newSz == 0 {
+		t.Fatalf("unexpected new file size: %d", newSz)
+	}
+
+	// Compare the original size with the new size.
+	// db size might increase by a few page sizes due to the new small update.
+	if sz < newSz-5*int64(pagesize) {
+		t.Fatalf("unexpected file growth: %d => %d", sz, newSz)
+	}
+}
+
+// Ensure that a re-opened database is consistent.
+func TestOpen_Check(t *testing.T) {
+	path := tempfile()
+
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.View(func(tx *bolt.Tx) error { return <-tx.Check() }); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err = bolt.Open(path, 0666, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.View(func(tx *bolt.Tx) error { return <-tx.Check() }); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that write errors to the meta file handler during initialization are returned.
+func TestOpen_MetaInitWriteError(t *testing.T) {
+	t.Skip("pending")
+}
+
+// Ensure that a database that is too small returns an error.
+func TestOpen_FileTooSmall(t *testing.T) {
+	path := tempfile()
+
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pageSize := int64(db.Info().PageSize)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// corrupt the database
+	if err := os.Truncate(path, pageSize); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err = bolt.Open(path, 0666, nil)
+	if err == nil || err.Error() != "file size too small" {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// TestDB_Open_InitialMmapSize tests if having InitialMmapSize large enough
+// to hold data from concurrent write transaction resolves the issue that
+// read transaction blocks the write transaction and causes deadlock.
+// This is a very hacky test since the mmap size is not exposed.
+func TestDB_Open_InitialMmapSize(t *testing.T) {
+	path := tempfile()
+	defer os.Remove(path)
+
+	initMmapSize := 1 << 30  // 1GB
+	testWriteSize := 1 << 27 // 134MB
+
+	db, err := bolt.Open(path, 0666, &bolt.Options{InitialMmapSize: initMmapSize})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a long-running read transaction
+	// that never gets closed while writing
+	rtx, err := db.Begin(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a write transaction
+	wtx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := wtx.CreateBucket([]byte("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// and commit a large write
+	err = b.Put([]byte("foo"), make([]byte, testWriteSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		if err := wtx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("unexpected that the reader blocks writer")
+	case <-done:
+	}
+
+	if err := rtx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestOpen_BigPage checks the database uses bigger pages when
+// changing PageSize.
+func TestOpen_BigPage(t *testing.T) {
+	pageSize := os.Getpagesize()
+
+	db1 := MustOpenWithOption(&bolt.Options{PageSize: pageSize * 2})
+	defer db1.MustClose()
+
+	db2 := MustOpenWithOption(&bolt.Options{PageSize: pageSize * 4})
+	defer db2.MustClose()
+
+	if db1sz, db2sz := fileSize(db1.f), fileSize(db2.f); db1sz >= db2sz {
+		t.Errorf("expected %d < %d", db1sz, db2sz)
+	}
+}
+
+// TestOpen_RecoverFreeList tests opening the DB with free-list
+// write-out after no free list sync will recover the free list
+// and write it out.
+func TestOpen_RecoverFreeList(t *testing.T) {
+	db := MustOpenWithOption(&bolt.Options{NoFreelistSync: true})
+	defer db.MustClose()
+
+	// Write some pages.
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wbuf := make([]byte, 8192)
+	for i := 0; i < 100; i++ {
+		s := fmt.Sprintf("%d", i)
+		b, err := tx.CreateBucket([]byte(s))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = b.Put([]byte(s), wbuf); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate free pages.
+	if tx, err = db.Begin(true); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		s := fmt.Sprintf("%d", i)
+		b := tx.Bucket([]byte(s))
+		if b == nil {
+			t.Fatal(err)
+		}
+		if err := b.Delete([]byte(s)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Record freelist count from opening with NoFreelistSync.
+	db.MustReopen()
+	freepages := db.Stats().FreePageN
+	if freepages == 0 {
+		t.Fatalf("no free pages on NoFreelistSync reopen")
+	}
+	if err := db.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check free page count is reconstructed when opened with freelist sync.
+	db.o = &bolt.Options{}
+	db.MustReopen()
+	// One less free page for syncing the free list on open.
+	freepages--
+	if fp := db.Stats().FreePageN; fp < freepages {
+		t.Fatalf("closed with %d free pages, opened with %d", freepages, fp)
+	}
+}
+
+// Ensure that a database cannot open a transaction when it's not open.
+func TestDB_Begin_ErrDatabaseNotOpen(t *testing.T) {
+	var db bolt.DB
+	if _, err := db.Begin(false); err != bolt.ErrDatabaseNotOpen {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that a read-write transaction can be retrieved.
+func TestDB_BeginRW(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	} else if tx == nil {
+		t.Fatal("expected tx")
+	}
+
+	if tx.DB() != db.DB {
+		t.Fatal("unexpected tx database")
+	} else if !tx.Writable() {
+		t.Fatal("expected writable tx")
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that opening a transaction while the DB is closed returns an error.
+func TestDB_BeginRW_Closed(t *testing.T) {
+	var db bolt.DB
+	if _, err := db.Begin(true); err != bolt.ErrDatabaseNotOpen {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestDB_Close_PendingTx_RW(t *testing.T) { testDB_Close_PendingTx(t, true) }
+func TestDB_Close_PendingTx_RO(t *testing.T) { testDB_Close_PendingTx(t, false) }
+
+// Ensure that a database cannot close while transactions are open.
+func testDB_Close_PendingTx(t *testing.T, writable bool) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Start transaction.
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open update in separate goroutine.
+	done := make(chan struct{})
+	go func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		close(done)
+	}()
+
+	// Ensure database hasn't closed.
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("database closed too early")
+	default:
+	}
+
+	// Commit transaction.
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure database closed now.
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+	default:
+		t.Fatal("database did not close")
+	}
+}
+
+// Ensure a database can provide a transactional block.
+func TestDB_Update(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Delete([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		if v := b.Get([]byte("foo")); v != nil {
+			t.Fatalf("expected nil value, got: %v", v)
+		}
+		if v := b.Get([]byte("baz")); !bytes.Equal(v, []byte("bat")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a closed database returns an error while running a transaction block
+func TestDB_Update_Closed(t *testing.T) {
+	var db bolt.DB
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != bolt.ErrDatabaseNotOpen {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure a panic occurs while trying to commit a managed transaction.
+func TestDB_Update_ManualCommit(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var panicked bool
+	if err := db.Update(func(tx *bolt.Tx) error {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = true
+				}
+			}()
+
+			if err := tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if !panicked {
+		t.Fatal("expected panic")
+	}
+}
+
+// Ensure a panic occurs while trying to rollback a managed transaction.
+func TestDB_Update_ManualRollback(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var panicked bool
+	if err := db.Update(func(tx *bolt.Tx) error {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = true
+				}
+			}()
+
+			if err := tx.Rollback(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if !panicked {
+		t.Fatal("expected panic")
+	}
+}
+
+// Ensure a panic occurs while trying to commit a managed transaction.
+func TestDB_View_ManualCommit(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var panicked bool
+	if err := db.View(func(tx *bolt.Tx) error {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = true
+				}
+			}()
+
+			if err := tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if !panicked {
+		t.Fatal("expected panic")
+	}
+}
+
+// Ensure a panic occurs while trying to rollback a managed transaction.
+func TestDB_View_ManualRollback(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var panicked bool
+	if err := db.View(func(tx *bolt.Tx) error {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = true
+				}
+			}()
+
+			if err := tx.Rollback(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if !panicked {
+		t.Fatal("expected panic")
+	}
+}
+
+// Ensure a write transaction that panics does not hold open locks.
+func TestDB_Update_Panic(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Panic during update but recover.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Log("recover: update", r)
+			}
+		}()
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+				t.Fatal(err)
+			}
+			panic("omg")
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Verify we can update again.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that our change persisted.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte("widgets")) == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure a database can return an error through a read-only transactional block.
+func TestDB_View_Error(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		return errors.New("xxx")
+	}); err == nil || err.Error() != "xxx" {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure a read transaction that panics does not hold open locks.
+func TestDB_View_Panic(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Panic during view transaction but recover.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Log("recover: view", r)
+			}
+		}()
+
+		if err := db.View(func(tx *bolt.Tx) error {
+			if tx.Bucket([]byte("widgets")) == nil {
+				t.Fatal("expected bucket")
+			}
+			panic("omg")
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Verify that we can still use read transactions.
+	if err := db.View(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte("widgets")) == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that DB stats can be returned.
+func TestDB_Stats(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := db.Stats()
+	if stats.TxStats.PageCount != 2 {
+		t.Fatalf("unexpected TxStats.PageCount: %d", stats.TxStats.PageCount)
+	} else if stats.FreePageN != 0 {
+		t.Fatalf("unexpected FreePageN != 0: %d", stats.FreePageN)
+	} else if stats.PendingPageN != 2 {
+		t.Fatalf("unexpected PendingPageN != 2: %d", stats.PendingPageN)
+	}
+}
+
+// Ensure that database pages are in expected order and type.
+func TestDB_Consistency(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		if err := db.Update(func(tx *bolt.Tx) error {
+			if err := tx.Bucket([]byte("widgets")).Put([]byte("foo"), []byte("bar")); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if p, _ := tx.Page(0); p == nil {
+			t.Fatal("expected page")
+		} else if p.Type != "meta" {
+			t.Fatalf("unexpected page type: %s", p.Type)
+		}
+
+		if p, _ := tx.Page(1); p == nil {
+			t.Fatal("expected page")
+		} else if p.Type != "meta" {
+			t.Fatalf("unexpected page type: %s", p.Type)
+		}
+
+		if p, _ := tx.Page(2); p == nil {
+			t.Fatal("expected page")
+		} else if p.Type != "free" {
+			t.Fatalf("unexpected page type: %s", p.Type)
+		}
+
+		if p, _ := tx.Page(3); p == nil {
+			t.Fatal("expected page")
+		} else if p.Type != "free" {
+			t.Fatalf("unexpected page type: %s", p.Type)
+		}
+
+		if p, _ := tx.Page(4); p == nil {
+			t.Fatal("expected page")
+		} else if p.Type != "leaf" {
+			t.Fatalf("unexpected page type: %s", p.Type)
+		}
+
+		if p, _ := tx.Page(5); p == nil {
+			t.Fatal("expected page")
+		} else if p.Type != "freelist" {
+			t.Fatalf("unexpected page type: %s", p.Type)
+		}
+
+		if p, _ := tx.Page(6); p != nil {
+			t.Fatal("unexpected page")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that DB stats can be subtracted from one another.
+func TestDBStats_Sub(t *testing.T) {
+	var a, b bolt.Stats
+	a.TxStats.PageCount = 3
+	a.FreePageN = 4
+	b.TxStats.PageCount = 10
+	b.FreePageN = 14
+	diff := b.Sub(&a)
+	if diff.TxStats.PageCount != 7 {
+		t.Fatalf("unexpected TxStats.PageCount: %d", diff.TxStats.PageCount)
+	}
+
+	// free page stats are copied from the receiver and not subtracted
+	if diff.FreePageN != 14 {
+		t.Fatalf("unexpected FreePageN: %d", diff.FreePageN)
+	}
+}
+
+// Ensure two functions can perform updates in a single batch.
+func TestDB_Batch(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Iterate over multiple updates in separate goroutines.
+	n := 2
+	ch := make(chan error)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			ch <- db.Batch(func(tx *bolt.Tx) error {
+				return tx.Bucket([]byte("widgets")).Put(u64tob(uint64(i)), []byte{})
+			})
+		}(i)
+	}
+
+	// Check all responses to make sure there's no error.
+	for i := 0; i < n; i++ {
+		if err := <-ch; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Ensure data is correct.
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 0; i < n; i++ {
+			if v := b.Get(u64tob(uint64(i))); v == nil {
+				t.Errorf("key not found: %d", i)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDB_Batch_Panic(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var sentinel int
+	var bork = &sentinel
+	var problem interface{}
+	var err error
+
+	// Execute a function inside a batch that panics.
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				problem = p
+			}
+		}()
+		err = db.Batch(func(tx *bolt.Tx) error {
+			panic(bork)
+		})
+	}()
+
+	// Verify there is no error.
+	if g, e := err, error(nil); g != e {
+		t.Fatalf("wrong error: %v != %v", g, e)
+	}
+	// Verify the panic was captured.
+	if g, e := problem, bork; g != e {
+		t.Fatalf("wrong error: %v != %v", g, e)
+	}
+}
+
+func TestDB_BatchFull(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const size = 3
+	// buffered so we never leak goroutines
+	ch := make(chan error, size)
+	put := func(i int) {
+		ch <- db.Batch(func(tx *bolt.Tx) error {
+			return tx.Bucket([]byte("widgets")).Put(u64tob(uint64(i)), []byte{})
+		})
+	}
+
+	db.MaxBatchSize = size
+	// high enough to never trigger here
+	db.MaxBatchDelay = 1 * time.Hour
+
+	go put(1)
+	go put(2)
+
+	// Give the batch a chance to exhibit bugs.
+	time.Sleep(10 * time.Millisecond)
+
+	// not triggered yet
+	select {
+	case <-ch:
+		t.Fatalf("batch triggered too early")
+	default:
+	}
+
+	go put(3)
+
+	// Check all responses to make sure there's no error.
+	for i := 0; i < size; i++ {
+		if err := <-ch; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Ensure data is correct.
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 1; i <= size; i++ {
+			if v := b.Get(u64tob(uint64(i))); v == nil {
+				t.Errorf("key not found: %d", i)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDB_BatchTime(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const size = 1
+	// buffered so we never leak goroutines
+	ch := make(chan error, size)
+	put := func(i int) {
+		ch <- db.Batch(func(tx *bolt.Tx) error {
+			return tx.Bucket([]byte("widgets")).Put(u64tob(uint64(i)), []byte{})
+		})
+	}
+
+	db.MaxBatchSize = 1000
+	db.MaxBatchDelay = 0
+
+	go put(1)
+
+	// Batch must trigger by time alone.
+
+	// Check all responses to make sure there's no error.
+	for i := 0; i < size; i++ {
+		if err := <-ch; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Ensure data is correct.
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("widgets"))
+		for i := 1; i <= size; i++ {
+			if v := b.Get(u64tob(uint64(i))); v == nil {
+				t.Errorf("key not found: %d", i)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ExampleDB_Update() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Execute several commands within a read-write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			return err
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Read the value back from a separate read-only transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		fmt.Printf("The value of 'foo' is: %s\n", value)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release the file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// The value of 'foo' is: bar
+}
+
+func ExampleDB_View() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Insert data into a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("people"))
+		if err != nil {
+			return err
+		}
+		if err := b.Put([]byte("john"), []byte("doe")); err != nil {
+			return err
+		}
+		if err := b.Put([]byte("susy"), []byte("que")); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Access data from within a read-only transactional block.
+	if err := db.View(func(tx *bolt.Tx) error {
+		v := tx.Bucket([]byte("people")).Get([]byte("john"))
+		fmt.Printf("John's last name is %s.\n", v)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release the file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// John's last name is doe.
+}
+
+func ExampleDB_Begin_ReadOnly() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Create a bucket using a read-write transaction.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create several keys in a transaction.
+	tx, err := db.Begin(true)
+	if err != nil {
+		log.Fatal(err)
+	}
+	b := tx.Bucket([]byte("widgets"))
+	if err := b.Put([]byte("john"), []byte("blue")); err != nil {
+		log.Fatal(err)
+	}
+	if err := b.Put([]byte("abby"), []byte("red")); err != nil {
+		log.Fatal(err)
+	}
+	if err := b.Put([]byte("zephyr"), []byte("purple")); err != nil {
+		log.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Iterate over the values in sorted key order.
+	tx, err = db.Begin(false)
+	if err != nil {
+		log.Fatal(err)
+	}
+	c := tx.Bucket([]byte("widgets")).Cursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		fmt.Printf("%s likes %s\n", k, v)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// abby likes red
+	// john likes blue
+	// zephyr likes purple
+}
+
+func BenchmarkDBBatchAutomatic(b *testing.B) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("bench"))
+		return err
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+
+		for round := 0; round < 1000; round++ {
+			wg.Add(1)
+
+			go func(id uint32) {
+				defer wg.Done()
+				<-start
+
+				h := fnv.New32a()
+				buf := make([]byte, 4)
+				binary.LittleEndian.PutUint32(buf, id)
+				_, _ = h.Write(buf[:])
+				k := h.Sum(nil)
+				insert := func(tx *bolt.Tx) error {
+					b := tx.Bucket([]byte("bench"))
+					return b.Put(k, []byte("filler"))
+				}
+				if err := db.Batch(insert); err != nil {
+					b.Error(err)
+					return
+				}
+			}(uint32(round))
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	b.StopTimer()
+	validateBatchBench(b, db)
+}
+
+func BenchmarkDBBatchSingle(b *testing.B) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("bench"))
+		return err
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+
+		for round := 0; round < 1000; round++ {
+			wg.Add(1)
+			go func(id uint32) {
+				defer wg.Done()
+				<-start
+
+				h := fnv.New32a()
+				buf := make([]byte, 4)
+				binary.LittleEndian.PutUint32(buf, id)
+				_, _ = h.Write(buf[:])
+				k := h.Sum(nil)
+				insert := func(tx *bolt.Tx) error {
+					b := tx.Bucket([]byte("bench"))
+					return b.Put(k, []byte("filler"))
+				}
+				if err := db.Update(insert); err != nil {
+					b.Error(err)
+					return
+				}
+			}(uint32(round))
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	b.StopTimer()
+	validateBatchBench(b, db)
+}
+
+func BenchmarkDBBatchManual10x100(b *testing.B) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("bench"))
+		return err
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+
+		for major := 0; major < 10; major++ {
+			wg.Add(1)
+			go func(id uint32) {
+				defer wg.Done()
+				<-start
+
+				insert100 := func(tx *bolt.Tx) error {
+					h := fnv.New32a()
+					buf := make([]byte, 4)
+					for minor := uint32(0); minor < 100; minor++ {
+						binary.LittleEndian.PutUint32(buf, uint32(id*100+minor))
+						h.Reset()
+						_, _ = h.Write(buf[:])
+						k := h.Sum(nil)
+						b := tx.Bucket([]byte("bench"))
+						if err := b.Put(k, []byte("filler")); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+				if err := db.Update(insert100); err != nil {
+					b.Fatal(err)
+				}
+			}(uint32(major))
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	b.StopTimer()
+	validateBatchBench(b, db)
+}
+
+func validateBatchBench(b *testing.B, db *DB) {
+	var rollback = errors.New("sentinel error to cause rollback")
+	validate := func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte("bench"))
+		h := fnv.New32a()
+		buf := make([]byte, 4)
+		for id := uint32(0); id < 1000; id++ {
+			binary.LittleEndian.PutUint32(buf, id)
+			h.Reset()
+			_, _ = h.Write(buf[:])
+			k := h.Sum(nil)
+			v := bucket.Get(k)
+			if v == nil {
+				b.Errorf("not found id=%d key=%x", id, k)
+				continue
+			}
+			if g, e := v, []byte("filler"); !bytes.Equal(g, e) {
+				b.Errorf("bad value for id=%d key=%x: %s != %q", id, k, g, e)
+			}
+			if err := bucket.Delete(k); err != nil {
+				return err
+			}
+		}
+		// should be empty now
+		c := bucket.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			b.Errorf("unexpected key: %x = %q", k, v)
+		}
+		return rollback
+	}
+	if err := db.Update(validate); err != nil && err != rollback {
+		b.Error(err)
+	}
+}
+
+// DB is a test wrapper for bolt.DB.
+type DB struct {
+	*bolt.DB
+	f string
+	o *bolt.Options
+}
+
+// MustOpenDB returns a new, open DB at a temporary location.
+func MustOpenDB() *DB {
+	f := tempfile()
+	db, err := bolt.Open(f, 0666, nil)
+	if err != nil {
+		panic(err)
+	}
+	return &DB{
+		DB: db,
+		f:  f,
+	}
+}
+
+// MustOpenDBWithOption returns a new, open DB at a temporary location with given options.
+func MustOpenWithOption(o *bolt.Options) *DB {
+	f := tempfile()
+	db, err := bolt.Open(f, 0666, o)
+	if err != nil {
+		panic(err)
+	}
+	return &DB{
+		DB: db,
+		f:  f,
+		o:  o,
+	}
+}
+
+// Close closes the database and deletes the underlying file.
+func (db *DB) Close() error {
+	// Log statistics.
+	if *statsFlag {
+		db.PrintStats()
+	}
+
+	// Check database consistency after every test.
+	db.MustCheck()
+
+	// Close database and remove file.
+	defer os.Remove(db.Path())
+	return db.DB.Close()
+}
+
+// MustClose closes the database and deletes the underlying file. Panic on error.
+func (db *DB) MustClose() {
+	if err := db.Close(); err != nil {
+		panic(err)
+	}
+}
+
+// MustReopen reopen the database. Panic on error.
+func (db *DB) MustReopen() {
+	indb, err := bolt.Open(db.f, 0666, db.o)
+	if err != nil {
+		panic(err)
+	}
+	db.DB = indb
+}
+
+// PrintStats prints the database stats
+func (db *DB) PrintStats() {
+	var stats = db.Stats()
+	fmt.Printf("[db] %-20s %-20s %-20s\n",
+		fmt.Sprintf("pg(%d/%d)", stats.TxStats.PageCount, stats.TxStats.PageAlloc),
+		fmt.Sprintf("cur(%d)", stats.TxStats.CursorCount),
+		fmt.Sprintf("node(%d/%d)", stats.TxStats.NodeCount, stats.TxStats.NodeDeref),
+	)
+	fmt.Printf("     %-20s %-20s %-20s\n",
+		fmt.Sprintf("rebal(%d/%v)", stats.TxStats.Rebalance, truncDuration(stats.TxStats.RebalanceTime)),
+		fmt.Sprintf("spill(%d/%v)", stats.TxStats.Spill, truncDuration(stats.TxStats.SpillTime)),
+		fmt.Sprintf("w(%d/%v)", stats.TxStats.Write, truncDuration(stats.TxStats.WriteTime)),
+	)
+}
+
+// MustCheck runs a consistency check on the database and panics if any errors are found.
+func (db *DB) MustCheck() {
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Collect all the errors.
+		var errors []error
+		for err := range tx.Check() {
+			errors = append(errors, err)
+			if len(errors) > 10 {
+				break
+			}
+		}
+
+		// If errors occurred, copy the DB and print the errors.
+		if len(errors) > 0 {
+			var path = tempfile()
+			if err := tx.CopyFile(path, 0600); err != nil {
+				panic(err)
+			}
+
+			// Print errors.
+			fmt.Print("\n\n")
+			fmt.Printf("consistency check failed (%d errors)\n", len(errors))
+			for _, err := range errors {
+				fmt.Println(err)
+			}
+			fmt.Println("")
+			fmt.Println("db saved to:")
+			fmt.Println(path)
+			fmt.Print("\n\n")
+			os.Exit(-1)
+		}
+
+		return nil
+	}); err != nil && err != bolt.ErrDatabaseNotOpen {
+		panic(err)
+	}
+}
+
+// CopyTempFile copies a database to a temporary file.
+func (db *DB) CopyTempFile() {
+	path := tempfile()
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.CopyFile(path, 0600)
+	}); err != nil {
+		panic(err)
+	}
+	fmt.Println("db copied to: ", path)
+}
+
+// tempfile returns a temporary file path.
+func tempfile() string {
+	f, err := ioutil.TempFile("", "bolt-")
+	if err != nil {
+		panic(err)
+	}
+	if err := f.Close(); err != nil {
+		panic(err)
+	}
+	if err := os.Remove(f.Name()); err != nil {
+		panic(err)
+	}
+	return f.Name()
+}
+
+func trunc(b []byte, length int) []byte {
+	if length < len(b) {
+		return b[:length]
+	}
+	return b
+}
+
+func truncDuration(d time.Duration) string {
+	return regexp.MustCompile(`^(\d+)(\.\d+)`).ReplaceAllString(d.String(), "$1")
+}
+
+func fileSize(path string) int64 {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+// u64tob converts a uint64 into an 8-byte slice.
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}

--- a/vendor/github.com/coreos/bbolt/doc.go
+++ b/vendor/github.com/coreos/bbolt/doc.go
@@ -1,0 +1,44 @@
+/*
+Package bolt implements a low-level key/value store in pure Go. It supports
+fully serializable transactions, ACID semantics, and lock-free MVCC with
+multiple readers and a single writer. Bolt can be used for projects that
+want a simple data store without the need to add large dependencies such as
+Postgres or MySQL.
+
+Bolt is a single-level, zero-copy, B+tree data store. This means that Bolt is
+optimized for fast read access and does not require recovery in the event of a
+system crash. Transactions which have not finished committing will simply be
+rolled back in the event of a crash.
+
+The design of Bolt is based on Howard Chu's LMDB database project.
+
+Bolt currently works on Windows, Mac OS X, and Linux.
+
+
+Basics
+
+There are only a few types in Bolt: DB, Bucket, Tx, and Cursor. The DB is
+a collection of buckets and is represented by a single file on disk. A bucket is
+a collection of unique keys that are associated with values.
+
+Transactions provide either read-only or read-write access to the database.
+Read-only transactions can retrieve key/value pairs and can use Cursors to
+iterate over the dataset sequentially. Read-write transactions can create and
+delete buckets and can insert and remove keys. Only one read-write transaction
+is allowed at a time.
+
+
+Caveats
+
+The database uses a read-only, memory-mapped data file to ensure that
+applications cannot corrupt the database, however, this means that keys and
+values returned from Bolt cannot be changed. Writing to a read-only byte slice
+will cause Go to panic.
+
+Keys and values retrieved from the database are only valid for the life of
+the transaction. When used outside the transaction, these byte slices can
+point to different data or can point to invalid memory which will cause a panic.
+
+
+*/
+package bolt

--- a/vendor/github.com/coreos/bbolt/errors.go
+++ b/vendor/github.com/coreos/bbolt/errors.go
@@ -1,0 +1,71 @@
+package bolt
+
+import "errors"
+
+// These errors can be returned when opening or calling methods on a DB.
+var (
+	// ErrDatabaseNotOpen is returned when a DB instance is accessed before it
+	// is opened or after it is closed.
+	ErrDatabaseNotOpen = errors.New("database not open")
+
+	// ErrDatabaseOpen is returned when opening a database that is
+	// already open.
+	ErrDatabaseOpen = errors.New("database already open")
+
+	// ErrInvalid is returned when both meta pages on a database are invalid.
+	// This typically occurs when a file is not a bolt database.
+	ErrInvalid = errors.New("invalid database")
+
+	// ErrVersionMismatch is returned when the data file was created with a
+	// different version of Bolt.
+	ErrVersionMismatch = errors.New("version mismatch")
+
+	// ErrChecksum is returned when either meta page checksum does not match.
+	ErrChecksum = errors.New("checksum error")
+
+	// ErrTimeout is returned when a database cannot obtain an exclusive lock
+	// on the data file after the timeout passed to Open().
+	ErrTimeout = errors.New("timeout")
+)
+
+// These errors can occur when beginning or committing a Tx.
+var (
+	// ErrTxNotWritable is returned when performing a write operation on a
+	// read-only transaction.
+	ErrTxNotWritable = errors.New("tx not writable")
+
+	// ErrTxClosed is returned when committing or rolling back a transaction
+	// that has already been committed or rolled back.
+	ErrTxClosed = errors.New("tx closed")
+
+	// ErrDatabaseReadOnly is returned when a mutating transaction is started on a
+	// read-only database.
+	ErrDatabaseReadOnly = errors.New("database is in read-only mode")
+)
+
+// These errors can occur when putting or deleting a value or a bucket.
+var (
+	// ErrBucketNotFound is returned when trying to access a bucket that has
+	// not been created yet.
+	ErrBucketNotFound = errors.New("bucket not found")
+
+	// ErrBucketExists is returned when creating a bucket that already exists.
+	ErrBucketExists = errors.New("bucket already exists")
+
+	// ErrBucketNameRequired is returned when creating a bucket with a blank name.
+	ErrBucketNameRequired = errors.New("bucket name required")
+
+	// ErrKeyRequired is returned when inserting a zero-length key.
+	ErrKeyRequired = errors.New("key required")
+
+	// ErrKeyTooLarge is returned when inserting a key that is larger than MaxKeySize.
+	ErrKeyTooLarge = errors.New("key too large")
+
+	// ErrValueTooLarge is returned when inserting a value that is larger than MaxValueSize.
+	ErrValueTooLarge = errors.New("value too large")
+
+	// ErrIncompatibleValue is returned when trying create or delete a bucket
+	// on an existing non-bucket key or when trying to create or delete a
+	// non-bucket key on an existing bucket key.
+	ErrIncompatibleValue = errors.New("incompatible value")
+)

--- a/vendor/github.com/coreos/bbolt/freelist.go
+++ b/vendor/github.com/coreos/bbolt/freelist.go
@@ -1,0 +1,330 @@
+package bolt
+
+import (
+	"fmt"
+	"sort"
+	"unsafe"
+)
+
+// txPending holds a list of pgids and corresponding allocation txns
+// that are pending to be freed.
+type txPending struct {
+	ids              []pgid
+	alloctx          []txid // txids allocating the ids
+	lastReleaseBegin txid   // beginning txid of last matching releaseRange
+}
+
+// freelist represents a list of all pages that are available for allocation.
+// It also tracks pages that have been freed but are still in use by open transactions.
+type freelist struct {
+	ids     []pgid              // all free and available free page ids.
+	allocs  map[pgid]txid       // mapping of txid that allocated a pgid.
+	pending map[txid]*txPending // mapping of soon-to-be free page ids by tx.
+	cache   map[pgid]bool       // fast lookup of all free and pending page ids.
+}
+
+// newFreelist returns an empty, initialized freelist.
+func newFreelist() *freelist {
+	return &freelist{
+		allocs:  make(map[pgid]txid),
+		pending: make(map[txid]*txPending),
+		cache:   make(map[pgid]bool),
+	}
+}
+
+// size returns the size of the page after serialization.
+func (f *freelist) size() int {
+	n := f.count()
+	if n >= 0xFFFF {
+		// The first element will be used to store the count. See freelist.write.
+		n++
+	}
+	return pageHeaderSize + (int(unsafe.Sizeof(pgid(0))) * n)
+}
+
+// count returns count of pages on the freelist
+func (f *freelist) count() int {
+	return f.free_count() + f.pending_count()
+}
+
+// free_count returns count of free pages
+func (f *freelist) free_count() int {
+	return len(f.ids)
+}
+
+// pending_count returns count of pending pages
+func (f *freelist) pending_count() int {
+	var count int
+	for _, txp := range f.pending {
+		count += len(txp.ids)
+	}
+	return count
+}
+
+// copyall copies into dst a list of all free ids and all pending ids in one sorted list.
+// f.count returns the minimum length required for dst.
+func (f *freelist) copyall(dst []pgid) {
+	m := make(pgids, 0, f.pending_count())
+	for _, txp := range f.pending {
+		m = append(m, txp.ids...)
+	}
+	sort.Sort(m)
+	mergepgids(dst, f.ids, m)
+}
+
+// allocate returns the starting page id of a contiguous list of pages of a given size.
+// If a contiguous block cannot be found then 0 is returned.
+func (f *freelist) allocate(txid txid, n int) pgid {
+	if len(f.ids) == 0 {
+		return 0
+	}
+
+	var initial, previd pgid
+	for i, id := range f.ids {
+		if id <= 1 {
+			panic(fmt.Sprintf("invalid page allocation: %d", id))
+		}
+
+		// Reset initial page if this is not contiguous.
+		if previd == 0 || id-previd != 1 {
+			initial = id
+		}
+
+		// If we found a contiguous block then remove it and return it.
+		if (id-initial)+1 == pgid(n) {
+			// If we're allocating off the beginning then take the fast path
+			// and just adjust the existing slice. This will use extra memory
+			// temporarily but the append() in free() will realloc the slice
+			// as is necessary.
+			if (i + 1) == n {
+				f.ids = f.ids[i+1:]
+			} else {
+				copy(f.ids[i-n+1:], f.ids[i+1:])
+				f.ids = f.ids[:len(f.ids)-n]
+			}
+
+			// Remove from the free cache.
+			for i := pgid(0); i < pgid(n); i++ {
+				delete(f.cache, initial+i)
+			}
+			f.allocs[initial] = txid
+			return initial
+		}
+
+		previd = id
+	}
+	return 0
+}
+
+// free releases a page and its overflow for a given transaction id.
+// If the page is already free then a panic will occur.
+func (f *freelist) free(txid txid, p *page) {
+	if p.id <= 1 {
+		panic(fmt.Sprintf("cannot free page 0 or 1: %d", p.id))
+	}
+
+	// Free page and all its overflow pages.
+	txp := f.pending[txid]
+	if txp == nil {
+		txp = &txPending{}
+		f.pending[txid] = txp
+	}
+	allocTxid, ok := f.allocs[p.id]
+	if ok {
+		delete(f.allocs, p.id)
+	} else if (p.flags & (freelistPageFlag | metaPageFlag)) != 0 {
+		// Safe to claim txid as allocating since these types are private to txid.
+		allocTxid = txid
+	}
+
+	for id := p.id; id <= p.id+pgid(p.overflow); id++ {
+		// Verify that page is not already free.
+		if f.cache[id] {
+			panic(fmt.Sprintf("page %d already freed", id))
+		}
+		// Add to the freelist and cache.
+		txp.ids = append(txp.ids, id)
+		txp.alloctx = append(txp.alloctx, allocTxid)
+		f.cache[id] = true
+	}
+}
+
+// release moves all page ids for a transaction id (or older) to the freelist.
+func (f *freelist) release(txid txid) {
+	m := make(pgids, 0)
+	for tid, txp := range f.pending {
+		if tid <= txid {
+			// Move transaction's pending pages to the available freelist.
+			// Don't remove from the cache since the page is still free.
+			m = append(m, txp.ids...)
+			delete(f.pending, tid)
+		}
+	}
+	sort.Sort(m)
+	f.ids = pgids(f.ids).merge(m)
+}
+
+// releaseRange moves pending pages allocated within an extent [begin,end] to the free list.
+func (f *freelist) releaseRange(begin, end txid) {
+	if begin > end {
+		return
+	}
+	var m pgids
+	for tid, txp := range f.pending {
+		if tid < begin || tid > end {
+			continue
+		}
+		// Don't recompute freed pages if ranges haven't updated.
+		if txp.lastReleaseBegin == begin {
+			continue
+		}
+		for i := 0; i < len(txp.ids); i++ {
+			if atx := txp.alloctx[i]; atx < begin || atx > end {
+				continue
+			}
+			m = append(m, txp.ids[i])
+			txp.ids[i] = txp.ids[len(txp.ids)-1]
+			txp.ids = txp.ids[:len(txp.ids)-1]
+			txp.alloctx[i] = txp.alloctx[len(txp.alloctx)-1]
+			txp.alloctx = txp.alloctx[:len(txp.alloctx)-1]
+			i--
+		}
+		txp.lastReleaseBegin = begin
+		if len(txp.ids) == 0 {
+			delete(f.pending, tid)
+		}
+	}
+	sort.Sort(m)
+	f.ids = pgids(f.ids).merge(m)
+}
+
+// rollback removes the pages from a given pending tx.
+func (f *freelist) rollback(txid txid) {
+	// Remove page ids from cache.
+	txp := f.pending[txid]
+	if txp == nil {
+		return
+	}
+	var m pgids
+	for i, pgid := range txp.ids {
+		delete(f.cache, pgid)
+		tx := txp.alloctx[i]
+		if tx == 0 {
+			continue
+		}
+		if tx != txid {
+			// Pending free aborted; restore page back to alloc list.
+			f.allocs[pgid] = tx
+		} else {
+			// Freed page was allocated by this txn; OK to throw away.
+			m = append(m, pgid)
+		}
+	}
+	// Remove pages from pending list and mark as free if allocated by txid.
+	delete(f.pending, txid)
+	sort.Sort(m)
+	f.ids = pgids(f.ids).merge(m)
+}
+
+// freed returns whether a given page is in the free list.
+func (f *freelist) freed(pgid pgid) bool {
+	return f.cache[pgid]
+}
+
+// read initializes the freelist from a freelist page.
+func (f *freelist) read(p *page) {
+	// If the page.count is at the max uint16 value (64k) then it's considered
+	// an overflow and the size of the freelist is stored as the first element.
+	idx, count := 0, int(p.count)
+	if count == 0xFFFF {
+		idx = 1
+		count = int(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0])
+	}
+
+	// Copy the list of page ids from the freelist.
+	if count == 0 {
+		f.ids = nil
+	} else {
+		ids := ((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[idx : idx+count]
+		f.ids = make([]pgid, len(ids))
+		copy(f.ids, ids)
+
+		// Make sure they're sorted.
+		sort.Sort(pgids(f.ids))
+	}
+
+	// Rebuild the page cache.
+	f.reindex()
+}
+
+// read initializes the freelist from a given list of ids.
+func (f *freelist) readIDs(ids []pgid) {
+	f.ids = ids
+	f.reindex()
+}
+
+// write writes the page ids onto a freelist page. All free and pending ids are
+// saved to disk since in the event of a program crash, all pending ids will
+// become free.
+func (f *freelist) write(p *page) error {
+	// Combine the old free pgids and pgids waiting on an open transaction.
+
+	// Update the header flag.
+	p.flags |= freelistPageFlag
+
+	// The page.count can only hold up to 64k elements so if we overflow that
+	// number then we handle it by putting the size in the first element.
+	lenids := f.count()
+	if lenids == 0 {
+		p.count = uint16(lenids)
+	} else if lenids < 0xFFFF {
+		p.count = uint16(lenids)
+		f.copyall(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[:])
+	} else {
+		p.count = 0xFFFF
+		((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0] = pgid(lenids)
+		f.copyall(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[1:])
+	}
+
+	return nil
+}
+
+// reload reads the freelist from a page and filters out pending items.
+func (f *freelist) reload(p *page) {
+	f.read(p)
+
+	// Build a cache of only pending pages.
+	pcache := make(map[pgid]bool)
+	for _, txp := range f.pending {
+		for _, pendingID := range txp.ids {
+			pcache[pendingID] = true
+		}
+	}
+
+	// Check each page in the freelist and build a new available freelist
+	// with any pages not in the pending lists.
+	var a []pgid
+	for _, id := range f.ids {
+		if !pcache[id] {
+			a = append(a, id)
+		}
+	}
+	f.ids = a
+
+	// Once the available list is rebuilt then rebuild the free cache so that
+	// it includes the available and pending free pages.
+	f.reindex()
+}
+
+// reindex rebuilds the free cache based on available and pending free lists.
+func (f *freelist) reindex() {
+	f.cache = make(map[pgid]bool, len(f.ids))
+	for _, id := range f.ids {
+		f.cache[id] = true
+	}
+	for _, txp := range f.pending {
+		for _, pendingID := range txp.ids {
+			f.cache[pendingID] = true
+		}
+	}
+}

--- a/vendor/github.com/coreos/bbolt/freelist_test.go
+++ b/vendor/github.com/coreos/bbolt/freelist_test.go
@@ -1,0 +1,160 @@
+package bolt
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+	"unsafe"
+)
+
+// Ensure that a page is added to a transaction's freelist.
+func TestFreelist_free(t *testing.T) {
+	f := newFreelist()
+	f.free(100, &page{id: 12})
+	if !reflect.DeepEqual([]pgid{12}, f.pending[100].ids) {
+		t.Fatalf("exp=%v; got=%v", []pgid{12}, f.pending[100])
+	}
+}
+
+// Ensure that a page and its overflow is added to a transaction's freelist.
+func TestFreelist_free_overflow(t *testing.T) {
+	f := newFreelist()
+	f.free(100, &page{id: 12, overflow: 3})
+	if exp := []pgid{12, 13, 14, 15}; !reflect.DeepEqual(exp, f.pending[100].ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f.pending[100])
+	}
+}
+
+// Ensure that a transaction's free pages can be released.
+func TestFreelist_release(t *testing.T) {
+	f := newFreelist()
+	f.free(100, &page{id: 12, overflow: 1})
+	f.free(100, &page{id: 9})
+	f.free(102, &page{id: 39})
+	f.release(100)
+	f.release(101)
+	if exp := []pgid{9, 12, 13}; !reflect.DeepEqual(exp, f.ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f.ids)
+	}
+
+	f.release(102)
+	if exp := []pgid{9, 12, 13, 39}; !reflect.DeepEqual(exp, f.ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f.ids)
+	}
+}
+
+// Ensure that a freelist can find contiguous blocks of pages.
+func TestFreelist_allocate(t *testing.T) {
+	f := newFreelist()
+	f.ids = []pgid{3, 4, 5, 6, 7, 9, 12, 13, 18}
+	if id := int(f.allocate(1, 3)); id != 3 {
+		t.Fatalf("exp=3; got=%v", id)
+	}
+	if id := int(f.allocate(1, 1)); id != 6 {
+		t.Fatalf("exp=6; got=%v", id)
+	}
+	if id := int(f.allocate(1, 3)); id != 0 {
+		t.Fatalf("exp=0; got=%v", id)
+	}
+	if id := int(f.allocate(1, 2)); id != 12 {
+		t.Fatalf("exp=12; got=%v", id)
+	}
+	if id := int(f.allocate(1, 1)); id != 7 {
+		t.Fatalf("exp=7; got=%v", id)
+	}
+	if id := int(f.allocate(1, 0)); id != 0 {
+		t.Fatalf("exp=0; got=%v", id)
+	}
+	if id := int(f.allocate(1, 0)); id != 0 {
+		t.Fatalf("exp=0; got=%v", id)
+	}
+	if exp := []pgid{9, 18}; !reflect.DeepEqual(exp, f.ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f.ids)
+	}
+
+	if id := int(f.allocate(1, 1)); id != 9 {
+		t.Fatalf("exp=9; got=%v", id)
+	}
+	if id := int(f.allocate(1, 1)); id != 18 {
+		t.Fatalf("exp=18; got=%v", id)
+	}
+	if id := int(f.allocate(1, 1)); id != 0 {
+		t.Fatalf("exp=0; got=%v", id)
+	}
+	if exp := []pgid{}; !reflect.DeepEqual(exp, f.ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f.ids)
+	}
+}
+
+// Ensure that a freelist can deserialize from a freelist page.
+func TestFreelist_read(t *testing.T) {
+	// Create a page.
+	var buf [4096]byte
+	page := (*page)(unsafe.Pointer(&buf[0]))
+	page.flags = freelistPageFlag
+	page.count = 2
+
+	// Insert 2 page ids.
+	ids := (*[3]pgid)(unsafe.Pointer(&page.ptr))
+	ids[0] = 23
+	ids[1] = 50
+
+	// Deserialize page into a freelist.
+	f := newFreelist()
+	f.read(page)
+
+	// Ensure that there are two page ids in the freelist.
+	if exp := []pgid{23, 50}; !reflect.DeepEqual(exp, f.ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f.ids)
+	}
+}
+
+// Ensure that a freelist can serialize into a freelist page.
+func TestFreelist_write(t *testing.T) {
+	// Create a freelist and write it to a page.
+	var buf [4096]byte
+	f := &freelist{ids: []pgid{12, 39}, pending: make(map[txid]*txPending)}
+	f.pending[100] = &txPending{ids: []pgid{28, 11}}
+	f.pending[101] = &txPending{ids: []pgid{3}}
+	p := (*page)(unsafe.Pointer(&buf[0]))
+	if err := f.write(p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the page back out.
+	f2 := newFreelist()
+	f2.read(p)
+
+	// Ensure that the freelist is correct.
+	// All pages should be present and in reverse order.
+	if exp := []pgid{3, 11, 12, 28, 39}; !reflect.DeepEqual(exp, f2.ids) {
+		t.Fatalf("exp=%v; got=%v", exp, f2.ids)
+	}
+}
+
+func Benchmark_FreelistRelease10K(b *testing.B)    { benchmark_FreelistRelease(b, 10000) }
+func Benchmark_FreelistRelease100K(b *testing.B)   { benchmark_FreelistRelease(b, 100000) }
+func Benchmark_FreelistRelease1000K(b *testing.B)  { benchmark_FreelistRelease(b, 1000000) }
+func Benchmark_FreelistRelease10000K(b *testing.B) { benchmark_FreelistRelease(b, 10000000) }
+
+func benchmark_FreelistRelease(b *testing.B, size int) {
+	ids := randomPgids(size)
+	pending := randomPgids(len(ids) / 400)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		txp := &txPending{ids: pending}
+		f := &freelist{ids: ids, pending: map[txid]*txPending{1: txp}}
+		f.release(1)
+	}
+}
+
+func randomPgids(n int) []pgid {
+	rand.Seed(42)
+	pgids := make(pgids, n)
+	for i := range pgids {
+		pgids[i] = pgid(rand.Int63())
+	}
+	sort.Sort(pgids)
+	return pgids
+}

--- a/vendor/github.com/coreos/bbolt/node.go
+++ b/vendor/github.com/coreos/bbolt/node.go
@@ -1,0 +1,604 @@
+package bolt
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"unsafe"
+)
+
+// node represents an in-memory, deserialized page.
+type node struct {
+	bucket     *Bucket
+	isLeaf     bool
+	unbalanced bool
+	spilled    bool
+	key        []byte
+	pgid       pgid
+	parent     *node
+	children   nodes
+	inodes     inodes
+}
+
+// root returns the top-level node this node is attached to.
+func (n *node) root() *node {
+	if n.parent == nil {
+		return n
+	}
+	return n.parent.root()
+}
+
+// minKeys returns the minimum number of inodes this node should have.
+func (n *node) minKeys() int {
+	if n.isLeaf {
+		return 1
+	}
+	return 2
+}
+
+// size returns the size of the node after serialization.
+func (n *node) size() int {
+	sz, elsz := pageHeaderSize, n.pageElementSize()
+	for i := 0; i < len(n.inodes); i++ {
+		item := &n.inodes[i]
+		sz += elsz + len(item.key) + len(item.value)
+	}
+	return sz
+}
+
+// sizeLessThan returns true if the node is less than a given size.
+// This is an optimization to avoid calculating a large node when we only need
+// to know if it fits inside a certain page size.
+func (n *node) sizeLessThan(v int) bool {
+	sz, elsz := pageHeaderSize, n.pageElementSize()
+	for i := 0; i < len(n.inodes); i++ {
+		item := &n.inodes[i]
+		sz += elsz + len(item.key) + len(item.value)
+		if sz >= v {
+			return false
+		}
+	}
+	return true
+}
+
+// pageElementSize returns the size of each page element based on the type of node.
+func (n *node) pageElementSize() int {
+	if n.isLeaf {
+		return leafPageElementSize
+	}
+	return branchPageElementSize
+}
+
+// childAt returns the child node at a given index.
+func (n *node) childAt(index int) *node {
+	if n.isLeaf {
+		panic(fmt.Sprintf("invalid childAt(%d) on a leaf node", index))
+	}
+	return n.bucket.node(n.inodes[index].pgid, n)
+}
+
+// childIndex returns the index of a given child node.
+func (n *node) childIndex(child *node) int {
+	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, child.key) != -1 })
+	return index
+}
+
+// numChildren returns the number of children.
+func (n *node) numChildren() int {
+	return len(n.inodes)
+}
+
+// nextSibling returns the next node with the same parent.
+func (n *node) nextSibling() *node {
+	if n.parent == nil {
+		return nil
+	}
+	index := n.parent.childIndex(n)
+	if index >= n.parent.numChildren()-1 {
+		return nil
+	}
+	return n.parent.childAt(index + 1)
+}
+
+// prevSibling returns the previous node with the same parent.
+func (n *node) prevSibling() *node {
+	if n.parent == nil {
+		return nil
+	}
+	index := n.parent.childIndex(n)
+	if index == 0 {
+		return nil
+	}
+	return n.parent.childAt(index - 1)
+}
+
+// put inserts a key/value.
+func (n *node) put(oldKey, newKey, value []byte, pgid pgid, flags uint32) {
+	if pgid >= n.bucket.tx.meta.pgid {
+		panic(fmt.Sprintf("pgid (%d) above high water mark (%d)", pgid, n.bucket.tx.meta.pgid))
+	} else if len(oldKey) <= 0 {
+		panic("put: zero-length old key")
+	} else if len(newKey) <= 0 {
+		panic("put: zero-length new key")
+	}
+
+	// Find insertion index.
+	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, oldKey) != -1 })
+
+	// Add capacity and shift nodes if we don't have an exact match and need to insert.
+	exact := (len(n.inodes) > 0 && index < len(n.inodes) && bytes.Equal(n.inodes[index].key, oldKey))
+	if !exact {
+		n.inodes = append(n.inodes, inode{})
+		copy(n.inodes[index+1:], n.inodes[index:])
+	}
+
+	inode := &n.inodes[index]
+	inode.flags = flags
+	inode.key = newKey
+	inode.value = value
+	inode.pgid = pgid
+	_assert(len(inode.key) > 0, "put: zero-length inode key")
+}
+
+// del removes a key from the node.
+func (n *node) del(key []byte) {
+	// Find index of key.
+	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, key) != -1 })
+
+	// Exit if the key isn't found.
+	if index >= len(n.inodes) || !bytes.Equal(n.inodes[index].key, key) {
+		return
+	}
+
+	// Delete inode from the node.
+	n.inodes = append(n.inodes[:index], n.inodes[index+1:]...)
+
+	// Mark the node as needing rebalancing.
+	n.unbalanced = true
+}
+
+// read initializes the node from a page.
+func (n *node) read(p *page) {
+	n.pgid = p.id
+	n.isLeaf = ((p.flags & leafPageFlag) != 0)
+	n.inodes = make(inodes, int(p.count))
+
+	for i := 0; i < int(p.count); i++ {
+		inode := &n.inodes[i]
+		if n.isLeaf {
+			elem := p.leafPageElement(uint16(i))
+			inode.flags = elem.flags
+			inode.key = elem.key()
+			inode.value = elem.value()
+		} else {
+			elem := p.branchPageElement(uint16(i))
+			inode.pgid = elem.pgid
+			inode.key = elem.key()
+		}
+		_assert(len(inode.key) > 0, "read: zero-length inode key")
+	}
+
+	// Save first key so we can find the node in the parent when we spill.
+	if len(n.inodes) > 0 {
+		n.key = n.inodes[0].key
+		_assert(len(n.key) > 0, "read: zero-length node key")
+	} else {
+		n.key = nil
+	}
+}
+
+// write writes the items onto one or more pages.
+func (n *node) write(p *page) {
+	// Initialize page.
+	if n.isLeaf {
+		p.flags |= leafPageFlag
+	} else {
+		p.flags |= branchPageFlag
+	}
+
+	if len(n.inodes) >= 0xFFFF {
+		panic(fmt.Sprintf("inode overflow: %d (pgid=%d)", len(n.inodes), p.id))
+	}
+	p.count = uint16(len(n.inodes))
+
+	// Stop here if there are no items to write.
+	if p.count == 0 {
+		return
+	}
+
+	// Loop over each item and write it to the page.
+	b := (*[maxAllocSize]byte)(unsafe.Pointer(&p.ptr))[n.pageElementSize()*len(n.inodes):]
+	for i, item := range n.inodes {
+		_assert(len(item.key) > 0, "write: zero-length inode key")
+
+		// Write the page element.
+		if n.isLeaf {
+			elem := p.leafPageElement(uint16(i))
+			elem.pos = uint32(uintptr(unsafe.Pointer(&b[0])) - uintptr(unsafe.Pointer(elem)))
+			elem.flags = item.flags
+			elem.ksize = uint32(len(item.key))
+			elem.vsize = uint32(len(item.value))
+		} else {
+			elem := p.branchPageElement(uint16(i))
+			elem.pos = uint32(uintptr(unsafe.Pointer(&b[0])) - uintptr(unsafe.Pointer(elem)))
+			elem.ksize = uint32(len(item.key))
+			elem.pgid = item.pgid
+			_assert(elem.pgid != p.id, "write: circular dependency occurred")
+		}
+
+		// If the length of key+value is larger than the max allocation size
+		// then we need to reallocate the byte array pointer.
+		//
+		// See: https://github.com/boltdb/bolt/pull/335
+		klen, vlen := len(item.key), len(item.value)
+		if len(b) < klen+vlen {
+			b = (*[maxAllocSize]byte)(unsafe.Pointer(&b[0]))[:]
+		}
+
+		// Write data for the element to the end of the page.
+		copy(b[0:], item.key)
+		b = b[klen:]
+		copy(b[0:], item.value)
+		b = b[vlen:]
+	}
+
+	// DEBUG ONLY: n.dump()
+}
+
+// split breaks up a node into multiple smaller nodes, if appropriate.
+// This should only be called from the spill() function.
+func (n *node) split(pageSize int) []*node {
+	var nodes []*node
+
+	node := n
+	for {
+		// Split node into two.
+		a, b := node.splitTwo(pageSize)
+		nodes = append(nodes, a)
+
+		// If we can't split then exit the loop.
+		if b == nil {
+			break
+		}
+
+		// Set node to b so it gets split on the next iteration.
+		node = b
+	}
+
+	return nodes
+}
+
+// splitTwo breaks up a node into two smaller nodes, if appropriate.
+// This should only be called from the split() function.
+func (n *node) splitTwo(pageSize int) (*node, *node) {
+	// Ignore the split if the page doesn't have at least enough nodes for
+	// two pages or if the nodes can fit in a single page.
+	if len(n.inodes) <= (minKeysPerPage*2) || n.sizeLessThan(pageSize) {
+		return n, nil
+	}
+
+	// Determine the threshold before starting a new node.
+	var fillPercent = n.bucket.FillPercent
+	if fillPercent < minFillPercent {
+		fillPercent = minFillPercent
+	} else if fillPercent > maxFillPercent {
+		fillPercent = maxFillPercent
+	}
+	threshold := int(float64(pageSize) * fillPercent)
+
+	// Determine split position and sizes of the two pages.
+	splitIndex, _ := n.splitIndex(threshold)
+
+	// Split node into two separate nodes.
+	// If there's no parent then we'll need to create one.
+	if n.parent == nil {
+		n.parent = &node{bucket: n.bucket, children: []*node{n}}
+	}
+
+	// Create a new node and add it to the parent.
+	next := &node{bucket: n.bucket, isLeaf: n.isLeaf, parent: n.parent}
+	n.parent.children = append(n.parent.children, next)
+
+	// Split inodes across two nodes.
+	next.inodes = n.inodes[splitIndex:]
+	n.inodes = n.inodes[:splitIndex]
+
+	// Update the statistics.
+	n.bucket.tx.stats.Split++
+
+	return n, next
+}
+
+// splitIndex finds the position where a page will fill a given threshold.
+// It returns the index as well as the size of the first page.
+// This is only be called from split().
+func (n *node) splitIndex(threshold int) (index, sz int) {
+	sz = pageHeaderSize
+
+	// Loop until we only have the minimum number of keys required for the second page.
+	for i := 0; i < len(n.inodes)-minKeysPerPage; i++ {
+		index = i
+		inode := n.inodes[i]
+		elsize := n.pageElementSize() + len(inode.key) + len(inode.value)
+
+		// If we have at least the minimum number of keys and adding another
+		// node would put us over the threshold then exit and return.
+		if i >= minKeysPerPage && sz+elsize > threshold {
+			break
+		}
+
+		// Add the element size to the total size.
+		sz += elsize
+	}
+
+	return
+}
+
+// spill writes the nodes to dirty pages and splits nodes as it goes.
+// Returns an error if dirty pages cannot be allocated.
+func (n *node) spill() error {
+	var tx = n.bucket.tx
+	if n.spilled {
+		return nil
+	}
+
+	// Spill child nodes first. Child nodes can materialize sibling nodes in
+	// the case of split-merge so we cannot use a range loop. We have to check
+	// the children size on every loop iteration.
+	sort.Sort(n.children)
+	for i := 0; i < len(n.children); i++ {
+		if err := n.children[i].spill(); err != nil {
+			return err
+		}
+	}
+
+	// We no longer need the child list because it's only used for spill tracking.
+	n.children = nil
+
+	// Split nodes into appropriate sizes. The first node will always be n.
+	var nodes = n.split(tx.db.pageSize)
+	for _, node := range nodes {
+		// Add node's page to the freelist if it's not new.
+		if node.pgid > 0 {
+			tx.db.freelist.free(tx.meta.txid, tx.page(node.pgid))
+			node.pgid = 0
+		}
+
+		// Allocate contiguous space for the node.
+		p, err := tx.allocate((node.size() + tx.db.pageSize - 1) / tx.db.pageSize)
+		if err != nil {
+			return err
+		}
+
+		// Write the node.
+		if p.id >= tx.meta.pgid {
+			panic(fmt.Sprintf("pgid (%d) above high water mark (%d)", p.id, tx.meta.pgid))
+		}
+		node.pgid = p.id
+		node.write(p)
+		node.spilled = true
+
+		// Insert into parent inodes.
+		if node.parent != nil {
+			var key = node.key
+			if key == nil {
+				key = node.inodes[0].key
+			}
+
+			node.parent.put(key, node.inodes[0].key, nil, node.pgid, 0)
+			node.key = node.inodes[0].key
+			_assert(len(node.key) > 0, "spill: zero-length node key")
+		}
+
+		// Update the statistics.
+		tx.stats.Spill++
+	}
+
+	// If the root node split and created a new root then we need to spill that
+	// as well. We'll clear out the children to make sure it doesn't try to respill.
+	if n.parent != nil && n.parent.pgid == 0 {
+		n.children = nil
+		return n.parent.spill()
+	}
+
+	return nil
+}
+
+// rebalance attempts to combine the node with sibling nodes if the node fill
+// size is below a threshold or if there are not enough keys.
+func (n *node) rebalance() {
+	if !n.unbalanced {
+		return
+	}
+	n.unbalanced = false
+
+	// Update statistics.
+	n.bucket.tx.stats.Rebalance++
+
+	// Ignore if node is above threshold (25%) and has enough keys.
+	var threshold = n.bucket.tx.db.pageSize / 4
+	if n.size() > threshold && len(n.inodes) > n.minKeys() {
+		return
+	}
+
+	// Root node has special handling.
+	if n.parent == nil {
+		// If root node is a branch and only has one node then collapse it.
+		if !n.isLeaf && len(n.inodes) == 1 {
+			// Move root's child up.
+			child := n.bucket.node(n.inodes[0].pgid, n)
+			n.isLeaf = child.isLeaf
+			n.inodes = child.inodes[:]
+			n.children = child.children
+
+			// Reparent all child nodes being moved.
+			for _, inode := range n.inodes {
+				if child, ok := n.bucket.nodes[inode.pgid]; ok {
+					child.parent = n
+				}
+			}
+
+			// Remove old child.
+			child.parent = nil
+			delete(n.bucket.nodes, child.pgid)
+			child.free()
+		}
+
+		return
+	}
+
+	// If node has no keys then just remove it.
+	if n.numChildren() == 0 {
+		n.parent.del(n.key)
+		n.parent.removeChild(n)
+		delete(n.bucket.nodes, n.pgid)
+		n.free()
+		n.parent.rebalance()
+		return
+	}
+
+	_assert(n.parent.numChildren() > 1, "parent must have at least 2 children")
+
+	// Destination node is right sibling if idx == 0, otherwise left sibling.
+	var target *node
+	var useNextSibling = (n.parent.childIndex(n) == 0)
+	if useNextSibling {
+		target = n.nextSibling()
+	} else {
+		target = n.prevSibling()
+	}
+
+	// If both this node and the target node are too small then merge them.
+	if useNextSibling {
+		// Reparent all child nodes being moved.
+		for _, inode := range target.inodes {
+			if child, ok := n.bucket.nodes[inode.pgid]; ok {
+				child.parent.removeChild(child)
+				child.parent = n
+				child.parent.children = append(child.parent.children, child)
+			}
+		}
+
+		// Copy over inodes from target and remove target.
+		n.inodes = append(n.inodes, target.inodes...)
+		n.parent.del(target.key)
+		n.parent.removeChild(target)
+		delete(n.bucket.nodes, target.pgid)
+		target.free()
+	} else {
+		// Reparent all child nodes being moved.
+		for _, inode := range n.inodes {
+			if child, ok := n.bucket.nodes[inode.pgid]; ok {
+				child.parent.removeChild(child)
+				child.parent = target
+				child.parent.children = append(child.parent.children, child)
+			}
+		}
+
+		// Copy over inodes to target and remove node.
+		target.inodes = append(target.inodes, n.inodes...)
+		n.parent.del(n.key)
+		n.parent.removeChild(n)
+		delete(n.bucket.nodes, n.pgid)
+		n.free()
+	}
+
+	// Either this node or the target node was deleted from the parent so rebalance it.
+	n.parent.rebalance()
+}
+
+// removes a node from the list of in-memory children.
+// This does not affect the inodes.
+func (n *node) removeChild(target *node) {
+	for i, child := range n.children {
+		if child == target {
+			n.children = append(n.children[:i], n.children[i+1:]...)
+			return
+		}
+	}
+}
+
+// dereference causes the node to copy all its inode key/value references to heap memory.
+// This is required when the mmap is reallocated so inodes are not pointing to stale data.
+func (n *node) dereference() {
+	if n.key != nil {
+		key := make([]byte, len(n.key))
+		copy(key, n.key)
+		n.key = key
+		_assert(n.pgid == 0 || len(n.key) > 0, "dereference: zero-length node key on existing node")
+	}
+
+	for i := range n.inodes {
+		inode := &n.inodes[i]
+
+		key := make([]byte, len(inode.key))
+		copy(key, inode.key)
+		inode.key = key
+		_assert(len(inode.key) > 0, "dereference: zero-length inode key")
+
+		value := make([]byte, len(inode.value))
+		copy(value, inode.value)
+		inode.value = value
+	}
+
+	// Recursively dereference children.
+	for _, child := range n.children {
+		child.dereference()
+	}
+
+	// Update statistics.
+	n.bucket.tx.stats.NodeDeref++
+}
+
+// free adds the node's underlying page to the freelist.
+func (n *node) free() {
+	if n.pgid != 0 {
+		n.bucket.tx.db.freelist.free(n.bucket.tx.meta.txid, n.bucket.tx.page(n.pgid))
+		n.pgid = 0
+	}
+}
+
+// dump writes the contents of the node to STDERR for debugging purposes.
+/*
+func (n *node) dump() {
+	// Write node header.
+	var typ = "branch"
+	if n.isLeaf {
+		typ = "leaf"
+	}
+	warnf("[NODE %d {type=%s count=%d}]", n.pgid, typ, len(n.inodes))
+
+	// Write out abbreviated version of each item.
+	for _, item := range n.inodes {
+		if n.isLeaf {
+			if item.flags&bucketLeafFlag != 0 {
+				bucket := (*bucket)(unsafe.Pointer(&item.value[0]))
+				warnf("+L %08x -> (bucket root=%d)", trunc(item.key, 4), bucket.root)
+			} else {
+				warnf("+L %08x -> %08x", trunc(item.key, 4), trunc(item.value, 4))
+			}
+		} else {
+			warnf("+B %08x -> pgid=%d", trunc(item.key, 4), item.pgid)
+		}
+	}
+	warn("")
+}
+*/
+
+type nodes []*node
+
+func (s nodes) Len() int           { return len(s) }
+func (s nodes) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s nodes) Less(i, j int) bool { return bytes.Compare(s[i].inodes[0].key, s[j].inodes[0].key) == -1 }
+
+// inode represents an internal node inside of a node.
+// It can be used to point to elements in a page or point
+// to an element which hasn't been added to a page yet.
+type inode struct {
+	flags uint32
+	pgid  pgid
+	key   []byte
+	value []byte
+}
+
+type inodes []inode

--- a/vendor/github.com/coreos/bbolt/node_test.go
+++ b/vendor/github.com/coreos/bbolt/node_test.go
@@ -1,0 +1,156 @@
+package bolt
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// Ensure that a node can insert a key/value.
+func TestNode_put(t *testing.T) {
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{meta: &meta{pgid: 1}}}}
+	n.put([]byte("baz"), []byte("baz"), []byte("2"), 0, 0)
+	n.put([]byte("foo"), []byte("foo"), []byte("0"), 0, 0)
+	n.put([]byte("bar"), []byte("bar"), []byte("1"), 0, 0)
+	n.put([]byte("foo"), []byte("foo"), []byte("3"), 0, leafPageFlag)
+
+	if len(n.inodes) != 3 {
+		t.Fatalf("exp=3; got=%d", len(n.inodes))
+	}
+	if k, v := n.inodes[0].key, n.inodes[0].value; string(k) != "bar" || string(v) != "1" {
+		t.Fatalf("exp=<bar,1>; got=<%s,%s>", k, v)
+	}
+	if k, v := n.inodes[1].key, n.inodes[1].value; string(k) != "baz" || string(v) != "2" {
+		t.Fatalf("exp=<baz,2>; got=<%s,%s>", k, v)
+	}
+	if k, v := n.inodes[2].key, n.inodes[2].value; string(k) != "foo" || string(v) != "3" {
+		t.Fatalf("exp=<foo,3>; got=<%s,%s>", k, v)
+	}
+	if n.inodes[2].flags != uint32(leafPageFlag) {
+		t.Fatalf("not a leaf: %d", n.inodes[2].flags)
+	}
+}
+
+// Ensure that a node can deserialize from a leaf page.
+func TestNode_read_LeafPage(t *testing.T) {
+	// Create a page.
+	var buf [4096]byte
+	page := (*page)(unsafe.Pointer(&buf[0]))
+	page.flags = leafPageFlag
+	page.count = 2
+
+	// Insert 2 elements at the beginning. sizeof(leafPageElement) == 16
+	nodes := (*[3]leafPageElement)(unsafe.Pointer(&page.ptr))
+	nodes[0] = leafPageElement{flags: 0, pos: 32, ksize: 3, vsize: 4}  // pos = sizeof(leafPageElement) * 2
+	nodes[1] = leafPageElement{flags: 0, pos: 23, ksize: 10, vsize: 3} // pos = sizeof(leafPageElement) + 3 + 4
+
+	// Write data for the nodes at the end.
+	data := (*[4096]byte)(unsafe.Pointer(&nodes[2]))
+	copy(data[:], []byte("barfooz"))
+	copy(data[7:], []byte("helloworldbye"))
+
+	// Deserialize page into a leaf.
+	n := &node{}
+	n.read(page)
+
+	// Check that there are two inodes with correct data.
+	if !n.isLeaf {
+		t.Fatal("expected leaf")
+	}
+	if len(n.inodes) != 2 {
+		t.Fatalf("exp=2; got=%d", len(n.inodes))
+	}
+	if k, v := n.inodes[0].key, n.inodes[0].value; string(k) != "bar" || string(v) != "fooz" {
+		t.Fatalf("exp=<bar,fooz>; got=<%s,%s>", k, v)
+	}
+	if k, v := n.inodes[1].key, n.inodes[1].value; string(k) != "helloworld" || string(v) != "bye" {
+		t.Fatalf("exp=<helloworld,bye>; got=<%s,%s>", k, v)
+	}
+}
+
+// Ensure that a node can serialize into a leaf page.
+func TestNode_write_LeafPage(t *testing.T) {
+	// Create a node.
+	n := &node{isLeaf: true, inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n.put([]byte("susy"), []byte("susy"), []byte("que"), 0, 0)
+	n.put([]byte("ricki"), []byte("ricki"), []byte("lake"), 0, 0)
+	n.put([]byte("john"), []byte("john"), []byte("johnson"), 0, 0)
+
+	// Write it to a page.
+	var buf [4096]byte
+	p := (*page)(unsafe.Pointer(&buf[0]))
+	n.write(p)
+
+	// Read the page back in.
+	n2 := &node{}
+	n2.read(p)
+
+	// Check that the two pages are the same.
+	if len(n2.inodes) != 3 {
+		t.Fatalf("exp=3; got=%d", len(n2.inodes))
+	}
+	if k, v := n2.inodes[0].key, n2.inodes[0].value; string(k) != "john" || string(v) != "johnson" {
+		t.Fatalf("exp=<john,johnson>; got=<%s,%s>", k, v)
+	}
+	if k, v := n2.inodes[1].key, n2.inodes[1].value; string(k) != "ricki" || string(v) != "lake" {
+		t.Fatalf("exp=<ricki,lake>; got=<%s,%s>", k, v)
+	}
+	if k, v := n2.inodes[2].key, n2.inodes[2].value; string(k) != "susy" || string(v) != "que" {
+		t.Fatalf("exp=<susy,que>; got=<%s,%s>", k, v)
+	}
+}
+
+// Ensure that a node can split into appropriate subgroups.
+func TestNode_split(t *testing.T) {
+	// Create a node.
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000003"), []byte("00000003"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000004"), []byte("00000004"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000005"), []byte("00000005"), []byte("0123456701234567"), 0, 0)
+
+	// Split between 2 & 3.
+	n.split(100)
+
+	var parent = n.parent
+	if len(parent.children) != 2 {
+		t.Fatalf("exp=2; got=%d", len(parent.children))
+	}
+	if len(parent.children[0].inodes) != 2 {
+		t.Fatalf("exp=2; got=%d", len(parent.children[0].inodes))
+	}
+	if len(parent.children[1].inodes) != 3 {
+		t.Fatalf("exp=3; got=%d", len(parent.children[1].inodes))
+	}
+}
+
+// Ensure that a page with the minimum number of inodes just returns a single node.
+func TestNode_split_MinKeys(t *testing.T) {
+	// Create a node.
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
+
+	// Split.
+	n.split(20)
+	if n.parent != nil {
+		t.Fatalf("expected nil parent")
+	}
+}
+
+// Ensure that a node that has keys that all fit on a page just returns one leaf.
+func TestNode_split_SinglePage(t *testing.T) {
+	// Create a node.
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000003"), []byte("00000003"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000004"), []byte("00000004"), []byte("0123456701234567"), 0, 0)
+	n.put([]byte("00000005"), []byte("00000005"), []byte("0123456701234567"), 0, 0)
+
+	// Split.
+	n.split(4096)
+	if n.parent != nil {
+		t.Fatalf("expected nil parent")
+	}
+}

--- a/vendor/github.com/coreos/bbolt/page.go
+++ b/vendor/github.com/coreos/bbolt/page.go
@@ -1,0 +1,197 @@
+package bolt
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"unsafe"
+)
+
+const pageHeaderSize = int(unsafe.Offsetof(((*page)(nil)).ptr))
+
+const minKeysPerPage = 2
+
+const branchPageElementSize = int(unsafe.Sizeof(branchPageElement{}))
+const leafPageElementSize = int(unsafe.Sizeof(leafPageElement{}))
+
+const (
+	branchPageFlag   = 0x01
+	leafPageFlag     = 0x02
+	metaPageFlag     = 0x04
+	freelistPageFlag = 0x10
+)
+
+const (
+	bucketLeafFlag = 0x01
+)
+
+type pgid uint64
+
+type page struct {
+	id       pgid
+	flags    uint16
+	count    uint16
+	overflow uint32
+	ptr      uintptr
+}
+
+// typ returns a human readable page type string used for debugging.
+func (p *page) typ() string {
+	if (p.flags & branchPageFlag) != 0 {
+		return "branch"
+	} else if (p.flags & leafPageFlag) != 0 {
+		return "leaf"
+	} else if (p.flags & metaPageFlag) != 0 {
+		return "meta"
+	} else if (p.flags & freelistPageFlag) != 0 {
+		return "freelist"
+	}
+	return fmt.Sprintf("unknown<%02x>", p.flags)
+}
+
+// meta returns a pointer to the metadata section of the page.
+func (p *page) meta() *meta {
+	return (*meta)(unsafe.Pointer(&p.ptr))
+}
+
+// leafPageElement retrieves the leaf node by index
+func (p *page) leafPageElement(index uint16) *leafPageElement {
+	n := &((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	return n
+}
+
+// leafPageElements retrieves a list of leaf nodes.
+func (p *page) leafPageElements() []leafPageElement {
+	if p.count == 0 {
+		return nil
+	}
+	return ((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
+}
+
+// branchPageElement retrieves the branch node by index
+func (p *page) branchPageElement(index uint16) *branchPageElement {
+	return &((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
+}
+
+// branchPageElements retrieves a list of branch nodes.
+func (p *page) branchPageElements() []branchPageElement {
+	if p.count == 0 {
+		return nil
+	}
+	return ((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
+}
+
+// dump writes n bytes of the page to STDERR as hex output.
+func (p *page) hexdump(n int) {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(p))[:n]
+	fmt.Fprintf(os.Stderr, "%x\n", buf)
+}
+
+type pages []*page
+
+func (s pages) Len() int           { return len(s) }
+func (s pages) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s pages) Less(i, j int) bool { return s[i].id < s[j].id }
+
+// branchPageElement represents a node on a branch page.
+type branchPageElement struct {
+	pos   uint32
+	ksize uint32
+	pgid  pgid
+}
+
+// key returns a byte slice of the node key.
+func (n *branchPageElement) key() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos]))[:n.ksize]
+}
+
+// leafPageElement represents a node on a leaf page.
+type leafPageElement struct {
+	flags uint32
+	pos   uint32
+	ksize uint32
+	vsize uint32
+}
+
+// key returns a byte slice of the node key.
+func (n *leafPageElement) key() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos]))[:n.ksize:n.ksize]
+}
+
+// value returns a byte slice of the node value.
+func (n *leafPageElement) value() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos+n.ksize]))[:n.vsize:n.vsize]
+}
+
+// PageInfo represents human readable information about a page.
+type PageInfo struct {
+	ID            int
+	Type          string
+	Count         int
+	OverflowCount int
+}
+
+type pgids []pgid
+
+func (s pgids) Len() int           { return len(s) }
+func (s pgids) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s pgids) Less(i, j int) bool { return s[i] < s[j] }
+
+// merge returns the sorted union of a and b.
+func (a pgids) merge(b pgids) pgids {
+	// Return the opposite slice if one is nil.
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	merged := make(pgids, len(a)+len(b))
+	mergepgids(merged, a, b)
+	return merged
+}
+
+// mergepgids copies the sorted union of a and b into dst.
+// If dst is too small, it panics.
+func mergepgids(dst, a, b pgids) {
+	if len(dst) < len(a)+len(b) {
+		panic(fmt.Errorf("mergepgids bad len %d < %d + %d", len(dst), len(a), len(b)))
+	}
+	// Copy in the opposite slice if one is nil.
+	if len(a) == 0 {
+		copy(dst, b)
+		return
+	}
+	if len(b) == 0 {
+		copy(dst, a)
+		return
+	}
+
+	// Merged will hold all elements from both lists.
+	merged := dst[:0]
+
+	// Assign lead to the slice with a lower starting value, follow to the higher value.
+	lead, follow := a, b
+	if b[0] < a[0] {
+		lead, follow = b, a
+	}
+
+	// Continue while there are elements in the lead.
+	for len(lead) > 0 {
+		// Merge largest prefix of lead that is ahead of follow[0].
+		n := sort.Search(len(lead), func(i int) bool { return lead[i] > follow[0] })
+		merged = append(merged, lead[:n]...)
+		if n >= len(lead) {
+			break
+		}
+
+		// Swap lead and follow.
+		lead, follow = follow, lead[n:]
+	}
+
+	// Append what's left in follow.
+	_ = append(merged, follow...)
+}

--- a/vendor/github.com/coreos/bbolt/page_test.go
+++ b/vendor/github.com/coreos/bbolt/page_test.go
@@ -1,0 +1,72 @@
+package bolt
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"testing/quick"
+)
+
+// Ensure that the page type can be returned in human readable format.
+func TestPage_typ(t *testing.T) {
+	if typ := (&page{flags: branchPageFlag}).typ(); typ != "branch" {
+		t.Fatalf("exp=branch; got=%v", typ)
+	}
+	if typ := (&page{flags: leafPageFlag}).typ(); typ != "leaf" {
+		t.Fatalf("exp=leaf; got=%v", typ)
+	}
+	if typ := (&page{flags: metaPageFlag}).typ(); typ != "meta" {
+		t.Fatalf("exp=meta; got=%v", typ)
+	}
+	if typ := (&page{flags: freelistPageFlag}).typ(); typ != "freelist" {
+		t.Fatalf("exp=freelist; got=%v", typ)
+	}
+	if typ := (&page{flags: 20000}).typ(); typ != "unknown<4e20>" {
+		t.Fatalf("exp=unknown<4e20>; got=%v", typ)
+	}
+}
+
+// Ensure that the hexdump debugging function doesn't blow up.
+func TestPage_dump(t *testing.T) {
+	(&page{id: 256}).hexdump(16)
+}
+
+func TestPgids_merge(t *testing.T) {
+	a := pgids{4, 5, 6, 10, 11, 12, 13, 27}
+	b := pgids{1, 3, 8, 9, 25, 30}
+	c := a.merge(b)
+	if !reflect.DeepEqual(c, pgids{1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30}) {
+		t.Errorf("mismatch: %v", c)
+	}
+
+	a = pgids{4, 5, 6, 10, 11, 12, 13, 27, 35, 36}
+	b = pgids{8, 9, 25, 30}
+	c = a.merge(b)
+	if !reflect.DeepEqual(c, pgids{4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30, 35, 36}) {
+		t.Errorf("mismatch: %v", c)
+	}
+}
+
+func TestPgids_merge_quick(t *testing.T) {
+	if err := quick.Check(func(a, b pgids) bool {
+		// Sort incoming lists.
+		sort.Sort(a)
+		sort.Sort(b)
+
+		// Merge the two lists together.
+		got := a.merge(b)
+
+		// The expected value should be the two lists combined and sorted.
+		exp := append(a, b...)
+		sort.Sort(exp)
+
+		if !reflect.DeepEqual(exp, got) {
+			t.Errorf("\nexp=%+v\ngot=%+v\n", exp, got)
+			return false
+		}
+
+		return true
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/vendor/github.com/coreos/bbolt/quick_test.go
+++ b/vendor/github.com/coreos/bbolt/quick_test.go
@@ -1,0 +1,87 @@
+package bolt_test
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"reflect"
+	"testing/quick"
+	"time"
+)
+
+// testing/quick defaults to 5 iterations and a random seed.
+// You can override these settings from the command line:
+//
+//   -quick.count     The number of iterations to perform.
+//   -quick.seed      The seed to use for randomizing.
+//   -quick.maxitems  The maximum number of items to insert into a DB.
+//   -quick.maxksize  The maximum size of a key.
+//   -quick.maxvsize  The maximum size of a value.
+//
+
+var qcount, qseed, qmaxitems, qmaxksize, qmaxvsize int
+
+func init() {
+	flag.IntVar(&qcount, "quick.count", 5, "")
+	flag.IntVar(&qseed, "quick.seed", int(time.Now().UnixNano())%100000, "")
+	flag.IntVar(&qmaxitems, "quick.maxitems", 1000, "")
+	flag.IntVar(&qmaxksize, "quick.maxksize", 1024, "")
+	flag.IntVar(&qmaxvsize, "quick.maxvsize", 1024, "")
+	flag.Parse()
+	fmt.Fprintln(os.Stderr, "seed:", qseed)
+	fmt.Fprintf(os.Stderr, "quick settings: count=%v, items=%v, ksize=%v, vsize=%v\n", qcount, qmaxitems, qmaxksize, qmaxvsize)
+}
+
+func qconfig() *quick.Config {
+	return &quick.Config{
+		MaxCount: qcount,
+		Rand:     rand.New(rand.NewSource(int64(qseed))),
+	}
+}
+
+type testdata []testdataitem
+
+func (t testdata) Len() int           { return len(t) }
+func (t testdata) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t testdata) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key) == -1 }
+
+func (t testdata) Generate(rand *rand.Rand, size int) reflect.Value {
+	n := rand.Intn(qmaxitems-1) + 1
+	items := make(testdata, n)
+	used := make(map[string]bool)
+	for i := 0; i < n; i++ {
+		item := &items[i]
+		// Ensure that keys are unique by looping until we find one that we have not already used.
+		for {
+			item.Key = randByteSlice(rand, 1, qmaxksize)
+			if !used[string(item.Key)] {
+				used[string(item.Key)] = true
+				break
+			}
+		}
+		item.Value = randByteSlice(rand, 0, qmaxvsize)
+	}
+	return reflect.ValueOf(items)
+}
+
+type revtestdata []testdataitem
+
+func (t revtestdata) Len() int           { return len(t) }
+func (t revtestdata) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t revtestdata) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key) == 1 }
+
+type testdataitem struct {
+	Key   []byte
+	Value []byte
+}
+
+func randByteSlice(rand *rand.Rand, minSize, maxSize int) []byte {
+	n := rand.Intn(maxSize-minSize) + minSize
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte(rand.Intn(255))
+	}
+	return b
+}

--- a/vendor/github.com/coreos/bbolt/simulation_no_freelist_sync_test.go
+++ b/vendor/github.com/coreos/bbolt/simulation_no_freelist_sync_test.go
@@ -1,0 +1,47 @@
+package bolt_test
+
+import (
+	"testing"
+
+	"github.com/coreos/bbolt"
+)
+
+func TestSimulateNoFreeListSync_1op_1p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1, 1)
+}
+func TestSimulateNoFreeListSync_10op_1p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10, 1)
+}
+func TestSimulateNoFreeListSync_100op_1p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 100, 1)
+}
+func TestSimulateNoFreeListSync_1000op_1p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1000, 1)
+}
+func TestSimulateNoFreeListSync_10000op_1p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 1)
+}
+func TestSimulateNoFreeListSync_10op_10p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10, 10)
+}
+func TestSimulateNoFreeListSync_100op_10p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 100, 10)
+}
+func TestSimulateNoFreeListSync_1000op_10p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1000, 10)
+}
+func TestSimulateNoFreeListSync_10000op_10p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 10)
+}
+func TestSimulateNoFreeListSync_100op_100p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 100, 100)
+}
+func TestSimulateNoFreeListSync_1000op_100p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1000, 100)
+}
+func TestSimulateNoFreeListSync_10000op_100p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 100)
+}
+func TestSimulateNoFreeListSync_10000op_1000p(t *testing.T) {
+	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 1000)
+}

--- a/vendor/github.com/coreos/bbolt/simulation_test.go
+++ b/vendor/github.com/coreos/bbolt/simulation_test.go
@@ -1,0 +1,336 @@
+package bolt_test
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/coreos/bbolt"
+)
+
+func TestSimulate_1op_1p(t *testing.T)     { testSimulate(t, nil, 1, 1, 1) }
+func TestSimulate_10op_1p(t *testing.T)    { testSimulate(t, nil, 1, 10, 1) }
+func TestSimulate_100op_1p(t *testing.T)   { testSimulate(t, nil, 1, 100, 1) }
+func TestSimulate_1000op_1p(t *testing.T)  { testSimulate(t, nil, 1, 1000, 1) }
+func TestSimulate_10000op_1p(t *testing.T) { testSimulate(t, nil, 1, 10000, 1) }
+
+func TestSimulate_10op_10p(t *testing.T)    { testSimulate(t, nil, 1, 10, 10) }
+func TestSimulate_100op_10p(t *testing.T)   { testSimulate(t, nil, 1, 100, 10) }
+func TestSimulate_1000op_10p(t *testing.T)  { testSimulate(t, nil, 1, 1000, 10) }
+func TestSimulate_10000op_10p(t *testing.T) { testSimulate(t, nil, 1, 10000, 10) }
+
+func TestSimulate_100op_100p(t *testing.T)   { testSimulate(t, nil, 1, 100, 100) }
+func TestSimulate_1000op_100p(t *testing.T)  { testSimulate(t, nil, 1, 1000, 100) }
+func TestSimulate_10000op_100p(t *testing.T) { testSimulate(t, nil, 1, 10000, 100) }
+
+func TestSimulate_10000op_1000p(t *testing.T) { testSimulate(t, nil, 1, 10000, 1000) }
+
+// Randomly generate operations on a given database with multiple clients to ensure consistency and thread safety.
+func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, parallelism int) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	rand.Seed(int64(qseed))
+
+	// A list of operations that readers and writers can perform.
+	var readerHandlers = []simulateHandler{simulateGetHandler}
+	var writerHandlers = []simulateHandler{simulateGetHandler, simulatePutHandler}
+
+	var versions = make(map[int]*QuickDB)
+	versions[1] = NewQuickDB()
+
+	db := MustOpenWithOption(openOption)
+	defer db.MustClose()
+
+	var mutex sync.Mutex
+
+	// Run n threads in parallel, each with their own operation.
+	var wg sync.WaitGroup
+
+	for n := 0; n < round; n++ {
+
+		var threads = make(chan bool, parallelism)
+		var i int
+		for {
+			threads <- true
+			wg.Add(1)
+			writable := ((rand.Int() % 100) < 20) // 20% writers
+
+			// Choose an operation to execute.
+			var handler simulateHandler
+			if writable {
+				handler = writerHandlers[rand.Intn(len(writerHandlers))]
+			} else {
+				handler = readerHandlers[rand.Intn(len(readerHandlers))]
+			}
+
+			// Execute a thread for the given operation.
+			go func(writable bool, handler simulateHandler) {
+				defer wg.Done()
+
+				// Start transaction.
+				tx, err := db.Begin(writable)
+				if err != nil {
+					t.Fatal("tx begin: ", err)
+				}
+
+				// Obtain current state of the dataset.
+				mutex.Lock()
+				var qdb = versions[tx.ID()]
+				if writable {
+					qdb = versions[tx.ID()-1].Copy()
+				}
+				mutex.Unlock()
+
+				// Make sure we commit/rollback the tx at the end and update the state.
+				if writable {
+					defer func() {
+						mutex.Lock()
+						versions[tx.ID()] = qdb
+						mutex.Unlock()
+
+						if err := tx.Commit(); err != nil {
+							t.Fatal(err)
+						}
+					}()
+				} else {
+					defer func() { _ = tx.Rollback() }()
+				}
+
+				// Ignore operation if we don't have data yet.
+				if qdb == nil {
+					return
+				}
+
+				// Execute handler.
+				handler(tx, qdb)
+
+				// Release a thread back to the scheduling loop.
+				<-threads
+			}(writable, handler)
+
+			i++
+			if i > threadCount {
+				break
+			}
+		}
+
+		// Wait until all threads are done.
+		wg.Wait()
+
+		db.MustClose()
+		db.MustReopen()
+	}
+}
+
+type simulateHandler func(tx *bolt.Tx, qdb *QuickDB)
+
+// Retrieves a key from the database and verifies that it is what is expected.
+func simulateGetHandler(tx *bolt.Tx, qdb *QuickDB) {
+	// Randomly retrieve an existing exist.
+	keys := qdb.Rand()
+	if len(keys) == 0 {
+		return
+	}
+
+	// Retrieve root bucket.
+	b := tx.Bucket(keys[0])
+	if b == nil {
+		panic(fmt.Sprintf("bucket[0] expected: %08x\n", trunc(keys[0], 4)))
+	}
+
+	// Drill into nested buckets.
+	for _, key := range keys[1 : len(keys)-1] {
+		b = b.Bucket(key)
+		if b == nil {
+			panic(fmt.Sprintf("bucket[n] expected: %v -> %v\n", keys, key))
+		}
+	}
+
+	// Verify key/value on the final bucket.
+	expected := qdb.Get(keys)
+	actual := b.Get(keys[len(keys)-1])
+	if !bytes.Equal(actual, expected) {
+		fmt.Println("=== EXPECTED ===")
+		fmt.Println(expected)
+		fmt.Println("=== ACTUAL ===")
+		fmt.Println(actual)
+		fmt.Println("=== END ===")
+		panic("value mismatch")
+	}
+}
+
+// Inserts a key into the database.
+func simulatePutHandler(tx *bolt.Tx, qdb *QuickDB) {
+	var err error
+	keys, value := randKeys(), randValue()
+
+	// Retrieve root bucket.
+	b := tx.Bucket(keys[0])
+	if b == nil {
+		b, err = tx.CreateBucket(keys[0])
+		if err != nil {
+			panic("create bucket: " + err.Error())
+		}
+	}
+
+	// Create nested buckets, if necessary.
+	for _, key := range keys[1 : len(keys)-1] {
+		child := b.Bucket(key)
+		if child != nil {
+			b = child
+		} else {
+			b, err = b.CreateBucket(key)
+			if err != nil {
+				panic("create bucket: " + err.Error())
+			}
+		}
+	}
+
+	// Insert into database.
+	if err := b.Put(keys[len(keys)-1], value); err != nil {
+		panic("put: " + err.Error())
+	}
+
+	// Insert into in-memory database.
+	qdb.Put(keys, value)
+}
+
+// QuickDB is an in-memory database that replicates the functionality of the
+// Bolt DB type except that it is entirely in-memory. It is meant for testing
+// that the Bolt database is consistent.
+type QuickDB struct {
+	sync.RWMutex
+	m map[string]interface{}
+}
+
+// NewQuickDB returns an instance of QuickDB.
+func NewQuickDB() *QuickDB {
+	return &QuickDB{m: make(map[string]interface{})}
+}
+
+// Get retrieves the value at a key path.
+func (db *QuickDB) Get(keys [][]byte) []byte {
+	db.RLock()
+	defer db.RUnlock()
+
+	m := db.m
+	for _, key := range keys[:len(keys)-1] {
+		value := m[string(key)]
+		if value == nil {
+			return nil
+		}
+		switch value := value.(type) {
+		case map[string]interface{}:
+			m = value
+		case []byte:
+			return nil
+		}
+	}
+
+	// Only return if it's a simple value.
+	if value, ok := m[string(keys[len(keys)-1])].([]byte); ok {
+		return value
+	}
+	return nil
+}
+
+// Put inserts a value into a key path.
+func (db *QuickDB) Put(keys [][]byte, value []byte) {
+	db.Lock()
+	defer db.Unlock()
+
+	// Build buckets all the way down the key path.
+	m := db.m
+	for _, key := range keys[:len(keys)-1] {
+		if _, ok := m[string(key)].([]byte); ok {
+			return // Keypath intersects with a simple value. Do nothing.
+		}
+
+		if m[string(key)] == nil {
+			m[string(key)] = make(map[string]interface{})
+		}
+		m = m[string(key)].(map[string]interface{})
+	}
+
+	// Insert value into the last key.
+	m[string(keys[len(keys)-1])] = value
+}
+
+// Rand returns a random key path that points to a simple value.
+func (db *QuickDB) Rand() [][]byte {
+	db.RLock()
+	defer db.RUnlock()
+	if len(db.m) == 0 {
+		return nil
+	}
+	var keys [][]byte
+	db.rand(db.m, &keys)
+	return keys
+}
+
+func (db *QuickDB) rand(m map[string]interface{}, keys *[][]byte) {
+	i, index := 0, rand.Intn(len(m))
+	for k, v := range m {
+		if i == index {
+			*keys = append(*keys, []byte(k))
+			if v, ok := v.(map[string]interface{}); ok {
+				db.rand(v, keys)
+			}
+			return
+		}
+		i++
+	}
+	panic("quickdb rand: out-of-range")
+}
+
+// Copy copies the entire database.
+func (db *QuickDB) Copy() *QuickDB {
+	db.RLock()
+	defer db.RUnlock()
+	return &QuickDB{m: db.copy(db.m)}
+}
+
+func (db *QuickDB) copy(m map[string]interface{}) map[string]interface{} {
+	clone := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		switch v := v.(type) {
+		case map[string]interface{}:
+			clone[k] = db.copy(v)
+		default:
+			clone[k] = v
+		}
+	}
+	return clone
+}
+
+func randKey() []byte {
+	var min, max = 1, 1024
+	n := rand.Intn(max-min) + min
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte(rand.Intn(255))
+	}
+	return b
+}
+
+func randKeys() [][]byte {
+	var keys [][]byte
+	var count = rand.Intn(2) + 2
+	for i := 0; i < count; i++ {
+		keys = append(keys, randKey())
+	}
+	return keys
+}
+
+func randValue() []byte {
+	n := rand.Intn(8192)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte(rand.Intn(255))
+	}
+	return b
+}

--- a/vendor/github.com/coreos/bbolt/tx.go
+++ b/vendor/github.com/coreos/bbolt/tx.go
@@ -1,0 +1,698 @@
+package bolt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+	"unsafe"
+)
+
+// txid represents the internal transaction identifier.
+type txid uint64
+
+// Tx represents a read-only or read/write transaction on the database.
+// Read-only transactions can be used for retrieving values for keys and creating cursors.
+// Read/write transactions can create and remove buckets and create and remove keys.
+//
+// IMPORTANT: You must commit or rollback transactions when you are done with
+// them. Pages can not be reclaimed by the writer until no more transactions
+// are using them. A long running read transaction can cause the database to
+// quickly grow.
+type Tx struct {
+	writable       bool
+	managed        bool
+	db             *DB
+	meta           *meta
+	root           Bucket
+	pages          map[pgid]*page
+	stats          TxStats
+	commitHandlers []func()
+
+	// WriteFlag specifies the flag for write-related methods like WriteTo().
+	// Tx opens the database file with the specified flag to copy the data.
+	//
+	// By default, the flag is unset, which works well for mostly in-memory
+	// workloads. For databases that are much larger than available RAM,
+	// set the flag to syscall.O_DIRECT to avoid trashing the page cache.
+	WriteFlag int
+}
+
+// init initializes the transaction.
+func (tx *Tx) init(db *DB) {
+	tx.db = db
+	tx.pages = nil
+
+	// Copy the meta page since it can be changed by the writer.
+	tx.meta = &meta{}
+	db.meta().copy(tx.meta)
+
+	// Copy over the root bucket.
+	tx.root = newBucket(tx)
+	tx.root.bucket = &bucket{}
+	*tx.root.bucket = tx.meta.root
+
+	// Increment the transaction id and add a page cache for writable transactions.
+	if tx.writable {
+		tx.pages = make(map[pgid]*page)
+		tx.meta.txid += txid(1)
+	}
+}
+
+// ID returns the transaction id.
+func (tx *Tx) ID() int {
+	return int(tx.meta.txid)
+}
+
+// DB returns a reference to the database that created the transaction.
+func (tx *Tx) DB() *DB {
+	return tx.db
+}
+
+// Size returns current database size in bytes as seen by this transaction.
+func (tx *Tx) Size() int64 {
+	return int64(tx.meta.pgid) * int64(tx.db.pageSize)
+}
+
+// Writable returns whether the transaction can perform write operations.
+func (tx *Tx) Writable() bool {
+	return tx.writable
+}
+
+// Cursor creates a cursor associated with the root bucket.
+// All items in the cursor will return a nil value because all root bucket keys point to buckets.
+// The cursor is only valid as long as the transaction is open.
+// Do not use a cursor after the transaction is closed.
+func (tx *Tx) Cursor() *Cursor {
+	return tx.root.Cursor()
+}
+
+// Stats retrieves a copy of the current transaction statistics.
+func (tx *Tx) Stats() TxStats {
+	return tx.stats
+}
+
+// Bucket retrieves a bucket by name.
+// Returns nil if the bucket does not exist.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (tx *Tx) Bucket(name []byte) *Bucket {
+	return tx.root.Bucket(name)
+}
+
+// CreateBucket creates a new bucket.
+// Returns an error if the bucket already exists, if the bucket name is blank, or if the bucket name is too long.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (tx *Tx) CreateBucket(name []byte) (*Bucket, error) {
+	return tx.root.CreateBucket(name)
+}
+
+// CreateBucketIfNotExists creates a new bucket if it doesn't already exist.
+// Returns an error if the bucket name is blank, or if the bucket name is too long.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (tx *Tx) CreateBucketIfNotExists(name []byte) (*Bucket, error) {
+	return tx.root.CreateBucketIfNotExists(name)
+}
+
+// DeleteBucket deletes a bucket.
+// Returns an error if the bucket cannot be found or if the key represents a non-bucket value.
+func (tx *Tx) DeleteBucket(name []byte) error {
+	return tx.root.DeleteBucket(name)
+}
+
+// ForEach executes a function for each bucket in the root.
+// If the provided function returns an error then the iteration is stopped and
+// the error is returned to the caller.
+func (tx *Tx) ForEach(fn func(name []byte, b *Bucket) error) error {
+	return tx.root.ForEach(func(k, v []byte) error {
+		return fn(k, tx.root.Bucket(k))
+	})
+}
+
+// OnCommit adds a handler function to be executed after the transaction successfully commits.
+func (tx *Tx) OnCommit(fn func()) {
+	tx.commitHandlers = append(tx.commitHandlers, fn)
+}
+
+// Commit writes all changes to disk and updates the meta page.
+// Returns an error if a disk write error occurs, or if Commit is
+// called on a read-only transaction.
+func (tx *Tx) Commit() error {
+	_assert(!tx.managed, "managed tx commit not allowed")
+	if tx.db == nil {
+		return ErrTxClosed
+	} else if !tx.writable {
+		return ErrTxNotWritable
+	}
+
+	// TODO(benbjohnson): Use vectorized I/O to write out dirty pages.
+
+	// Rebalance nodes which have had deletions.
+	var startTime = time.Now()
+	tx.root.rebalance()
+	if tx.stats.Rebalance > 0 {
+		tx.stats.RebalanceTime += time.Since(startTime)
+	}
+
+	// spill data onto dirty pages.
+	startTime = time.Now()
+	if err := tx.root.spill(); err != nil {
+		tx.rollback()
+		return err
+	}
+	tx.stats.SpillTime += time.Since(startTime)
+
+	// Free the old root bucket.
+	tx.meta.root.root = tx.root.root
+
+	// Free the old freelist because commit writes out a fresh freelist.
+	if tx.meta.freelist != pgidNoFreelist {
+		tx.db.freelist.free(tx.meta.txid, tx.db.page(tx.meta.freelist))
+	}
+
+	if !tx.db.NoFreelistSync {
+		err := tx.commitFreelist()
+		if err != nil {
+			return err
+		}
+	} else {
+		tx.meta.freelist = pgidNoFreelist
+	}
+
+	// Write dirty pages to disk.
+	startTime = time.Now()
+	if err := tx.write(); err != nil {
+		tx.rollback()
+		return err
+	}
+
+	// If strict mode is enabled then perform a consistency check.
+	// Only the first consistency error is reported in the panic.
+	if tx.db.StrictMode {
+		ch := tx.Check()
+		var errs []string
+		for {
+			err, ok := <-ch
+			if !ok {
+				break
+			}
+			errs = append(errs, err.Error())
+		}
+		if len(errs) > 0 {
+			panic("check fail: " + strings.Join(errs, "\n"))
+		}
+	}
+
+	// Write meta to disk.
+	if err := tx.writeMeta(); err != nil {
+		tx.rollback()
+		return err
+	}
+	tx.stats.WriteTime += time.Since(startTime)
+
+	// Finalize the transaction.
+	tx.close()
+
+	// Execute commit handlers now that the locks have been removed.
+	for _, fn := range tx.commitHandlers {
+		fn()
+	}
+
+	return nil
+}
+
+func (tx *Tx) commitFreelist() error {
+	// Allocate new pages for the new free list. This will overestimate
+	// the size of the freelist but not underestimate the size (which would be bad).
+	opgid := tx.meta.pgid
+	p, err := tx.allocate((tx.db.freelist.size() / tx.db.pageSize) + 1)
+	if err != nil {
+		tx.rollback()
+		return err
+	}
+	if err := tx.db.freelist.write(p); err != nil {
+		tx.rollback()
+		return err
+	}
+	tx.meta.freelist = p.id
+	// If the high water mark has moved up then attempt to grow the database.
+	if tx.meta.pgid > opgid {
+		if err := tx.db.grow(int(tx.meta.pgid+1) * tx.db.pageSize); err != nil {
+			tx.rollback()
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Rollback closes the transaction and ignores all previous updates. Read-only
+// transactions must be rolled back and not committed.
+func (tx *Tx) Rollback() error {
+	_assert(!tx.managed, "managed tx rollback not allowed")
+	if tx.db == nil {
+		return ErrTxClosed
+	}
+	tx.rollback()
+	return nil
+}
+
+func (tx *Tx) rollback() {
+	if tx.db == nil {
+		return
+	}
+	if tx.writable {
+		tx.db.freelist.rollback(tx.meta.txid)
+		tx.db.freelist.reload(tx.db.page(tx.db.meta().freelist))
+	}
+	tx.close()
+}
+
+func (tx *Tx) close() {
+	if tx.db == nil {
+		return
+	}
+	if tx.writable {
+		// Grab freelist stats.
+		var freelistFreeN = tx.db.freelist.free_count()
+		var freelistPendingN = tx.db.freelist.pending_count()
+		var freelistAlloc = tx.db.freelist.size()
+
+		// Remove transaction ref & writer lock.
+		tx.db.rwtx = nil
+		tx.db.rwlock.Unlock()
+
+		// Merge statistics.
+		tx.db.statlock.Lock()
+		tx.db.stats.FreePageN = freelistFreeN
+		tx.db.stats.PendingPageN = freelistPendingN
+		tx.db.stats.FreeAlloc = (freelistFreeN + freelistPendingN) * tx.db.pageSize
+		tx.db.stats.FreelistInuse = freelistAlloc
+		tx.db.stats.TxStats.add(&tx.stats)
+		tx.db.statlock.Unlock()
+	} else {
+		tx.db.removeTx(tx)
+	}
+
+	// Clear all references.
+	tx.db = nil
+	tx.meta = nil
+	tx.root = Bucket{tx: tx}
+	tx.pages = nil
+}
+
+// Copy writes the entire database to a writer.
+// This function exists for backwards compatibility. Use WriteTo() instead.
+func (tx *Tx) Copy(w io.Writer) error {
+	_, err := tx.WriteTo(w)
+	return err
+}
+
+// WriteTo writes the entire database to a writer.
+// If err == nil then exactly tx.Size() bytes will be written into the writer.
+func (tx *Tx) WriteTo(w io.Writer) (n int64, err error) {
+	// Attempt to open reader with WriteFlag
+	f, err := os.OpenFile(tx.db.path, os.O_RDONLY|tx.WriteFlag, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Generate a meta page. We use the same page data for both meta pages.
+	buf := make([]byte, tx.db.pageSize)
+	page := (*page)(unsafe.Pointer(&buf[0]))
+	page.flags = metaPageFlag
+	*page.meta() = *tx.meta
+
+	// Write meta 0.
+	page.id = 0
+	page.meta().checksum = page.meta().sum64()
+	nn, err := w.Write(buf)
+	n += int64(nn)
+	if err != nil {
+		return n, fmt.Errorf("meta 0 copy: %s", err)
+	}
+
+	// Write meta 1 with a lower transaction id.
+	page.id = 1
+	page.meta().txid -= 1
+	page.meta().checksum = page.meta().sum64()
+	nn, err = w.Write(buf)
+	n += int64(nn)
+	if err != nil {
+		return n, fmt.Errorf("meta 1 copy: %s", err)
+	}
+
+	// Move past the meta pages in the file.
+	if _, err := f.Seek(int64(tx.db.pageSize*2), os.SEEK_SET); err != nil {
+		return n, fmt.Errorf("seek: %s", err)
+	}
+
+	// Copy data pages.
+	wn, err := io.CopyN(w, f, tx.Size()-int64(tx.db.pageSize*2))
+	n += wn
+	if err != nil {
+		return n, err
+	}
+
+	return n, f.Close()
+}
+
+// CopyFile copies the entire database to file at the given path.
+// A reader transaction is maintained during the copy so it is safe to continue
+// using the database while a copy is in progress.
+func (tx *Tx) CopyFile(path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Copy(f)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// Check performs several consistency checks on the database for this transaction.
+// An error is returned if any inconsistency is found.
+//
+// It can be safely run concurrently on a writable transaction. However, this
+// incurs a high cost for large databases and databases with a lot of subbuckets
+// because of caching. This overhead can be removed if running on a read-only
+// transaction, however, it is not safe to execute other writer transactions at
+// the same time.
+func (tx *Tx) Check() <-chan error {
+	ch := make(chan error)
+	go tx.check(ch)
+	return ch
+}
+
+func (tx *Tx) check(ch chan error) {
+	// Check if any pages are double freed.
+	freed := make(map[pgid]bool)
+	all := make([]pgid, tx.db.freelist.count())
+	tx.db.freelist.copyall(all)
+	for _, id := range all {
+		if freed[id] {
+			ch <- fmt.Errorf("page %d: already freed", id)
+		}
+		freed[id] = true
+	}
+
+	// Track every reachable page.
+	reachable := make(map[pgid]*page)
+	reachable[0] = tx.page(0) // meta0
+	reachable[1] = tx.page(1) // meta1
+	if tx.meta.freelist != pgidNoFreelist {
+		for i := uint32(0); i <= tx.page(tx.meta.freelist).overflow; i++ {
+			reachable[tx.meta.freelist+pgid(i)] = tx.page(tx.meta.freelist)
+		}
+	}
+
+	// Recursively check buckets.
+	tx.checkBucket(&tx.root, reachable, freed, ch)
+
+	// Ensure all pages below high water mark are either reachable or freed.
+	for i := pgid(0); i < tx.meta.pgid; i++ {
+		_, isReachable := reachable[i]
+		if !isReachable && !freed[i] {
+			ch <- fmt.Errorf("page %d: unreachable unfreed", int(i))
+		}
+	}
+
+	// Close the channel to signal completion.
+	close(ch)
+}
+
+func (tx *Tx) checkBucket(b *Bucket, reachable map[pgid]*page, freed map[pgid]bool, ch chan error) {
+	// Ignore inline buckets.
+	if b.root == 0 {
+		return
+	}
+
+	// Check every page used by this bucket.
+	b.tx.forEachPage(b.root, 0, func(p *page, _ int) {
+		if p.id > tx.meta.pgid {
+			ch <- fmt.Errorf("page %d: out of bounds: %d", int(p.id), int(b.tx.meta.pgid))
+		}
+
+		// Ensure each page is only referenced once.
+		for i := pgid(0); i <= pgid(p.overflow); i++ {
+			var id = p.id + i
+			if _, ok := reachable[id]; ok {
+				ch <- fmt.Errorf("page %d: multiple references", int(id))
+			}
+			reachable[id] = p
+		}
+
+		// We should only encounter un-freed leaf and branch pages.
+		if freed[p.id] {
+			ch <- fmt.Errorf("page %d: reachable freed", int(p.id))
+		} else if (p.flags&branchPageFlag) == 0 && (p.flags&leafPageFlag) == 0 {
+			ch <- fmt.Errorf("page %d: invalid type: %s", int(p.id), p.typ())
+		}
+	})
+
+	// Check each bucket within this bucket.
+	_ = b.ForEach(func(k, v []byte) error {
+		if child := b.Bucket(k); child != nil {
+			tx.checkBucket(child, reachable, freed, ch)
+		}
+		return nil
+	})
+}
+
+// allocate returns a contiguous block of memory starting at a given page.
+func (tx *Tx) allocate(count int) (*page, error) {
+	p, err := tx.db.allocate(tx.meta.txid, count)
+	if err != nil {
+		return nil, err
+	}
+
+	// Save to our page cache.
+	tx.pages[p.id] = p
+
+	// Update statistics.
+	tx.stats.PageCount++
+	tx.stats.PageAlloc += count * tx.db.pageSize
+
+	return p, nil
+}
+
+// write writes any dirty pages to disk.
+func (tx *Tx) write() error {
+	// Sort pages by id.
+	pages := make(pages, 0, len(tx.pages))
+	for _, p := range tx.pages {
+		pages = append(pages, p)
+	}
+	// Clear out page cache early.
+	tx.pages = make(map[pgid]*page)
+	sort.Sort(pages)
+
+	// Write pages to disk in order.
+	for _, p := range pages {
+		size := (int(p.overflow) + 1) * tx.db.pageSize
+		offset := int64(p.id) * int64(tx.db.pageSize)
+
+		// Write out page in "max allocation" sized chunks.
+		ptr := (*[maxAllocSize]byte)(unsafe.Pointer(p))
+		for {
+			// Limit our write to our max allocation size.
+			sz := size
+			if sz > maxAllocSize-1 {
+				sz = maxAllocSize - 1
+			}
+
+			// Write chunk to disk.
+			buf := ptr[:sz]
+			if _, err := tx.db.ops.writeAt(buf, offset); err != nil {
+				return err
+			}
+
+			// Update statistics.
+			tx.stats.Write++
+
+			// Exit inner for loop if we've written all the chunks.
+			size -= sz
+			if size == 0 {
+				break
+			}
+
+			// Otherwise move offset forward and move pointer to next chunk.
+			offset += int64(sz)
+			ptr = (*[maxAllocSize]byte)(unsafe.Pointer(&ptr[sz]))
+		}
+	}
+
+	// Ignore file sync if flag is set on DB.
+	if !tx.db.NoSync || IgnoreNoSync {
+		if err := fdatasync(tx.db); err != nil {
+			return err
+		}
+	}
+
+	// Put small pages back to page pool.
+	for _, p := range pages {
+		// Ignore page sizes over 1 page.
+		// These are allocated using make() instead of the page pool.
+		if int(p.overflow) != 0 {
+			continue
+		}
+
+		buf := (*[maxAllocSize]byte)(unsafe.Pointer(p))[:tx.db.pageSize]
+
+		// See https://go.googlesource.com/go/+/f03c9202c43e0abb130669852082117ca50aa9b1
+		for i := range buf {
+			buf[i] = 0
+		}
+		tx.db.pagePool.Put(buf)
+	}
+
+	return nil
+}
+
+// writeMeta writes the meta to the disk.
+func (tx *Tx) writeMeta() error {
+	// Create a temporary buffer for the meta page.
+	buf := make([]byte, tx.db.pageSize)
+	p := tx.db.pageInBuffer(buf, 0)
+	tx.meta.write(p)
+
+	// Write the meta page to file.
+	if _, err := tx.db.ops.writeAt(buf, int64(p.id)*int64(tx.db.pageSize)); err != nil {
+		return err
+	}
+	if !tx.db.NoSync || IgnoreNoSync {
+		if err := fdatasync(tx.db); err != nil {
+			return err
+		}
+	}
+
+	// Update statistics.
+	tx.stats.Write++
+
+	return nil
+}
+
+// page returns a reference to the page with a given id.
+// If page has been written to then a temporary buffered page is returned.
+func (tx *Tx) page(id pgid) *page {
+	// Check the dirty pages first.
+	if tx.pages != nil {
+		if p, ok := tx.pages[id]; ok {
+			return p
+		}
+	}
+
+	// Otherwise return directly from the mmap.
+	return tx.db.page(id)
+}
+
+// forEachPage iterates over every page within a given page and executes a function.
+func (tx *Tx) forEachPage(pgid pgid, depth int, fn func(*page, int)) {
+	p := tx.page(pgid)
+
+	// Execute function.
+	fn(p, depth)
+
+	// Recursively loop over children.
+	if (p.flags & branchPageFlag) != 0 {
+		for i := 0; i < int(p.count); i++ {
+			elem := p.branchPageElement(uint16(i))
+			tx.forEachPage(elem.pgid, depth+1, fn)
+		}
+	}
+}
+
+// Page returns page information for a given page number.
+// This is only safe for concurrent use when used by a writable transaction.
+func (tx *Tx) Page(id int) (*PageInfo, error) {
+	if tx.db == nil {
+		return nil, ErrTxClosed
+	} else if pgid(id) >= tx.meta.pgid {
+		return nil, nil
+	}
+
+	// Build the page info.
+	p := tx.db.page(pgid(id))
+	info := &PageInfo{
+		ID:            id,
+		Count:         int(p.count),
+		OverflowCount: int(p.overflow),
+	}
+
+	// Determine the type (or if it's free).
+	if tx.db.freelist.freed(pgid(id)) {
+		info.Type = "free"
+	} else {
+		info.Type = p.typ()
+	}
+
+	return info, nil
+}
+
+// TxStats represents statistics about the actions performed by the transaction.
+type TxStats struct {
+	// Page statistics.
+	PageCount int // number of page allocations
+	PageAlloc int // total bytes allocated
+
+	// Cursor statistics.
+	CursorCount int // number of cursors created
+
+	// Node statistics
+	NodeCount int // number of node allocations
+	NodeDeref int // number of node dereferences
+
+	// Rebalance statistics.
+	Rebalance     int           // number of node rebalances
+	RebalanceTime time.Duration // total time spent rebalancing
+
+	// Split/Spill statistics.
+	Split     int           // number of nodes split
+	Spill     int           // number of nodes spilled
+	SpillTime time.Duration // total time spent spilling
+
+	// Write statistics.
+	Write     int           // number of writes performed
+	WriteTime time.Duration // total time spent writing to disk
+}
+
+func (s *TxStats) add(other *TxStats) {
+	s.PageCount += other.PageCount
+	s.PageAlloc += other.PageAlloc
+	s.CursorCount += other.CursorCount
+	s.NodeCount += other.NodeCount
+	s.NodeDeref += other.NodeDeref
+	s.Rebalance += other.Rebalance
+	s.RebalanceTime += other.RebalanceTime
+	s.Split += other.Split
+	s.Spill += other.Spill
+	s.SpillTime += other.SpillTime
+	s.Write += other.Write
+	s.WriteTime += other.WriteTime
+}
+
+// Sub calculates and returns the difference between two sets of transaction stats.
+// This is useful when obtaining stats at two different points and time and
+// you need the performance counters that occurred within that time span.
+func (s *TxStats) Sub(other *TxStats) TxStats {
+	var diff TxStats
+	diff.PageCount = s.PageCount - other.PageCount
+	diff.PageAlloc = s.PageAlloc - other.PageAlloc
+	diff.CursorCount = s.CursorCount - other.CursorCount
+	diff.NodeCount = s.NodeCount - other.NodeCount
+	diff.NodeDeref = s.NodeDeref - other.NodeDeref
+	diff.Rebalance = s.Rebalance - other.Rebalance
+	diff.RebalanceTime = s.RebalanceTime - other.RebalanceTime
+	diff.Split = s.Split - other.Split
+	diff.Spill = s.Spill - other.Spill
+	diff.SpillTime = s.SpillTime - other.SpillTime
+	diff.Write = s.Write - other.Write
+	diff.WriteTime = s.WriteTime - other.WriteTime
+	return diff
+}

--- a/vendor/github.com/coreos/bbolt/tx_test.go
+++ b/vendor/github.com/coreos/bbolt/tx_test.go
@@ -1,0 +1,716 @@
+package bolt_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/coreos/bbolt"
+)
+
+// Ensure that committing a closed transaction returns an error.
+func TestTx_Commit_ErrTxClosed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tx.CreateBucket([]byte("foo")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Commit(); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that rolling back a closed transaction returns an error.
+func TestTx_Rollback_ErrTxClosed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that committing a read-only transaction returns an error.
+func TestTx_Commit_ErrTxNotWritable(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	tx, err := db.Begin(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != bolt.ErrTxNotWritable {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a transaction can retrieve a cursor on the root bucket.
+func TestTx_Cursor(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := tx.CreateBucket([]byte("woojits")); err != nil {
+			t.Fatal(err)
+		}
+
+		c := tx.Cursor()
+		if k, v := c.First(); !bytes.Equal(k, []byte("widgets")) {
+			t.Fatalf("unexpected key: %v", k)
+		} else if v != nil {
+			t.Fatalf("unexpected value: %v", v)
+		}
+
+		if k, v := c.Next(); !bytes.Equal(k, []byte("woojits")) {
+			t.Fatalf("unexpected key: %v", k)
+		} else if v != nil {
+			t.Fatalf("unexpected value: %v", v)
+		}
+
+		if k, v := c.Next(); k != nil {
+			t.Fatalf("unexpected key: %v", k)
+		} else if v != nil {
+			t.Fatalf("unexpected value: %v", k)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that creating a bucket with a read-only transaction returns an error.
+func TestTx_CreateBucket_ErrTxNotWritable(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.View(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("foo"))
+		if err != bolt.ErrTxNotWritable {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that creating a bucket on a closed transaction returns an error.
+func TestTx_CreateBucket_ErrTxClosed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tx.CreateBucket([]byte("foo")); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that a Tx can retrieve a bucket.
+func TestTx_Bucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		if tx.Bucket([]byte("widgets")) == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a Tx retrieving a non-existent key returns nil.
+func TestTx_Get_NotFound(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if b.Get([]byte("no_such_key")) != nil {
+			t.Fatal("expected nil value")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can be created and retrieved.
+func TestTx_CreateBucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Create a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		} else if b == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the bucket through a separate transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte("widgets")) == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can be created if it doesn't already exist.
+func TestTx_CreateBucketIfNotExists(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create bucket.
+		if b, err := tx.CreateBucketIfNotExists([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		} else if b == nil {
+			t.Fatal("expected bucket")
+		}
+
+		// Create bucket again.
+		if b, err := tx.CreateBucketIfNotExists([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		} else if b == nil {
+			t.Fatal("expected bucket")
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the bucket through a separate transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte("widgets")) == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure transaction returns an error if creating an unnamed bucket.
+func TestTx_CreateBucketIfNotExists_ErrBucketNameRequired(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists([]byte{}); err != bolt.ErrBucketNameRequired {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if _, err := tx.CreateBucketIfNotExists(nil); err != bolt.ErrBucketNameRequired {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket cannot be created twice.
+func TestTx_CreateBucket_ErrBucketExists(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Create a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the same bucket again.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != bolt.ErrBucketExists {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket is created with a non-blank name.
+func TestTx_CreateBucket_ErrBucketNameRequired(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucket(nil); err != bolt.ErrBucketNameRequired {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can be deleted.
+func TestTx_DeleteBucket(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	// Create a bucket and add a value.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the bucket and make sure we can't get the value.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		if tx.Bucket([]byte("widgets")) != nil {
+			t.Fatal("unexpected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		// Create the bucket again and make sure there's not a phantom value.
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v := b.Get([]byte("foo")); v != nil {
+			t.Fatalf("unexpected phantom value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that deleting a bucket on a closed transaction returns an error.
+func TestTx_DeleteBucket_ErrTxClosed(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	tx, err := db.Begin(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.DeleteBucket([]byte("foo")); err != bolt.ErrTxClosed {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure that deleting a bucket with a read-only transaction returns an error.
+func TestTx_DeleteBucket_ReadOnly(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.View(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket([]byte("foo")); err != bolt.ErrTxNotWritable {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that nothing happens when deleting a bucket that doesn't exist.
+func TestTx_DeleteBucket_NotFound(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket([]byte("widgets")); err != bolt.ErrBucketNotFound {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that no error is returned when a tx.ForEach function does not return
+// an error.
+func TestTx_ForEach_NoError(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that an error is returned when a tx.ForEach function returns an error.
+func TestTx_ForEach_WithError(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+
+		marker := errors.New("marker")
+		if err := tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return marker
+		}); err != marker {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that Tx commit handlers are called after a transaction successfully commits.
+func TestTx_OnCommit(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var x int
+	if err := db.Update(func(tx *bolt.Tx) error {
+		tx.OnCommit(func() { x += 1 })
+		tx.OnCommit(func() { x += 2 })
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if x != 3 {
+		t.Fatalf("unexpected x: %d", x)
+	}
+}
+
+// Ensure that Tx commit handlers are NOT called after a transaction rolls back.
+func TestTx_OnCommit_Rollback(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	var x int
+	if err := db.Update(func(tx *bolt.Tx) error {
+		tx.OnCommit(func() { x += 1 })
+		tx.OnCommit(func() { x += 2 })
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
+			t.Fatal(err)
+		}
+		return errors.New("rollback this commit")
+	}); err == nil || err.Error() != "rollback this commit" {
+		t.Fatalf("unexpected error: %s", err)
+	} else if x != 0 {
+		t.Fatalf("unexpected x: %d", x)
+	}
+}
+
+// Ensure that the database can be copied to a file path.
+func TestTx_CopyFile(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	path := tempfile()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.CopyFile(path, 0600)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db2, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db2.View(func(tx *bolt.Tx) error {
+		if v := tx.Bucket([]byte("widgets")).Get([]byte("foo")); !bytes.Equal(v, []byte("bar")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		if v := tx.Bucket([]byte("widgets")).Get([]byte("baz")); !bytes.Equal(v, []byte("bat")) {
+			t.Fatalf("unexpected value: %v", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db2.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type failWriterError struct{}
+
+func (failWriterError) Error() string {
+	return "error injected for tests"
+}
+
+type failWriter struct {
+	// fail after this many bytes
+	After int
+}
+
+func (f *failWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	if n > f.After {
+		n = f.After
+		err = failWriterError{}
+	}
+	f.After -= n
+	return n, err
+}
+
+// Ensure that Copy handles write errors right.
+func TestTx_CopyFile_Error_Meta(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.Copy(&failWriter{})
+	}); err == nil || err.Error() != "meta 0 copy: error injected for tests" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Ensure that Copy handles write errors right.
+func TestTx_CopyFile_Error_Normal(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.Copy(&failWriter{3 * db.Info().PageSize})
+	}); err == nil || err.Error() != "error injected for tests" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func ExampleTx_Rollback() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Create a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte("widgets"))
+		return err
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set a value for a key.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("widgets")).Put([]byte("foo"), []byte("bar"))
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Update the key but rollback the transaction so it never saves.
+	tx, err := db.Begin(true)
+	if err != nil {
+		log.Fatal(err)
+	}
+	b := tx.Bucket([]byte("widgets"))
+	if err := b.Put([]byte("foo"), []byte("baz")); err != nil {
+		log.Fatal(err)
+	}
+	if err := tx.Rollback(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Ensure that our original value is still set.
+	if err := db.View(func(tx *bolt.Tx) error {
+		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		fmt.Printf("The value for 'foo' is still: %s\n", value)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// The value for 'foo' is still: bar
+}
+
+func ExampleTx_CopyFile() {
+	// Open the database.
+	db, err := bolt.Open(tempfile(), 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(db.Path())
+
+	// Create a bucket and a key.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			return err
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Copy the database to another file.
+	toFile := tempfile()
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.CopyFile(toFile, 0666)
+	}); err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(toFile)
+
+	// Open the cloned database.
+	db2, err := bolt.Open(toFile, 0666, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Ensure that the key exists in the copy.
+	if err := db2.View(func(tx *bolt.Tx) error {
+		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+		fmt.Printf("The value for 'foo' in the clone is: %s\n", value)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Close database to release file lock.
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := db2.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// The value for 'foo' in the clone is: bar
+}

--- a/vendor/github.com/patrickmn/go-cache/CONTRIBUTORS
+++ b/vendor/github.com/patrickmn/go-cache/CONTRIBUTORS
@@ -1,0 +1,9 @@
+This is a list of people who have contributed code to go-cache. They, or their
+employers, are the copyright holders of the contributed code. Contributed code
+is subject to the license restrictions listed in LICENSE (as they were when the
+code was contributed.)
+
+Dustin Sallings <dustin@spy.net>
+Jason Mooberry <jasonmoo@me.com>
+Sergey Shepelev <temotor@gmail.com>
+Alex Edwards <ajmedwards@gmail.com>

--- a/vendor/github.com/patrickmn/go-cache/LICENSE
+++ b/vendor/github.com/patrickmn/go-cache/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/patrickmn/go-cache/README.md
+++ b/vendor/github.com/patrickmn/go-cache/README.md
@@ -1,0 +1,83 @@
+# go-cache
+
+go-cache is an in-memory key:value store/cache similar to memcached that is
+suitable for applications running on a single machine. Its major advantage is
+that, being essentially a thread-safe `map[string]interface{}` with expiration
+times, it doesn't need to serialize or transmit its contents over the network.
+
+Any object can be stored, for a given duration or forever, and the cache can be
+safely used by multiple goroutines.
+
+Although go-cache isn't meant to be used as a persistent datastore, the entire
+cache can be saved to and loaded from a file (using `c.Items()` to retrieve the
+items map to serialize, and `NewFrom()` to create a cache from a deserialized
+one) to recover from downtime quickly. (See the docs for `NewFrom()` for caveats.)
+
+### Installation
+
+`go get github.com/patrickmn/go-cache`
+
+### Usage
+
+```go
+import (
+	"fmt"
+	"github.com/patrickmn/go-cache"
+	"time"
+)
+
+func main() {
+	// Create a cache with a default expiration time of 5 minutes, and which
+	// purges expired items every 10 minutes
+	c := cache.New(5*time.Minute, 10*time.Minute)
+
+	// Set the value of the key "foo" to "bar", with the default expiration time
+	c.Set("foo", "bar", cache.DefaultExpiration)
+
+	// Set the value of the key "baz" to 42, with no expiration time
+	// (the item won't be removed until it is re-set, or removed using
+	// c.Delete("baz")
+	c.Set("baz", 42, cache.NoExpiration)
+
+	// Get the string associated with the key "foo" from the cache
+	foo, found := c.Get("foo")
+	if found {
+		fmt.Println(foo)
+	}
+
+	// Since Go is statically typed, and cache values can be anything, type
+	// assertion is needed when values are being passed to functions that don't
+	// take arbitrary types, (i.e. interface{}). The simplest way to do this for
+	// values which will only be used once--e.g. for passing to another
+	// function--is:
+	foo, found := c.Get("foo")
+	if found {
+		MyFunction(foo.(string))
+	}
+
+	// This gets tedious if the value is used several times in the same function.
+	// You might do either of the following instead:
+	if x, found := c.Get("foo"); found {
+		foo := x.(string)
+		// ...
+	}
+	// or
+	var foo string
+	if x, found := c.Get("foo"); found {
+		foo = x.(string)
+	}
+	// ...
+	// foo can then be passed around freely as a string
+
+	// Want performance? Store pointers!
+	c.Set("foo", &MyStruct, cache.DefaultExpiration)
+	if x, found := c.Get("foo"); found {
+		foo := x.(*MyStruct)
+			// ...
+	}
+}
+```
+
+### Reference
+
+`godoc` or [http://godoc.org/github.com/patrickmn/go-cache](http://godoc.org/github.com/patrickmn/go-cache)

--- a/vendor/github.com/patrickmn/go-cache/cache.go
+++ b/vendor/github.com/patrickmn/go-cache/cache.go
@@ -1,0 +1,1161 @@
+package cache
+
+import (
+	"encoding/gob"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+)
+
+type Item struct {
+	Object     interface{}
+	Expiration int64
+}
+
+// Returns true if the item has expired.
+func (item Item) Expired() bool {
+	if item.Expiration == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.Expiration
+}
+
+const (
+	// For use with functions that take an expiration time.
+	NoExpiration time.Duration = -1
+	// For use with functions that take an expiration time. Equivalent to
+	// passing in the same expiration duration as was given to New() or
+	// NewFrom() when the cache was created (e.g. 5 minutes.)
+	DefaultExpiration time.Duration = 0
+)
+
+type Cache struct {
+	*cache
+	// If this is confusing, see the comment at the bottom of New()
+}
+
+type cache struct {
+	defaultExpiration time.Duration
+	items             map[string]Item
+	mu                sync.RWMutex
+	onEvicted         func(string, interface{})
+	janitor           *janitor
+}
+
+// Add an item to the cache, replacing any existing item. If the duration is 0
+// (DefaultExpiration), the cache's default expiration time is used. If it is -1
+// (NoExpiration), the item never expires.
+func (c *cache) Set(k string, x interface{}, d time.Duration) {
+	// "Inlining" of set
+	var e int64
+	if d == DefaultExpiration {
+		d = c.defaultExpiration
+	}
+	if d > 0 {
+		e = time.Now().Add(d).UnixNano()
+	}
+	c.mu.Lock()
+	c.items[k] = Item{
+		Object:     x,
+		Expiration: e,
+	}
+	// TODO: Calls to mu.Unlock are currently not deferred because defer
+	// adds ~200 ns (as of go1.)
+	c.mu.Unlock()
+}
+
+func (c *cache) set(k string, x interface{}, d time.Duration) {
+	var e int64
+	if d == DefaultExpiration {
+		d = c.defaultExpiration
+	}
+	if d > 0 {
+		e = time.Now().Add(d).UnixNano()
+	}
+	c.items[k] = Item{
+		Object:     x,
+		Expiration: e,
+	}
+}
+
+// Add an item to the cache, replacing any existing item, using the default
+// expiration.
+func (c *cache) SetDefault(k string, x interface{}) {
+	c.Set(k, x, DefaultExpiration)
+}
+
+// Add an item to the cache only if an item doesn't already exist for the given
+// key, or if the existing item has expired. Returns an error otherwise.
+func (c *cache) Add(k string, x interface{}, d time.Duration) error {
+	c.mu.Lock()
+	_, found := c.get(k)
+	if found {
+		c.mu.Unlock()
+		return fmt.Errorf("Item %s already exists", k)
+	}
+	c.set(k, x, d)
+	c.mu.Unlock()
+	return nil
+}
+
+// Set a new value for the cache key only if it already exists, and the existing
+// item hasn't expired. Returns an error otherwise.
+func (c *cache) Replace(k string, x interface{}, d time.Duration) error {
+	c.mu.Lock()
+	_, found := c.get(k)
+	if !found {
+		c.mu.Unlock()
+		return fmt.Errorf("Item %s doesn't exist", k)
+	}
+	c.set(k, x, d)
+	c.mu.Unlock()
+	return nil
+}
+
+// Get an item from the cache. Returns the item or nil, and a bool indicating
+// whether the key was found.
+func (c *cache) Get(k string) (interface{}, bool) {
+	c.mu.RLock()
+	// "Inlining" of get and Expired
+	item, found := c.items[k]
+	if !found {
+		c.mu.RUnlock()
+		return nil, false
+	}
+	if item.Expiration > 0 {
+		if time.Now().UnixNano() > item.Expiration {
+			c.mu.RUnlock()
+			return nil, false
+		}
+	}
+	c.mu.RUnlock()
+	return item.Object, true
+}
+
+// GetWithExpiration returns an item and its expiration time from the cache.
+// It returns the item or nil, the expiration time if one is set (if the item
+// never expires a zero value for time.Time is returned), and a bool indicating
+// whether the key was found.
+func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
+	c.mu.RLock()
+	// "Inlining" of get and Expired
+	item, found := c.items[k]
+	if !found {
+		c.mu.RUnlock()
+		return nil, time.Time{}, false
+	}
+
+	if item.Expiration > 0 {
+		if time.Now().UnixNano() > item.Expiration {
+			c.mu.RUnlock()
+			return nil, time.Time{}, false
+		}
+
+		// Return the item and the expiration time
+		c.mu.RUnlock()
+		return item.Object, time.Unix(0, item.Expiration), true
+	}
+
+	// If expiration <= 0 (i.e. no expiration time set) then return the item
+	// and a zeroed time.Time
+	c.mu.RUnlock()
+	return item.Object, time.Time{}, true
+}
+
+func (c *cache) get(k string) (interface{}, bool) {
+	item, found := c.items[k]
+	if !found {
+		return nil, false
+	}
+	// "Inlining" of Expired
+	if item.Expiration > 0 {
+		if time.Now().UnixNano() > item.Expiration {
+			return nil, false
+		}
+	}
+	return item.Object, true
+}
+
+// Increment an item of type int, int8, int16, int32, int64, uintptr, uint,
+// uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
+// item's value is not an integer, if it was not found, or if it is not
+// possible to increment it by n. To retrieve the incremented value, use one
+// of the specialized methods, e.g. IncrementInt64.
+func (c *cache) Increment(k string, n int64) error {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return fmt.Errorf("Item %s not found", k)
+	}
+	switch v.Object.(type) {
+	case int:
+		v.Object = v.Object.(int) + int(n)
+	case int8:
+		v.Object = v.Object.(int8) + int8(n)
+	case int16:
+		v.Object = v.Object.(int16) + int16(n)
+	case int32:
+		v.Object = v.Object.(int32) + int32(n)
+	case int64:
+		v.Object = v.Object.(int64) + n
+	case uint:
+		v.Object = v.Object.(uint) + uint(n)
+	case uintptr:
+		v.Object = v.Object.(uintptr) + uintptr(n)
+	case uint8:
+		v.Object = v.Object.(uint8) + uint8(n)
+	case uint16:
+		v.Object = v.Object.(uint16) + uint16(n)
+	case uint32:
+		v.Object = v.Object.(uint32) + uint32(n)
+	case uint64:
+		v.Object = v.Object.(uint64) + uint64(n)
+	case float32:
+		v.Object = v.Object.(float32) + float32(n)
+	case float64:
+		v.Object = v.Object.(float64) + float64(n)
+	default:
+		c.mu.Unlock()
+		return fmt.Errorf("The value for %s is not an integer", k)
+	}
+	c.items[k] = v
+	c.mu.Unlock()
+	return nil
+}
+
+// Increment an item of type float32 or float64 by n. Returns an error if the
+// item's value is not floating point, if it was not found, or if it is not
+// possible to increment it by n. Pass a negative number to decrement the
+// value. To retrieve the incremented value, use one of the specialized methods,
+// e.g. IncrementFloat64.
+func (c *cache) IncrementFloat(k string, n float64) error {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return fmt.Errorf("Item %s not found", k)
+	}
+	switch v.Object.(type) {
+	case float32:
+		v.Object = v.Object.(float32) + float32(n)
+	case float64:
+		v.Object = v.Object.(float64) + n
+	default:
+		c.mu.Unlock()
+		return fmt.Errorf("The value for %s does not have type float32 or float64", k)
+	}
+	c.items[k] = v
+	c.mu.Unlock()
+	return nil
+}
+
+// Increment an item of type int by n. Returns an error if the item's value is
+// not an int, or if it was not found. If there is no error, the incremented
+// value is returned.
+func (c *cache) IncrementInt(k string, n int) (int, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type int8 by n. Returns an error if the item's value is
+// not an int8, or if it was not found. If there is no error, the incremented
+// value is returned.
+func (c *cache) IncrementInt8(k string, n int8) (int8, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int8)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int8", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type int16 by n. Returns an error if the item's value is
+// not an int16, or if it was not found. If there is no error, the incremented
+// value is returned.
+func (c *cache) IncrementInt16(k string, n int16) (int16, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int16)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int16", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type int32 by n. Returns an error if the item's value is
+// not an int32, or if it was not found. If there is no error, the incremented
+// value is returned.
+func (c *cache) IncrementInt32(k string, n int32) (int32, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int32)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int32", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type int64 by n. Returns an error if the item's value is
+// not an int64, or if it was not found. If there is no error, the incremented
+// value is returned.
+func (c *cache) IncrementInt64(k string, n int64) (int64, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int64)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int64", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type uint by n. Returns an error if the item's value is
+// not an uint, or if it was not found. If there is no error, the incremented
+// value is returned.
+func (c *cache) IncrementUint(k string, n uint) (uint, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type uintptr by n. Returns an error if the item's value
+// is not an uintptr, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementUintptr(k string, n uintptr) (uintptr, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uintptr)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uintptr", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type uint8 by n. Returns an error if the item's value
+// is not an uint8, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementUint8(k string, n uint8) (uint8, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint8)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint8", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type uint16 by n. Returns an error if the item's value
+// is not an uint16, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementUint16(k string, n uint16) (uint16, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint16)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint16", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type uint32 by n. Returns an error if the item's value
+// is not an uint32, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementUint32(k string, n uint32) (uint32, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint32)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint32", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type uint64 by n. Returns an error if the item's value
+// is not an uint64, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementUint64(k string, n uint64) (uint64, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint64)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint64", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type float32 by n. Returns an error if the item's value
+// is not an float32, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementFloat32(k string, n float32) (float32, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(float32)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an float32", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Increment an item of type float64 by n. Returns an error if the item's value
+// is not an float64, or if it was not found. If there is no error, the
+// incremented value is returned.
+func (c *cache) IncrementFloat64(k string, n float64) (float64, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(float64)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an float64", k)
+	}
+	nv := rv + n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type int, int8, int16, int32, int64, uintptr, uint,
+// uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
+// item's value is not an integer, if it was not found, or if it is not
+// possible to decrement it by n. To retrieve the decremented value, use one
+// of the specialized methods, e.g. DecrementInt64.
+func (c *cache) Decrement(k string, n int64) error {
+	// TODO: Implement Increment and Decrement more cleanly.
+	// (Cannot do Increment(k, n*-1) for uints.)
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return fmt.Errorf("Item not found")
+	}
+	switch v.Object.(type) {
+	case int:
+		v.Object = v.Object.(int) - int(n)
+	case int8:
+		v.Object = v.Object.(int8) - int8(n)
+	case int16:
+		v.Object = v.Object.(int16) - int16(n)
+	case int32:
+		v.Object = v.Object.(int32) - int32(n)
+	case int64:
+		v.Object = v.Object.(int64) - n
+	case uint:
+		v.Object = v.Object.(uint) - uint(n)
+	case uintptr:
+		v.Object = v.Object.(uintptr) - uintptr(n)
+	case uint8:
+		v.Object = v.Object.(uint8) - uint8(n)
+	case uint16:
+		v.Object = v.Object.(uint16) - uint16(n)
+	case uint32:
+		v.Object = v.Object.(uint32) - uint32(n)
+	case uint64:
+		v.Object = v.Object.(uint64) - uint64(n)
+	case float32:
+		v.Object = v.Object.(float32) - float32(n)
+	case float64:
+		v.Object = v.Object.(float64) - float64(n)
+	default:
+		c.mu.Unlock()
+		return fmt.Errorf("The value for %s is not an integer", k)
+	}
+	c.items[k] = v
+	c.mu.Unlock()
+	return nil
+}
+
+// Decrement an item of type float32 or float64 by n. Returns an error if the
+// item's value is not floating point, if it was not found, or if it is not
+// possible to decrement it by n. Pass a negative number to decrement the
+// value. To retrieve the decremented value, use one of the specialized methods,
+// e.g. DecrementFloat64.
+func (c *cache) DecrementFloat(k string, n float64) error {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return fmt.Errorf("Item %s not found", k)
+	}
+	switch v.Object.(type) {
+	case float32:
+		v.Object = v.Object.(float32) - float32(n)
+	case float64:
+		v.Object = v.Object.(float64) - n
+	default:
+		c.mu.Unlock()
+		return fmt.Errorf("The value for %s does not have type float32 or float64", k)
+	}
+	c.items[k] = v
+	c.mu.Unlock()
+	return nil
+}
+
+// Decrement an item of type int by n. Returns an error if the item's value is
+// not an int, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementInt(k string, n int) (int, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type int8 by n. Returns an error if the item's value is
+// not an int8, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementInt8(k string, n int8) (int8, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int8)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int8", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type int16 by n. Returns an error if the item's value is
+// not an int16, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementInt16(k string, n int16) (int16, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int16)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int16", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type int32 by n. Returns an error if the item's value is
+// not an int32, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementInt32(k string, n int32) (int32, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int32)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int32", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type int64 by n. Returns an error if the item's value is
+// not an int64, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementInt64(k string, n int64) (int64, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(int64)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an int64", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type uint by n. Returns an error if the item's value is
+// not an uint, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementUint(k string, n uint) (uint, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type uintptr by n. Returns an error if the item's value
+// is not an uintptr, or if it was not found. If there is no error, the
+// decremented value is returned.
+func (c *cache) DecrementUintptr(k string, n uintptr) (uintptr, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uintptr)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uintptr", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type uint8 by n. Returns an error if the item's value is
+// not an uint8, or if it was not found. If there is no error, the decremented
+// value is returned.
+func (c *cache) DecrementUint8(k string, n uint8) (uint8, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint8)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint8", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type uint16 by n. Returns an error if the item's value
+// is not an uint16, or if it was not found. If there is no error, the
+// decremented value is returned.
+func (c *cache) DecrementUint16(k string, n uint16) (uint16, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint16)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint16", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type uint32 by n. Returns an error if the item's value
+// is not an uint32, or if it was not found. If there is no error, the
+// decremented value is returned.
+func (c *cache) DecrementUint32(k string, n uint32) (uint32, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint32)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint32", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type uint64 by n. Returns an error if the item's value
+// is not an uint64, or if it was not found. If there is no error, the
+// decremented value is returned.
+func (c *cache) DecrementUint64(k string, n uint64) (uint64, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(uint64)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an uint64", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type float32 by n. Returns an error if the item's value
+// is not an float32, or if it was not found. If there is no error, the
+// decremented value is returned.
+func (c *cache) DecrementFloat32(k string, n float32) (float32, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(float32)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an float32", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Decrement an item of type float64 by n. Returns an error if the item's value
+// is not an float64, or if it was not found. If there is no error, the
+// decremented value is returned.
+func (c *cache) DecrementFloat64(k string, n float64) (float64, error) {
+	c.mu.Lock()
+	v, found := c.items[k]
+	if !found || v.Expired() {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("Item %s not found", k)
+	}
+	rv, ok := v.Object.(float64)
+	if !ok {
+		c.mu.Unlock()
+		return 0, fmt.Errorf("The value for %s is not an float64", k)
+	}
+	nv := rv - n
+	v.Object = nv
+	c.items[k] = v
+	c.mu.Unlock()
+	return nv, nil
+}
+
+// Delete an item from the cache. Does nothing if the key is not in the cache.
+func (c *cache) Delete(k string) {
+	c.mu.Lock()
+	v, evicted := c.delete(k)
+	c.mu.Unlock()
+	if evicted {
+		c.onEvicted(k, v)
+	}
+}
+
+func (c *cache) delete(k string) (interface{}, bool) {
+	if c.onEvicted != nil {
+		if v, found := c.items[k]; found {
+			delete(c.items, k)
+			return v.Object, true
+		}
+	}
+	delete(c.items, k)
+	return nil, false
+}
+
+type keyAndValue struct {
+	key   string
+	value interface{}
+}
+
+// Delete all expired items from the cache.
+func (c *cache) DeleteExpired() {
+	var evictedItems []keyAndValue
+	now := time.Now().UnixNano()
+	c.mu.Lock()
+	for k, v := range c.items {
+		// "Inlining" of expired
+		if v.Expiration > 0 && now > v.Expiration {
+			ov, evicted := c.delete(k)
+			if evicted {
+				evictedItems = append(evictedItems, keyAndValue{k, ov})
+			}
+		}
+	}
+	c.mu.Unlock()
+	for _, v := range evictedItems {
+		c.onEvicted(v.key, v.value)
+	}
+}
+
+// Sets an (optional) function that is called with the key and value when an
+// item is evicted from the cache. (Including when it is deleted manually, but
+// not when it is overwritten.) Set to nil to disable.
+func (c *cache) OnEvicted(f func(string, interface{})) {
+	c.mu.Lock()
+	c.onEvicted = f
+	c.mu.Unlock()
+}
+
+// Write the cache's items (using Gob) to an io.Writer.
+//
+// NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
+// documentation for NewFrom().)
+func (c *cache) Save(w io.Writer) (err error) {
+	enc := gob.NewEncoder(w)
+	defer func() {
+		if x := recover(); x != nil {
+			err = fmt.Errorf("Error registering item types with Gob library")
+		}
+	}()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, v := range c.items {
+		gob.Register(v.Object)
+	}
+	err = enc.Encode(&c.items)
+	return
+}
+
+// Save the cache's items to the given filename, creating the file if it
+// doesn't exist, and overwriting it if it does.
+//
+// NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
+// documentation for NewFrom().)
+func (c *cache) SaveFile(fname string) error {
+	fp, err := os.Create(fname)
+	if err != nil {
+		return err
+	}
+	err = c.Save(fp)
+	if err != nil {
+		fp.Close()
+		return err
+	}
+	return fp.Close()
+}
+
+// Add (Gob-serialized) cache items from an io.Reader, excluding any items with
+// keys that already exist (and haven't expired) in the current cache.
+//
+// NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
+// documentation for NewFrom().)
+func (c *cache) Load(r io.Reader) error {
+	dec := gob.NewDecoder(r)
+	items := map[string]Item{}
+	err := dec.Decode(&items)
+	if err == nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		for k, v := range items {
+			ov, found := c.items[k]
+			if !found || ov.Expired() {
+				c.items[k] = v
+			}
+		}
+	}
+	return err
+}
+
+// Load and add cache items from the given filename, excluding any items with
+// keys that already exist in the current cache.
+//
+// NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
+// documentation for NewFrom().)
+func (c *cache) LoadFile(fname string) error {
+	fp, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+	err = c.Load(fp)
+	if err != nil {
+		fp.Close()
+		return err
+	}
+	return fp.Close()
+}
+
+// Copies all unexpired items in the cache into a new map and returns it.
+func (c *cache) Items() map[string]Item {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m := make(map[string]Item, len(c.items))
+	now := time.Now().UnixNano()
+	for k, v := range c.items {
+		// "Inlining" of Expired
+		if v.Expiration > 0 {
+			if now > v.Expiration {
+				continue
+			}
+		}
+		m[k] = v
+	}
+	return m
+}
+
+// Returns the number of items in the cache. This may include items that have
+// expired, but have not yet been cleaned up.
+func (c *cache) ItemCount() int {
+	c.mu.RLock()
+	n := len(c.items)
+	c.mu.RUnlock()
+	return n
+}
+
+// Delete all items from the cache.
+func (c *cache) Flush() {
+	c.mu.Lock()
+	c.items = map[string]Item{}
+	c.mu.Unlock()
+}
+
+type janitor struct {
+	Interval time.Duration
+	stop     chan bool
+}
+
+func (j *janitor) Run(c *cache) {
+	ticker := time.NewTicker(j.Interval)
+	for {
+		select {
+		case <-ticker.C:
+			c.DeleteExpired()
+		case <-j.stop:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func stopJanitor(c *Cache) {
+	c.janitor.stop <- true
+}
+
+func runJanitor(c *cache, ci time.Duration) {
+	j := &janitor{
+		Interval: ci,
+		stop:     make(chan bool),
+	}
+	c.janitor = j
+	go j.Run(c)
+}
+
+func newCache(de time.Duration, m map[string]Item) *cache {
+	if de == 0 {
+		de = -1
+	}
+	c := &cache{
+		defaultExpiration: de,
+		items:             m,
+	}
+	return c
+}
+
+func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]Item) *Cache {
+	c := newCache(de, m)
+	// This trick ensures that the janitor goroutine (which--granted it
+	// was enabled--is running DeleteExpired on c forever) does not keep
+	// the returned C object from being garbage collected. When it is
+	// garbage collected, the finalizer stops the janitor goroutine, after
+	// which c can be collected.
+	C := &Cache{c}
+	if ci > 0 {
+		runJanitor(c, ci)
+		runtime.SetFinalizer(C, stopJanitor)
+	}
+	return C
+}
+
+// Return a new cache with a given default expiration duration and cleanup
+// interval. If the expiration duration is less than one (or NoExpiration),
+// the items in the cache never expire (by default), and must be deleted
+// manually. If the cleanup interval is less than one, expired items are not
+// deleted from the cache before calling c.DeleteExpired().
+func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
+	items := make(map[string]Item)
+	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
+}
+
+// Return a new cache with a given default expiration duration and cleanup
+// interval. If the expiration duration is less than one (or NoExpiration),
+// the items in the cache never expire (by default), and must be deleted
+// manually. If the cleanup interval is less than one, expired items are not
+// deleted from the cache before calling c.DeleteExpired().
+//
+// NewFrom() also accepts an items map which will serve as the underlying map
+// for the cache. This is useful for starting from a deserialized cache
+// (serialized using e.g. gob.Encode() on c.Items()), or passing in e.g.
+// make(map[string]Item, 500) to improve startup performance when the cache
+// is expected to reach a certain minimum size.
+//
+// Only the cache's methods synchronize access to this map, so it is not
+// recommended to keep any references to the map around after creating a cache.
+// If need be, the map can be accessed at a later point using c.Items() (subject
+// to the same caveat.)
+//
+// Note regarding serialization: When using e.g. gob, make sure to
+// gob.Register() the individual types stored in the cache before encoding a
+// map retrieved with c.Items(), and to register those same types before
+// decoding a blob containing an items map.
+func NewFrom(defaultExpiration, cleanupInterval time.Duration, items map[string]Item) *Cache {
+	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
+}

--- a/vendor/github.com/patrickmn/go-cache/cache_test.go
+++ b/vendor/github.com/patrickmn/go-cache/cache_test.go
@@ -1,0 +1,1771 @@
+package cache
+
+import (
+	"bytes"
+	"io/ioutil"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+type TestStruct struct {
+	Num      int
+	Children []*TestStruct
+}
+
+func TestCache(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+
+	a, found := tc.Get("a")
+	if found || a != nil {
+		t.Error("Getting A found value that shouldn't exist:", a)
+	}
+
+	b, found := tc.Get("b")
+	if found || b != nil {
+		t.Error("Getting B found value that shouldn't exist:", b)
+	}
+
+	c, found := tc.Get("c")
+	if found || c != nil {
+		t.Error("Getting C found value that shouldn't exist:", c)
+	}
+
+	tc.Set("a", 1, DefaultExpiration)
+	tc.Set("b", "b", DefaultExpiration)
+	tc.Set("c", 3.5, DefaultExpiration)
+
+	x, found := tc.Get("a")
+	if !found {
+		t.Error("a was not found while getting a2")
+	}
+	if x == nil {
+		t.Error("x for a is nil")
+	} else if a2 := x.(int); a2+2 != 3 {
+		t.Error("a2 (which should be 1) plus 2 does not equal 3; value:", a2)
+	}
+
+	x, found = tc.Get("b")
+	if !found {
+		t.Error("b was not found while getting b2")
+	}
+	if x == nil {
+		t.Error("x for b is nil")
+	} else if b2 := x.(string); b2+"B" != "bB" {
+		t.Error("b2 (which should be b) plus B does not equal bB; value:", b2)
+	}
+
+	x, found = tc.Get("c")
+	if !found {
+		t.Error("c was not found while getting c2")
+	}
+	if x == nil {
+		t.Error("x for c is nil")
+	} else if c2 := x.(float64); c2+1.2 != 4.7 {
+		t.Error("c2 (which should be 3.5) plus 1.2 does not equal 4.7; value:", c2)
+	}
+}
+
+func TestCacheTimes(t *testing.T) {
+	var found bool
+
+	tc := New(50*time.Millisecond, 1*time.Millisecond)
+	tc.Set("a", 1, DefaultExpiration)
+	tc.Set("b", 2, NoExpiration)
+	tc.Set("c", 3, 20*time.Millisecond)
+	tc.Set("d", 4, 70*time.Millisecond)
+
+	<-time.After(25 * time.Millisecond)
+	_, found = tc.Get("c")
+	if found {
+		t.Error("Found c when it should have been automatically deleted")
+	}
+
+	<-time.After(30 * time.Millisecond)
+	_, found = tc.Get("a")
+	if found {
+		t.Error("Found a when it should have been automatically deleted")
+	}
+
+	_, found = tc.Get("b")
+	if !found {
+		t.Error("Did not find b even though it was set to never expire")
+	}
+
+	_, found = tc.Get("d")
+	if !found {
+		t.Error("Did not find d even though it was set to expire later than the default")
+	}
+
+	<-time.After(20 * time.Millisecond)
+	_, found = tc.Get("d")
+	if found {
+		t.Error("Found d when it should have been automatically deleted (later than the default)")
+	}
+}
+
+func TestNewFrom(t *testing.T) {
+	m := map[string]Item{
+		"a": Item{
+			Object:     1,
+			Expiration: 0,
+		},
+		"b": Item{
+			Object:     2,
+			Expiration: 0,
+		},
+	}
+	tc := NewFrom(DefaultExpiration, 0, m)
+	a, found := tc.Get("a")
+	if !found {
+		t.Fatal("Did not find a")
+	}
+	if a.(int) != 1 {
+		t.Fatal("a is not 1")
+	}
+	b, found := tc.Get("b")
+	if !found {
+		t.Fatal("Did not find b")
+	}
+	if b.(int) != 2 {
+		t.Fatal("b is not 2")
+	}
+}
+
+func TestStorePointerToStruct(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", &TestStruct{Num: 1}, DefaultExpiration)
+	x, found := tc.Get("foo")
+	if !found {
+		t.Fatal("*TestStruct was not found for foo")
+	}
+	foo := x.(*TestStruct)
+	foo.Num++
+
+	y, found := tc.Get("foo")
+	if !found {
+		t.Fatal("*TestStruct was not found for foo (second time)")
+	}
+	bar := y.(*TestStruct)
+	if bar.Num != 2 {
+		t.Fatal("TestStruct.Num is not 2")
+	}
+}
+
+func TestIncrementWithInt(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint", 1, DefaultExpiration)
+	err := tc.Increment("tint", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tint")
+	if !found {
+		t.Error("tint was not found")
+	}
+	if x.(int) != 3 {
+		t.Error("tint is not 3:", x)
+	}
+}
+
+func TestIncrementWithInt8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint8", int8(1), DefaultExpiration)
+	err := tc.Increment("tint8", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tint8")
+	if !found {
+		t.Error("tint8 was not found")
+	}
+	if x.(int8) != 3 {
+		t.Error("tint8 is not 3:", x)
+	}
+}
+
+func TestIncrementWithInt16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint16", int16(1), DefaultExpiration)
+	err := tc.Increment("tint16", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tint16")
+	if !found {
+		t.Error("tint16 was not found")
+	}
+	if x.(int16) != 3 {
+		t.Error("tint16 is not 3:", x)
+	}
+}
+
+func TestIncrementWithInt32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint32", int32(1), DefaultExpiration)
+	err := tc.Increment("tint32", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tint32")
+	if !found {
+		t.Error("tint32 was not found")
+	}
+	if x.(int32) != 3 {
+		t.Error("tint32 is not 3:", x)
+	}
+}
+
+func TestIncrementWithInt64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint64", int64(1), DefaultExpiration)
+	err := tc.Increment("tint64", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tint64")
+	if !found {
+		t.Error("tint64 was not found")
+	}
+	if x.(int64) != 3 {
+		t.Error("tint64 is not 3:", x)
+	}
+}
+
+func TestIncrementWithUint(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint", uint(1), DefaultExpiration)
+	err := tc.Increment("tuint", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tuint")
+	if !found {
+		t.Error("tuint was not found")
+	}
+	if x.(uint) != 3 {
+		t.Error("tuint is not 3:", x)
+	}
+}
+
+func TestIncrementWithUintptr(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuintptr", uintptr(1), DefaultExpiration)
+	err := tc.Increment("tuintptr", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+
+	x, found := tc.Get("tuintptr")
+	if !found {
+		t.Error("tuintptr was not found")
+	}
+	if x.(uintptr) != 3 {
+		t.Error("tuintptr is not 3:", x)
+	}
+}
+
+func TestIncrementWithUint8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint8", uint8(1), DefaultExpiration)
+	err := tc.Increment("tuint8", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tuint8")
+	if !found {
+		t.Error("tuint8 was not found")
+	}
+	if x.(uint8) != 3 {
+		t.Error("tuint8 is not 3:", x)
+	}
+}
+
+func TestIncrementWithUint16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint16", uint16(1), DefaultExpiration)
+	err := tc.Increment("tuint16", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+
+	x, found := tc.Get("tuint16")
+	if !found {
+		t.Error("tuint16 was not found")
+	}
+	if x.(uint16) != 3 {
+		t.Error("tuint16 is not 3:", x)
+	}
+}
+
+func TestIncrementWithUint32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint32", uint32(1), DefaultExpiration)
+	err := tc.Increment("tuint32", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("tuint32")
+	if !found {
+		t.Error("tuint32 was not found")
+	}
+	if x.(uint32) != 3 {
+		t.Error("tuint32 is not 3:", x)
+	}
+}
+
+func TestIncrementWithUint64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint64", uint64(1), DefaultExpiration)
+	err := tc.Increment("tuint64", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+
+	x, found := tc.Get("tuint64")
+	if !found {
+		t.Error("tuint64 was not found")
+	}
+	if x.(uint64) != 3 {
+		t.Error("tuint64 is not 3:", x)
+	}
+}
+
+func TestIncrementWithFloat32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float32", float32(1.5), DefaultExpiration)
+	err := tc.Increment("float32", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("float32")
+	if !found {
+		t.Error("float32 was not found")
+	}
+	if x.(float32) != 3.5 {
+		t.Error("float32 is not 3.5:", x)
+	}
+}
+
+func TestIncrementWithFloat64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float64", float64(1.5), DefaultExpiration)
+	err := tc.Increment("float64", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	x, found := tc.Get("float64")
+	if !found {
+		t.Error("float64 was not found")
+	}
+	if x.(float64) != 3.5 {
+		t.Error("float64 is not 3.5:", x)
+	}
+}
+
+func TestIncrementFloatWithFloat32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float32", float32(1.5), DefaultExpiration)
+	err := tc.IncrementFloat("float32", 2)
+	if err != nil {
+		t.Error("Error incrementfloating:", err)
+	}
+	x, found := tc.Get("float32")
+	if !found {
+		t.Error("float32 was not found")
+	}
+	if x.(float32) != 3.5 {
+		t.Error("float32 is not 3.5:", x)
+	}
+}
+
+func TestIncrementFloatWithFloat64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float64", float64(1.5), DefaultExpiration)
+	err := tc.IncrementFloat("float64", 2)
+	if err != nil {
+		t.Error("Error incrementfloating:", err)
+	}
+	x, found := tc.Get("float64")
+	if !found {
+		t.Error("float64 was not found")
+	}
+	if x.(float64) != 3.5 {
+		t.Error("float64 is not 3.5:", x)
+	}
+}
+
+func TestDecrementWithInt(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int", int(5), DefaultExpiration)
+	err := tc.Decrement("int", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("int")
+	if !found {
+		t.Error("int was not found")
+	}
+	if x.(int) != 3 {
+		t.Error("int is not 3:", x)
+	}
+}
+
+func TestDecrementWithInt8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int8", int8(5), DefaultExpiration)
+	err := tc.Decrement("int8", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("int8")
+	if !found {
+		t.Error("int8 was not found")
+	}
+	if x.(int8) != 3 {
+		t.Error("int8 is not 3:", x)
+	}
+}
+
+func TestDecrementWithInt16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int16", int16(5), DefaultExpiration)
+	err := tc.Decrement("int16", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("int16")
+	if !found {
+		t.Error("int16 was not found")
+	}
+	if x.(int16) != 3 {
+		t.Error("int16 is not 3:", x)
+	}
+}
+
+func TestDecrementWithInt32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int32", int32(5), DefaultExpiration)
+	err := tc.Decrement("int32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("int32")
+	if !found {
+		t.Error("int32 was not found")
+	}
+	if x.(int32) != 3 {
+		t.Error("int32 is not 3:", x)
+	}
+}
+
+func TestDecrementWithInt64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int64", int64(5), DefaultExpiration)
+	err := tc.Decrement("int64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("int64")
+	if !found {
+		t.Error("int64 was not found")
+	}
+	if x.(int64) != 3 {
+		t.Error("int64 is not 3:", x)
+	}
+}
+
+func TestDecrementWithUint(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint", uint(5), DefaultExpiration)
+	err := tc.Decrement("uint", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("uint")
+	if !found {
+		t.Error("uint was not found")
+	}
+	if x.(uint) != 3 {
+		t.Error("uint is not 3:", x)
+	}
+}
+
+func TestDecrementWithUintptr(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uintptr", uintptr(5), DefaultExpiration)
+	err := tc.Decrement("uintptr", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("uintptr")
+	if !found {
+		t.Error("uintptr was not found")
+	}
+	if x.(uintptr) != 3 {
+		t.Error("uintptr is not 3:", x)
+	}
+}
+
+func TestDecrementWithUint8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint8", uint8(5), DefaultExpiration)
+	err := tc.Decrement("uint8", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("uint8")
+	if !found {
+		t.Error("uint8 was not found")
+	}
+	if x.(uint8) != 3 {
+		t.Error("uint8 is not 3:", x)
+	}
+}
+
+func TestDecrementWithUint16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint16", uint16(5), DefaultExpiration)
+	err := tc.Decrement("uint16", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("uint16")
+	if !found {
+		t.Error("uint16 was not found")
+	}
+	if x.(uint16) != 3 {
+		t.Error("uint16 is not 3:", x)
+	}
+}
+
+func TestDecrementWithUint32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint32", uint32(5), DefaultExpiration)
+	err := tc.Decrement("uint32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("uint32")
+	if !found {
+		t.Error("uint32 was not found")
+	}
+	if x.(uint32) != 3 {
+		t.Error("uint32 is not 3:", x)
+	}
+}
+
+func TestDecrementWithUint64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint64", uint64(5), DefaultExpiration)
+	err := tc.Decrement("uint64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("uint64")
+	if !found {
+		t.Error("uint64 was not found")
+	}
+	if x.(uint64) != 3 {
+		t.Error("uint64 is not 3:", x)
+	}
+}
+
+func TestDecrementWithFloat32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float32", float32(5.5), DefaultExpiration)
+	err := tc.Decrement("float32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("float32")
+	if !found {
+		t.Error("float32 was not found")
+	}
+	if x.(float32) != 3.5 {
+		t.Error("float32 is not 3:", x)
+	}
+}
+
+func TestDecrementWithFloat64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float64", float64(5.5), DefaultExpiration)
+	err := tc.Decrement("float64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("float64")
+	if !found {
+		t.Error("float64 was not found")
+	}
+	if x.(float64) != 3.5 {
+		t.Error("float64 is not 3:", x)
+	}
+}
+
+func TestDecrementFloatWithFloat32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float32", float32(5.5), DefaultExpiration)
+	err := tc.DecrementFloat("float32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("float32")
+	if !found {
+		t.Error("float32 was not found")
+	}
+	if x.(float32) != 3.5 {
+		t.Error("float32 is not 3:", x)
+	}
+}
+
+func TestDecrementFloatWithFloat64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float64", float64(5.5), DefaultExpiration)
+	err := tc.DecrementFloat("float64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	x, found := tc.Get("float64")
+	if !found {
+		t.Error("float64 was not found")
+	}
+	if x.(float64) != 3.5 {
+		t.Error("float64 is not 3:", x)
+	}
+}
+
+func TestIncrementInt(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint", 1, DefaultExpiration)
+	n, err := tc.IncrementInt("tint", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tint")
+	if !found {
+		t.Error("tint was not found")
+	}
+	if x.(int) != 3 {
+		t.Error("tint is not 3:", x)
+	}
+}
+
+func TestIncrementInt8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint8", int8(1), DefaultExpiration)
+	n, err := tc.IncrementInt8("tint8", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tint8")
+	if !found {
+		t.Error("tint8 was not found")
+	}
+	if x.(int8) != 3 {
+		t.Error("tint8 is not 3:", x)
+	}
+}
+
+func TestIncrementInt16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint16", int16(1), DefaultExpiration)
+	n, err := tc.IncrementInt16("tint16", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tint16")
+	if !found {
+		t.Error("tint16 was not found")
+	}
+	if x.(int16) != 3 {
+		t.Error("tint16 is not 3:", x)
+	}
+}
+
+func TestIncrementInt32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint32", int32(1), DefaultExpiration)
+	n, err := tc.IncrementInt32("tint32", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tint32")
+	if !found {
+		t.Error("tint32 was not found")
+	}
+	if x.(int32) != 3 {
+		t.Error("tint32 is not 3:", x)
+	}
+}
+
+func TestIncrementInt64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tint64", int64(1), DefaultExpiration)
+	n, err := tc.IncrementInt64("tint64", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tint64")
+	if !found {
+		t.Error("tint64 was not found")
+	}
+	if x.(int64) != 3 {
+		t.Error("tint64 is not 3:", x)
+	}
+}
+
+func TestIncrementUint(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint", uint(1), DefaultExpiration)
+	n, err := tc.IncrementUint("tuint", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tuint")
+	if !found {
+		t.Error("tuint was not found")
+	}
+	if x.(uint) != 3 {
+		t.Error("tuint is not 3:", x)
+	}
+}
+
+func TestIncrementUintptr(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuintptr", uintptr(1), DefaultExpiration)
+	n, err := tc.IncrementUintptr("tuintptr", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tuintptr")
+	if !found {
+		t.Error("tuintptr was not found")
+	}
+	if x.(uintptr) != 3 {
+		t.Error("tuintptr is not 3:", x)
+	}
+}
+
+func TestIncrementUint8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint8", uint8(1), DefaultExpiration)
+	n, err := tc.IncrementUint8("tuint8", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tuint8")
+	if !found {
+		t.Error("tuint8 was not found")
+	}
+	if x.(uint8) != 3 {
+		t.Error("tuint8 is not 3:", x)
+	}
+}
+
+func TestIncrementUint16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint16", uint16(1), DefaultExpiration)
+	n, err := tc.IncrementUint16("tuint16", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tuint16")
+	if !found {
+		t.Error("tuint16 was not found")
+	}
+	if x.(uint16) != 3 {
+		t.Error("tuint16 is not 3:", x)
+	}
+}
+
+func TestIncrementUint32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint32", uint32(1), DefaultExpiration)
+	n, err := tc.IncrementUint32("tuint32", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tuint32")
+	if !found {
+		t.Error("tuint32 was not found")
+	}
+	if x.(uint32) != 3 {
+		t.Error("tuint32 is not 3:", x)
+	}
+}
+
+func TestIncrementUint64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("tuint64", uint64(1), DefaultExpiration)
+	n, err := tc.IncrementUint64("tuint64", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("tuint64")
+	if !found {
+		t.Error("tuint64 was not found")
+	}
+	if x.(uint64) != 3 {
+		t.Error("tuint64 is not 3:", x)
+	}
+}
+
+func TestIncrementFloat32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float32", float32(1.5), DefaultExpiration)
+	n, err := tc.IncrementFloat32("float32", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3.5 {
+		t.Error("Returned number is not 3.5:", n)
+	}
+	x, found := tc.Get("float32")
+	if !found {
+		t.Error("float32 was not found")
+	}
+	if x.(float32) != 3.5 {
+		t.Error("float32 is not 3.5:", x)
+	}
+}
+
+func TestIncrementFloat64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float64", float64(1.5), DefaultExpiration)
+	n, err := tc.IncrementFloat64("float64", 2)
+	if err != nil {
+		t.Error("Error incrementing:", err)
+	}
+	if n != 3.5 {
+		t.Error("Returned number is not 3.5:", n)
+	}
+	x, found := tc.Get("float64")
+	if !found {
+		t.Error("float64 was not found")
+	}
+	if x.(float64) != 3.5 {
+		t.Error("float64 is not 3.5:", x)
+	}
+}
+
+func TestDecrementInt8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int8", int8(5), DefaultExpiration)
+	n, err := tc.DecrementInt8("int8", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("int8")
+	if !found {
+		t.Error("int8 was not found")
+	}
+	if x.(int8) != 3 {
+		t.Error("int8 is not 3:", x)
+	}
+}
+
+func TestDecrementInt16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int16", int16(5), DefaultExpiration)
+	n, err := tc.DecrementInt16("int16", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("int16")
+	if !found {
+		t.Error("int16 was not found")
+	}
+	if x.(int16) != 3 {
+		t.Error("int16 is not 3:", x)
+	}
+}
+
+func TestDecrementInt32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int32", int32(5), DefaultExpiration)
+	n, err := tc.DecrementInt32("int32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("int32")
+	if !found {
+		t.Error("int32 was not found")
+	}
+	if x.(int32) != 3 {
+		t.Error("int32 is not 3:", x)
+	}
+}
+
+func TestDecrementInt64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int64", int64(5), DefaultExpiration)
+	n, err := tc.DecrementInt64("int64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("int64")
+	if !found {
+		t.Error("int64 was not found")
+	}
+	if x.(int64) != 3 {
+		t.Error("int64 is not 3:", x)
+	}
+}
+
+func TestDecrementUint(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint", uint(5), DefaultExpiration)
+	n, err := tc.DecrementUint("uint", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("uint")
+	if !found {
+		t.Error("uint was not found")
+	}
+	if x.(uint) != 3 {
+		t.Error("uint is not 3:", x)
+	}
+}
+
+func TestDecrementUintptr(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uintptr", uintptr(5), DefaultExpiration)
+	n, err := tc.DecrementUintptr("uintptr", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("uintptr")
+	if !found {
+		t.Error("uintptr was not found")
+	}
+	if x.(uintptr) != 3 {
+		t.Error("uintptr is not 3:", x)
+	}
+}
+
+func TestDecrementUint8(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint8", uint8(5), DefaultExpiration)
+	n, err := tc.DecrementUint8("uint8", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("uint8")
+	if !found {
+		t.Error("uint8 was not found")
+	}
+	if x.(uint8) != 3 {
+		t.Error("uint8 is not 3:", x)
+	}
+}
+
+func TestDecrementUint16(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint16", uint16(5), DefaultExpiration)
+	n, err := tc.DecrementUint16("uint16", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("uint16")
+	if !found {
+		t.Error("uint16 was not found")
+	}
+	if x.(uint16) != 3 {
+		t.Error("uint16 is not 3:", x)
+	}
+}
+
+func TestDecrementUint32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint32", uint32(5), DefaultExpiration)
+	n, err := tc.DecrementUint32("uint32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("uint32")
+	if !found {
+		t.Error("uint32 was not found")
+	}
+	if x.(uint32) != 3 {
+		t.Error("uint32 is not 3:", x)
+	}
+}
+
+func TestDecrementUint64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint64", uint64(5), DefaultExpiration)
+	n, err := tc.DecrementUint64("uint64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("uint64")
+	if !found {
+		t.Error("uint64 was not found")
+	}
+	if x.(uint64) != 3 {
+		t.Error("uint64 is not 3:", x)
+	}
+}
+
+func TestDecrementFloat32(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float32", float32(5), DefaultExpiration)
+	n, err := tc.DecrementFloat32("float32", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("float32")
+	if !found {
+		t.Error("float32 was not found")
+	}
+	if x.(float32) != 3 {
+		t.Error("float32 is not 3:", x)
+	}
+}
+
+func TestDecrementFloat64(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("float64", float64(5), DefaultExpiration)
+	n, err := tc.DecrementFloat64("float64", 2)
+	if err != nil {
+		t.Error("Error decrementing:", err)
+	}
+	if n != 3 {
+		t.Error("Returned number is not 3:", n)
+	}
+	x, found := tc.Get("float64")
+	if !found {
+		t.Error("float64 was not found")
+	}
+	if x.(float64) != 3 {
+		t.Error("float64 is not 3:", x)
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	err := tc.Add("foo", "bar", DefaultExpiration)
+	if err != nil {
+		t.Error("Couldn't add foo even though it shouldn't exist")
+	}
+	err = tc.Add("foo", "baz", DefaultExpiration)
+	if err == nil {
+		t.Error("Successfully added another foo when it should have returned an error")
+	}
+}
+
+func TestReplace(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	err := tc.Replace("foo", "bar", DefaultExpiration)
+	if err == nil {
+		t.Error("Replaced foo when it shouldn't exist")
+	}
+	tc.Set("foo", "bar", DefaultExpiration)
+	err = tc.Replace("foo", "bar", DefaultExpiration)
+	if err != nil {
+		t.Error("Couldn't replace existing key foo")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", "bar", DefaultExpiration)
+	tc.Delete("foo")
+	x, found := tc.Get("foo")
+	if found {
+		t.Error("foo was found, but it should have been deleted")
+	}
+	if x != nil {
+		t.Error("x is not nil:", x)
+	}
+}
+
+func TestItemCount(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", "1", DefaultExpiration)
+	tc.Set("bar", "2", DefaultExpiration)
+	tc.Set("baz", "3", DefaultExpiration)
+	if n := tc.ItemCount(); n != 3 {
+		t.Errorf("Item count is not 3: %d", n)
+	}
+}
+
+func TestFlush(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", "bar", DefaultExpiration)
+	tc.Set("baz", "yes", DefaultExpiration)
+	tc.Flush()
+	x, found := tc.Get("foo")
+	if found {
+		t.Error("foo was found, but it should have been deleted")
+	}
+	if x != nil {
+		t.Error("x is not nil:", x)
+	}
+	x, found = tc.Get("baz")
+	if found {
+		t.Error("baz was found, but it should have been deleted")
+	}
+	if x != nil {
+		t.Error("x is not nil:", x)
+	}
+}
+
+func TestIncrementOverflowInt(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("int8", int8(127), DefaultExpiration)
+	err := tc.Increment("int8", 1)
+	if err != nil {
+		t.Error("Error incrementing int8:", err)
+	}
+	x, _ := tc.Get("int8")
+	int8 := x.(int8)
+	if int8 != -128 {
+		t.Error("int8 did not overflow as expected; value:", int8)
+	}
+
+}
+
+func TestIncrementOverflowUint(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint8", uint8(255), DefaultExpiration)
+	err := tc.Increment("uint8", 1)
+	if err != nil {
+		t.Error("Error incrementing int8:", err)
+	}
+	x, _ := tc.Get("uint8")
+	uint8 := x.(uint8)
+	if uint8 != 0 {
+		t.Error("uint8 did not overflow as expected; value:", uint8)
+	}
+}
+
+func TestDecrementUnderflowUint(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("uint8", uint8(0), DefaultExpiration)
+	err := tc.Decrement("uint8", 1)
+	if err != nil {
+		t.Error("Error decrementing int8:", err)
+	}
+	x, _ := tc.Get("uint8")
+	uint8 := x.(uint8)
+	if uint8 != 255 {
+		t.Error("uint8 did not underflow as expected; value:", uint8)
+	}
+}
+
+func TestOnEvicted(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", 3, DefaultExpiration)
+	if tc.onEvicted != nil {
+		t.Fatal("tc.onEvicted is not nil")
+	}
+	works := false
+	tc.OnEvicted(func(k string, v interface{}) {
+		if k == "foo" && v.(int) == 3 {
+			works = true
+		}
+		tc.Set("bar", 4, DefaultExpiration)
+	})
+	tc.Delete("foo")
+	x, _ := tc.Get("bar")
+	if !works {
+		t.Error("works bool not true")
+	}
+	if x.(int) != 4 {
+		t.Error("bar was not 4")
+	}
+}
+
+func TestCacheSerialization(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	testFillAndSerialize(t, tc)
+
+	// Check if gob.Register behaves properly even after multiple gob.Register
+	// on c.Items (many of which will be the same type)
+	testFillAndSerialize(t, tc)
+}
+
+func testFillAndSerialize(t *testing.T, tc *Cache) {
+	tc.Set("a", "a", DefaultExpiration)
+	tc.Set("b", "b", DefaultExpiration)
+	tc.Set("c", "c", DefaultExpiration)
+	tc.Set("expired", "foo", 1*time.Millisecond)
+	tc.Set("*struct", &TestStruct{Num: 1}, DefaultExpiration)
+	tc.Set("[]struct", []TestStruct{
+		{Num: 2},
+		{Num: 3},
+	}, DefaultExpiration)
+	tc.Set("[]*struct", []*TestStruct{
+		&TestStruct{Num: 4},
+		&TestStruct{Num: 5},
+	}, DefaultExpiration)
+	tc.Set("structception", &TestStruct{
+		Num: 42,
+		Children: []*TestStruct{
+			&TestStruct{Num: 6174},
+			&TestStruct{Num: 4716},
+		},
+	}, DefaultExpiration)
+
+	fp := &bytes.Buffer{}
+	err := tc.Save(fp)
+	if err != nil {
+		t.Fatal("Couldn't save cache to fp:", err)
+	}
+
+	oc := New(DefaultExpiration, 0)
+	err = oc.Load(fp)
+	if err != nil {
+		t.Fatal("Couldn't load cache from fp:", err)
+	}
+
+	a, found := oc.Get("a")
+	if !found {
+		t.Error("a was not found")
+	}
+	if a.(string) != "a" {
+		t.Error("a is not a")
+	}
+
+	b, found := oc.Get("b")
+	if !found {
+		t.Error("b was not found")
+	}
+	if b.(string) != "b" {
+		t.Error("b is not b")
+	}
+
+	c, found := oc.Get("c")
+	if !found {
+		t.Error("c was not found")
+	}
+	if c.(string) != "c" {
+		t.Error("c is not c")
+	}
+
+	<-time.After(5 * time.Millisecond)
+	_, found = oc.Get("expired")
+	if found {
+		t.Error("expired was found")
+	}
+
+	s1, found := oc.Get("*struct")
+	if !found {
+		t.Error("*struct was not found")
+	}
+	if s1.(*TestStruct).Num != 1 {
+		t.Error("*struct.Num is not 1")
+	}
+
+	s2, found := oc.Get("[]struct")
+	if !found {
+		t.Error("[]struct was not found")
+	}
+	s2r := s2.([]TestStruct)
+	if len(s2r) != 2 {
+		t.Error("Length of s2r is not 2")
+	}
+	if s2r[0].Num != 2 {
+		t.Error("s2r[0].Num is not 2")
+	}
+	if s2r[1].Num != 3 {
+		t.Error("s2r[1].Num is not 3")
+	}
+
+	s3, found := oc.get("[]*struct")
+	if !found {
+		t.Error("[]*struct was not found")
+	}
+	s3r := s3.([]*TestStruct)
+	if len(s3r) != 2 {
+		t.Error("Length of s3r is not 2")
+	}
+	if s3r[0].Num != 4 {
+		t.Error("s3r[0].Num is not 4")
+	}
+	if s3r[1].Num != 5 {
+		t.Error("s3r[1].Num is not 5")
+	}
+
+	s4, found := oc.get("structception")
+	if !found {
+		t.Error("structception was not found")
+	}
+	s4r := s4.(*TestStruct)
+	if len(s4r.Children) != 2 {
+		t.Error("Length of s4r.Children is not 2")
+	}
+	if s4r.Children[0].Num != 6174 {
+		t.Error("s4r.Children[0].Num is not 6174")
+	}
+	if s4r.Children[1].Num != 4716 {
+		t.Error("s4r.Children[1].Num is not 4716")
+	}
+}
+
+func TestFileSerialization(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	tc.Add("a", "a", DefaultExpiration)
+	tc.Add("b", "b", DefaultExpiration)
+	f, err := ioutil.TempFile("", "go-cache-cache.dat")
+	if err != nil {
+		t.Fatal("Couldn't create cache file:", err)
+	}
+	fname := f.Name()
+	f.Close()
+	tc.SaveFile(fname)
+
+	oc := New(DefaultExpiration, 0)
+	oc.Add("a", "aa", 0) // this should not be overwritten
+	err = oc.LoadFile(fname)
+	if err != nil {
+		t.Error(err)
+	}
+	a, found := oc.Get("a")
+	if !found {
+		t.Error("a was not found")
+	}
+	astr := a.(string)
+	if astr != "aa" {
+		if astr == "a" {
+			t.Error("a was overwritten")
+		} else {
+			t.Error("a is not aa")
+		}
+	}
+	b, found := oc.Get("b")
+	if !found {
+		t.Error("b was not found")
+	}
+	if b.(string) != "b" {
+		t.Error("b is not b")
+	}
+}
+
+func TestSerializeUnserializable(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	ch := make(chan bool, 1)
+	ch <- true
+	tc.Set("chan", ch, DefaultExpiration)
+	fp := &bytes.Buffer{}
+	err := tc.Save(fp) // this should fail gracefully
+	if err.Error() != "gob NewTypeObject can't handle type: chan bool" {
+		t.Error("Error from Save was not gob NewTypeObject can't handle type chan bool:", err)
+	}
+}
+
+func BenchmarkCacheGetExpiring(b *testing.B) {
+	benchmarkCacheGet(b, 5*time.Minute)
+}
+
+func BenchmarkCacheGetNotExpiring(b *testing.B) {
+	benchmarkCacheGet(b, NoExpiration)
+}
+
+func benchmarkCacheGet(b *testing.B, exp time.Duration) {
+	b.StopTimer()
+	tc := New(exp, 0)
+	tc.Set("foo", "bar", DefaultExpiration)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.Get("foo")
+	}
+}
+
+func BenchmarkRWMutexMapGet(b *testing.B) {
+	b.StopTimer()
+	m := map[string]string{
+		"foo": "bar",
+	}
+	mu := sync.RWMutex{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		mu.RLock()
+		_, _ = m["foo"]
+		mu.RUnlock()
+	}
+}
+
+func BenchmarkRWMutexInterfaceMapGetStruct(b *testing.B) {
+	b.StopTimer()
+	s := struct{ name string }{name: "foo"}
+	m := map[interface{}]string{
+		s: "bar",
+	}
+	mu := sync.RWMutex{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		mu.RLock()
+		_, _ = m[s]
+		mu.RUnlock()
+	}
+}
+
+func BenchmarkRWMutexInterfaceMapGetString(b *testing.B) {
+	b.StopTimer()
+	m := map[interface{}]string{
+		"foo": "bar",
+	}
+	mu := sync.RWMutex{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		mu.RLock()
+		_, _ = m["foo"]
+		mu.RUnlock()
+	}
+}
+
+func BenchmarkCacheGetConcurrentExpiring(b *testing.B) {
+	benchmarkCacheGetConcurrent(b, 5*time.Minute)
+}
+
+func BenchmarkCacheGetConcurrentNotExpiring(b *testing.B) {
+	benchmarkCacheGetConcurrent(b, NoExpiration)
+}
+
+func benchmarkCacheGetConcurrent(b *testing.B, exp time.Duration) {
+	b.StopTimer()
+	tc := New(exp, 0)
+	tc.Set("foo", "bar", DefaultExpiration)
+	wg := new(sync.WaitGroup)
+	workers := runtime.NumCPU()
+	each := b.N / workers
+	wg.Add(workers)
+	b.StartTimer()
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := 0; j < each; j++ {
+				tc.Get("foo")
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func BenchmarkRWMutexMapGetConcurrent(b *testing.B) {
+	b.StopTimer()
+	m := map[string]string{
+		"foo": "bar",
+	}
+	mu := sync.RWMutex{}
+	wg := new(sync.WaitGroup)
+	workers := runtime.NumCPU()
+	each := b.N / workers
+	wg.Add(workers)
+	b.StartTimer()
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := 0; j < each; j++ {
+				mu.RLock()
+				_, _ = m["foo"]
+				mu.RUnlock()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func BenchmarkCacheGetManyConcurrentExpiring(b *testing.B) {
+	benchmarkCacheGetManyConcurrent(b, 5*time.Minute)
+}
+
+func BenchmarkCacheGetManyConcurrentNotExpiring(b *testing.B) {
+	benchmarkCacheGetManyConcurrent(b, NoExpiration)
+}
+
+func benchmarkCacheGetManyConcurrent(b *testing.B, exp time.Duration) {
+	// This is the same as BenchmarkCacheGetConcurrent, but its result
+	// can be compared against BenchmarkShardedCacheGetManyConcurrent
+	// in sharded_test.go.
+	b.StopTimer()
+	n := 10000
+	tc := New(exp, 0)
+	keys := make([]string, n)
+	for i := 0; i < n; i++ {
+		k := "foo" + strconv.Itoa(n)
+		keys[i] = k
+		tc.Set(k, "bar", DefaultExpiration)
+	}
+	each := b.N / n
+	wg := new(sync.WaitGroup)
+	wg.Add(n)
+	for _, v := range keys {
+		go func() {
+			for j := 0; j < each; j++ {
+				tc.Get(v)
+			}
+			wg.Done()
+		}()
+	}
+	b.StartTimer()
+	wg.Wait()
+}
+
+func BenchmarkCacheSetExpiring(b *testing.B) {
+	benchmarkCacheSet(b, 5*time.Minute)
+}
+
+func BenchmarkCacheSetNotExpiring(b *testing.B) {
+	benchmarkCacheSet(b, NoExpiration)
+}
+
+func benchmarkCacheSet(b *testing.B, exp time.Duration) {
+	b.StopTimer()
+	tc := New(exp, 0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.Set("foo", "bar", DefaultExpiration)
+	}
+}
+
+func BenchmarkRWMutexMapSet(b *testing.B) {
+	b.StopTimer()
+	m := map[string]string{}
+	mu := sync.RWMutex{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		mu.Lock()
+		m["foo"] = "bar"
+		mu.Unlock()
+	}
+}
+
+func BenchmarkCacheSetDelete(b *testing.B) {
+	b.StopTimer()
+	tc := New(DefaultExpiration, 0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.Set("foo", "bar", DefaultExpiration)
+		tc.Delete("foo")
+	}
+}
+
+func BenchmarkRWMutexMapSetDelete(b *testing.B) {
+	b.StopTimer()
+	m := map[string]string{}
+	mu := sync.RWMutex{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		mu.Lock()
+		m["foo"] = "bar"
+		mu.Unlock()
+		mu.Lock()
+		delete(m, "foo")
+		mu.Unlock()
+	}
+}
+
+func BenchmarkCacheSetDeleteSingleLock(b *testing.B) {
+	b.StopTimer()
+	tc := New(DefaultExpiration, 0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.mu.Lock()
+		tc.set("foo", "bar", DefaultExpiration)
+		tc.delete("foo")
+		tc.mu.Unlock()
+	}
+}
+
+func BenchmarkRWMutexMapSetDeleteSingleLock(b *testing.B) {
+	b.StopTimer()
+	m := map[string]string{}
+	mu := sync.RWMutex{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		mu.Lock()
+		m["foo"] = "bar"
+		delete(m, "foo")
+		mu.Unlock()
+	}
+}
+
+func BenchmarkIncrementInt(b *testing.B) {
+	b.StopTimer()
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", 0, DefaultExpiration)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.IncrementInt("foo", 1)
+	}
+}
+
+func BenchmarkDeleteExpiredLoop(b *testing.B) {
+	b.StopTimer()
+	tc := New(5*time.Minute, 0)
+	tc.mu.Lock()
+	for i := 0; i < 100000; i++ {
+		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
+	}
+	tc.mu.Unlock()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.DeleteExpired()
+	}
+}
+
+func TestGetWithExpiration(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+
+	a, expiration, found := tc.GetWithExpiration("a")
+	if found || a != nil || !expiration.IsZero() {
+		t.Error("Getting A found value that shouldn't exist:", a)
+	}
+
+	b, expiration, found := tc.GetWithExpiration("b")
+	if found || b != nil || !expiration.IsZero() {
+		t.Error("Getting B found value that shouldn't exist:", b)
+	}
+
+	c, expiration, found := tc.GetWithExpiration("c")
+	if found || c != nil || !expiration.IsZero() {
+		t.Error("Getting C found value that shouldn't exist:", c)
+	}
+
+	tc.Set("a", 1, DefaultExpiration)
+	tc.Set("b", "b", DefaultExpiration)
+	tc.Set("c", 3.5, DefaultExpiration)
+	tc.Set("d", 1, NoExpiration)
+	tc.Set("e", 1, 50*time.Millisecond)
+
+	x, expiration, found := tc.GetWithExpiration("a")
+	if !found {
+		t.Error("a was not found while getting a2")
+	}
+	if x == nil {
+		t.Error("x for a is nil")
+	} else if a2 := x.(int); a2+2 != 3 {
+		t.Error("a2 (which should be 1) plus 2 does not equal 3; value:", a2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for a is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("b")
+	if !found {
+		t.Error("b was not found while getting b2")
+	}
+	if x == nil {
+		t.Error("x for b is nil")
+	} else if b2 := x.(string); b2+"B" != "bB" {
+		t.Error("b2 (which should be b) plus B does not equal bB; value:", b2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for b is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("c")
+	if !found {
+		t.Error("c was not found while getting c2")
+	}
+	if x == nil {
+		t.Error("x for c is nil")
+	} else if c2 := x.(float64); c2+1.2 != 4.7 {
+		t.Error("c2 (which should be 3.5) plus 1.2 does not equal 4.7; value:", c2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for c is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("d")
+	if !found {
+		t.Error("d was not found while getting d2")
+	}
+	if x == nil {
+		t.Error("x for d is nil")
+	} else if d2 := x.(int); d2+2 != 3 {
+		t.Error("d (which should be 1) plus 2 does not equal 3; value:", d2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for d is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("e")
+	if !found {
+		t.Error("e was not found while getting e2")
+	}
+	if x == nil {
+		t.Error("x for e is nil")
+	} else if e2 := x.(int); e2+2 != 3 {
+		t.Error("e (which should be 1) plus 2 does not equal 3; value:", e2)
+	}
+	if expiration.UnixNano() != tc.items["e"].Expiration {
+		t.Error("expiration for e is not the correct time")
+	}
+	if expiration.UnixNano() < time.Now().UnixNano() {
+		t.Error("expiration for e is in the past")
+	}
+}

--- a/vendor/github.com/patrickmn/go-cache/sharded.go
+++ b/vendor/github.com/patrickmn/go-cache/sharded.go
@@ -1,0 +1,192 @@
+package cache
+
+import (
+	"crypto/rand"
+	"math"
+	"math/big"
+	insecurerand "math/rand"
+	"os"
+	"runtime"
+	"time"
+)
+
+// This is an experimental and unexported (for now) attempt at making a cache
+// with better algorithmic complexity than the standard one, namely by
+// preventing write locks of the entire cache when an item is added. As of the
+// time of writing, the overhead of selecting buckets results in cache
+// operations being about twice as slow as for the standard cache with small
+// total cache sizes, and faster for larger ones.
+//
+// See cache_test.go for a few benchmarks.
+
+type unexportedShardedCache struct {
+	*shardedCache
+}
+
+type shardedCache struct {
+	seed    uint32
+	m       uint32
+	cs      []*cache
+	janitor *shardedJanitor
+}
+
+// djb2 with better shuffling. 5x faster than FNV with the hash.Hash overhead.
+func djb33(seed uint32, k string) uint32 {
+	var (
+		l = uint32(len(k))
+		d = 5381 + seed + l
+		i = uint32(0)
+	)
+	// Why is all this 5x faster than a for loop?
+	if l >= 4 {
+		for i < l-4 {
+			d = (d * 33) ^ uint32(k[i])
+			d = (d * 33) ^ uint32(k[i+1])
+			d = (d * 33) ^ uint32(k[i+2])
+			d = (d * 33) ^ uint32(k[i+3])
+			i += 4
+		}
+	}
+	switch l - i {
+	case 1:
+	case 2:
+		d = (d * 33) ^ uint32(k[i])
+	case 3:
+		d = (d * 33) ^ uint32(k[i])
+		d = (d * 33) ^ uint32(k[i+1])
+	case 4:
+		d = (d * 33) ^ uint32(k[i])
+		d = (d * 33) ^ uint32(k[i+1])
+		d = (d * 33) ^ uint32(k[i+2])
+	}
+	return d ^ (d >> 16)
+}
+
+func (sc *shardedCache) bucket(k string) *cache {
+	return sc.cs[djb33(sc.seed, k)%sc.m]
+}
+
+func (sc *shardedCache) Set(k string, x interface{}, d time.Duration) {
+	sc.bucket(k).Set(k, x, d)
+}
+
+func (sc *shardedCache) Add(k string, x interface{}, d time.Duration) error {
+	return sc.bucket(k).Add(k, x, d)
+}
+
+func (sc *shardedCache) Replace(k string, x interface{}, d time.Duration) error {
+	return sc.bucket(k).Replace(k, x, d)
+}
+
+func (sc *shardedCache) Get(k string) (interface{}, bool) {
+	return sc.bucket(k).Get(k)
+}
+
+func (sc *shardedCache) Increment(k string, n int64) error {
+	return sc.bucket(k).Increment(k, n)
+}
+
+func (sc *shardedCache) IncrementFloat(k string, n float64) error {
+	return sc.bucket(k).IncrementFloat(k, n)
+}
+
+func (sc *shardedCache) Decrement(k string, n int64) error {
+	return sc.bucket(k).Decrement(k, n)
+}
+
+func (sc *shardedCache) Delete(k string) {
+	sc.bucket(k).Delete(k)
+}
+
+func (sc *shardedCache) DeleteExpired() {
+	for _, v := range sc.cs {
+		v.DeleteExpired()
+	}
+}
+
+// Returns the items in the cache. This may include items that have expired,
+// but have not yet been cleaned up. If this is significant, the Expiration
+// fields of the items should be checked. Note that explicit synchronization
+// is needed to use a cache and its corresponding Items() return values at
+// the same time, as the maps are shared.
+func (sc *shardedCache) Items() []map[string]Item {
+	res := make([]map[string]Item, len(sc.cs))
+	for i, v := range sc.cs {
+		res[i] = v.Items()
+	}
+	return res
+}
+
+func (sc *shardedCache) Flush() {
+	for _, v := range sc.cs {
+		v.Flush()
+	}
+}
+
+type shardedJanitor struct {
+	Interval time.Duration
+	stop     chan bool
+}
+
+func (j *shardedJanitor) Run(sc *shardedCache) {
+	j.stop = make(chan bool)
+	tick := time.Tick(j.Interval)
+	for {
+		select {
+		case <-tick:
+			sc.DeleteExpired()
+		case <-j.stop:
+			return
+		}
+	}
+}
+
+func stopShardedJanitor(sc *unexportedShardedCache) {
+	sc.janitor.stop <- true
+}
+
+func runShardedJanitor(sc *shardedCache, ci time.Duration) {
+	j := &shardedJanitor{
+		Interval: ci,
+	}
+	sc.janitor = j
+	go j.Run(sc)
+}
+
+func newShardedCache(n int, de time.Duration) *shardedCache {
+	max := big.NewInt(0).SetUint64(uint64(math.MaxUint32))
+	rnd, err := rand.Int(rand.Reader, max)
+	var seed uint32
+	if err != nil {
+		os.Stderr.Write([]byte("WARNING: go-cache's newShardedCache failed to read from the system CSPRNG (/dev/urandom or equivalent.) Your system's security may be compromised. Continuing with an insecure seed.\n"))
+		seed = insecurerand.Uint32()
+	} else {
+		seed = uint32(rnd.Uint64())
+	}
+	sc := &shardedCache{
+		seed: seed,
+		m:    uint32(n),
+		cs:   make([]*cache, n),
+	}
+	for i := 0; i < n; i++ {
+		c := &cache{
+			defaultExpiration: de,
+			items:             map[string]Item{},
+		}
+		sc.cs[i] = c
+	}
+	return sc
+}
+
+func unexportedNewSharded(defaultExpiration, cleanupInterval time.Duration, shards int) *unexportedShardedCache {
+	if defaultExpiration == 0 {
+		defaultExpiration = -1
+	}
+	sc := newShardedCache(shards, defaultExpiration)
+	SC := &unexportedShardedCache{sc}
+	if cleanupInterval > 0 {
+		runShardedJanitor(sc, cleanupInterval)
+		runtime.SetFinalizer(SC, stopShardedJanitor)
+	}
+	return SC
+}

--- a/vendor/github.com/patrickmn/go-cache/sharded_test.go
+++ b/vendor/github.com/patrickmn/go-cache/sharded_test.go
@@ -1,0 +1,85 @@
+package cache
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// func TestDjb33(t *testing.T) {
+// }
+
+var shardedKeys = []string{
+	"f",
+	"fo",
+	"foo",
+	"barf",
+	"barfo",
+	"foobar",
+	"bazbarf",
+	"bazbarfo",
+	"bazbarfoo",
+	"foobarbazq",
+	"foobarbazqu",
+	"foobarbazquu",
+	"foobarbazquux",
+}
+
+func TestShardedCache(t *testing.T) {
+	tc := unexportedNewSharded(DefaultExpiration, 0, 13)
+	for _, v := range shardedKeys {
+		tc.Set(v, "value", DefaultExpiration)
+	}
+}
+
+func BenchmarkShardedCacheGetExpiring(b *testing.B) {
+	benchmarkShardedCacheGet(b, 5*time.Minute)
+}
+
+func BenchmarkShardedCacheGetNotExpiring(b *testing.B) {
+	benchmarkShardedCacheGet(b, NoExpiration)
+}
+
+func benchmarkShardedCacheGet(b *testing.B, exp time.Duration) {
+	b.StopTimer()
+	tc := unexportedNewSharded(exp, 0, 10)
+	tc.Set("foobarba", "zquux", DefaultExpiration)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.Get("foobarba")
+	}
+}
+
+func BenchmarkShardedCacheGetManyConcurrentExpiring(b *testing.B) {
+	benchmarkShardedCacheGetManyConcurrent(b, 5*time.Minute)
+}
+
+func BenchmarkShardedCacheGetManyConcurrentNotExpiring(b *testing.B) {
+	benchmarkShardedCacheGetManyConcurrent(b, NoExpiration)
+}
+
+func benchmarkShardedCacheGetManyConcurrent(b *testing.B, exp time.Duration) {
+	b.StopTimer()
+	n := 10000
+	tsc := unexportedNewSharded(exp, 0, 20)
+	keys := make([]string, n)
+	for i := 0; i < n; i++ {
+		k := "foo" + strconv.Itoa(n)
+		keys[i] = k
+		tsc.Set(k, "bar", DefaultExpiration)
+	}
+	each := b.N / n
+	wg := new(sync.WaitGroup)
+	wg.Add(n)
+	for _, v := range keys {
+		go func() {
+			for j := 0; j < each; j++ {
+				tsc.Get(v)
+			}
+			wg.Done()
+		}()
+	}
+	b.StartTimer()
+	wg.Wait()
+}


### PR DESCRIPTION
Opening this here to continue the discussion from https://github.com/ncw/rclone/issues/711
Thanks @ncw for the suggestion. I'll reopen the PR with adequate commits once this gets to a near merge state.

To pick up from the issue:

> I see you are serializing fs.Object~s. I have a plan to add a couple of optional methods to Fses to allow object serialization and deserialization - I think this will make your life easier. You then wouldn't have to call NewObject in CachedObject.RefreshObject (which can be expensive). I could bring forwards this plan if you want.

I would be very interested. My initial idea was to allow each backend to export their objects and just manage the storage and cache retrieval from the cache backend. But then I realized that meant modifying most of the backends and FS interfaces and I wanted to avoid a big impacting change. 

> To be truly useful with mount, mount needs to be able to do non sequential writes, and reads from the same object. We could make two new optional interfaces on the Fs support that, Say ReadBlockAt and WriteBlockAt, or maybe on the open handle might be eaiser.

Yes, makes sense. If I understand correctly, a cache backend would be able to allow this even if the source FS wouldn't.

I actually had to do some changes to the ReadHandle which could relate to this. It's doing buffered reads and calls Open multiple times on the object to build up the buffer. While it doesn't stop it from working, I had terrible performance while doing a similar buffering on the backend.
I added a new feature flag `FileReadRaw` that basically tells `ReadFileHandle` to allow the backend to return the chunks that fuse asks for directly (latest commit has this). 

I assume this is what you were thinking too no? Your naming make more sense though.

> BTW your ListR implementation looks wrong - it doesn't seem to be recursing...

I did had something in mind while doing that but I forgot what it was. 
Anyway, I want to rewrite the structure part (listings). Bolt supports nested buckets and there's no reason to not replicate a proper folder structure in it too. That way it makes Object storage easier.

I'm also struggling  with wrapping crypt. If I wrap crypt under cache, I get a black screen during video playback and no weird errors in the log which suggests the bytes aren't right. I I wrap cache under crypt, I get `ErrorEncryptedBadBlock` mostly all the time. It originates from `Poly1305 one-time message authentication code` failing but I never got to understand why.
I studied the crypt code as best as I could and apart from decrypting the stream on the fly, it doesn't seem to be doing anything wrong. The same symptoms happen regardless of the caching technique (which I changed quite a couple of times). Oh and yeah, if I mount crypt directly or cache directly, both work but if I wrap each other then it doesn't which is even more frustrating.

Anyway, to get back to it, stuff to do:
- Since the chunks are read quite a couple of times, I added an option to cache in RAM too but that doesn't work yet so it's disabled. They should expire after some time or even after the stream passes them
- I would like to rewrite the file structure caching by using nested buckets in Bolt
- Maybe open a different PR for `ReadBlockAt` and `WriteBlockAt` to minimize the blast radius? @ncw 
- Fix / finish feature methods
- Review / expose more params that are currently hard coded
- Change serialization method @ncw if you have something started on it or ideas laid down, shoot them at me
- Hammer down this pesky crypt-cache issue
- Tweak logging

I'll probably split these and get a PR open with a first version to get some feedback 