### PR TITLE
copy: error out if dst could not be listed

### DIFF
--- a/fs/sync.go
+++ b/fs/sync.go
@@ -1002,7 +1002,7 @@ func (s *syncCopyMove) processJob(job listDirJob) (jobs []listDirJob) {
 	if dstListErr == ErrorDirNotFound {
 		// Copy the stuff anyway
 	} else if dstListErr != nil {
-		s.processError(errors.Wrapf(srcListErr, "error reading destination directory %q", job.remote))
+		s.processError(errors.Wrapf(dstListErr, "error reading destination directory %q", job.remote))
 		return nil
 	}
 


### PR DESCRIPTION
This fixes a bug that rclone does not display an error message when the destination could not be listed. For example, if we had invalid S3 credentials, then copy to S3 was flagged as a success.