### PR TITLE
S3 glacier documentation + RFC

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -299,6 +299,17 @@ Notes on above:
 For reference, [here's an Ansible script](https://gist.github.com/ebridges/ebfc9042dd7c756cd101cfa807b7ae2b) 
 that will generate one or more buckets that will work with `rclone sync`.
 
+### Glacier ###
+
+You can transition objects to glacier storage using a [lifecycle policy](http://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-lifecycle.html).
+The bucket can still be synced or copied into normally, but if rclone
+tries to access the data you will see an error like below.
+
+    2017/09/11 19:07:43 Failed to sync: failed to open source object: Object in GLACIER, restore first: path/to/file
+
+In this case you need to [restore](http://docs.aws.amazon.com/AmazonS3/latest/user-guide/restore-archived-objects.html)
+the object(s) in question before using rclone.
+
 ### Specific options ###
 
 Here are the command line options specific to this cloud storage

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -949,6 +949,11 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 		}
 	}
 	resp, err := o.fs.c.GetObject(&req)
+	if err, ok := err.(awserr.RequestFailure); ok {
+		if err.Code() == "InvalidObjectState" {
+			return nil, errors.Errorf("Object in GLACIER, restore first: %v", key)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi,

I'm using rclone to back up stuff into an S3 bucket and was playing around with [lifecycle policies](http://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-lifecycle.html) in an attempt to reduce storage costs. It is easy to make old files automatically move to lower cost glacier storage (though I've yet to verify if the increased cost per operation makes it worth it in my case).

When syncing to S3 everything works fine, but when syncing/copying back objects would need to be manually restored before rclone can download them. This PR only adds documentation and an error message to that effect.

I could look into adding actual restore support but I'm not sure how it should work. Since it takes minutes to hours after restore for the files to be available, it cannot really be done as part of sync/copy - it is basically a separate operation from the normal commands. Perhaps it could be a flag to check? Something like `rclone check --S3-restore-nonmatching`... though that does not seem quite right.