### PR TITLE
Local: Make documentation consistent with code

### DIFF
--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -120,7 +120,7 @@ $ rclone -L ls /tmp/a
         6 b/one
 ```
 
-#### --no-local-unicode-normalization ####
+#### --local-no-unicode-normalization ####
 
 By default rclone normalizes (NFC) the unicode representation of filenames and
 directories. This flag disables that normalization and uses the same


### PR DESCRIPTION
Change flag `--no-local-unicode-normalization` to `--local-no-unicode-normalization` since that's the way the flag is called in the source code.

Fixes #1633