### PR TITLE
fuse: re-use rcat to support uploads for all remotes

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -143,13 +143,6 @@ Assuming only one rclone instance is running, you can reset the cache
 like this:
 
     kill -SIGHUP $(pidof rclone)
-
-### Bugs ###
-
-  * All the remotes should work for read, but some may not for write
-    * those which need to know the size in advance won't - eg B2
-    * maybe should pass in size as -1 to mean work it out
-    * Or put in an an upload cache to cache the files on disk first
 `,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.CheckArgs(2, 2, command, args)

--- a/cmd/rcat/rcat.go
+++ b/cmd/rcat/rcat.go
@@ -50,7 +50,8 @@ a lot of data, you're better off caching locally and then
 
 		fdst, dstFileName := cmd.NewFsDstFile(args)
 		cmd.Run(false, false, command, func() error {
-			return fs.Rcat(fdst, dstFileName, os.Stdin, time.Now())
+			_, err := fs.Rcat(fdst, dstFileName, os.Stdin, time.Now())
+			return err
 		})
 	},
 }

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -1583,7 +1583,7 @@ func Cat(f Fs, w io.Writer, offset, count int64) error {
 }
 
 // Rcat reads data from the Reader until EOF and uploads it to a file on remote
-func Rcat(fdst Fs, dstFileName string, in0 io.ReadCloser, modTime time.Time) (err error) {
+func Rcat(fdst Fs, dstFileName string, in0 io.ReadCloser, modTime time.Time) (dst Object, err error) {
 	Stats.Transferring(dstFileName)
 	defer func() {
 		Stats.DoneTransferring(dstFileName, err == nil)
@@ -1595,7 +1595,7 @@ func Rcat(fdst Fs, dstFileName string, in0 io.ReadCloser, modTime time.Time) (er
 	hashOption := &HashesOption{Hashes: fdst.Hashes()}
 	hash, err := NewMultiHasherTypes(fdst.Hashes())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	readCounter := NewCountingReader(in0)
 	trackingIn := io.TeeReader(readCounter, hash)
@@ -1620,13 +1620,13 @@ func Rcat(fdst Fs, dstFileName string, in0 io.ReadCloser, modTime time.Time) (er
 		objInfo := NewStaticObjectInfo(dstFileName, modTime, int64(n), false, nil, nil)
 		if Config.DryRun {
 			Logf("stdin", "Not uploading as --dry-run")
-			return nil
+			return nil, nil
 		}
 		dst, err := fdst.Put(in, objInfo, hashOption)
 		if err != nil {
-			return err
+			return dst, err
 		}
-		return compare(dst)
+		return dst, compare(dst)
 	}
 	in := ioutil.NopCloser(io.MultiReader(bytes.NewReader(buf), trackingIn))
 
@@ -1636,7 +1636,7 @@ func Rcat(fdst Fs, dstFileName string, in0 io.ReadCloser, modTime time.Time) (er
 		Debugf(fdst, "Target remote doesn't support streaming uploads, creating temporary local FS to spool file")
 		tmpLocalFs, err := temporaryLocalFs()
 		if err != nil {
-			return errors.Wrap(err, "Failed to create temporary local FS to spool file")
+			return nil, errors.Wrap(err, "Failed to create temporary local FS to spool file")
 		}
 		defer func() {
 			err := Purge(tmpLocalFs)
@@ -1653,21 +1653,20 @@ func Rcat(fdst Fs, dstFileName string, in0 io.ReadCloser, modTime time.Time) (er
 		Logf("stdin", "Not uploading as --dry-run")
 		// prevents "broken pipe" errors
 		_, err = io.Copy(ioutil.Discard, in)
-		return err
+		return nil, err
 	}
 
 	objInfo := NewStaticObjectInfo(dstFileName, modTime, -1, false, nil, nil)
-	tmpObj, err := fStreamTo.Features().PutStream(in, objInfo, hashOption)
-	if err != nil {
-		return err
+	if dst, err = fStreamTo.Features().PutStream(in, objInfo, hashOption); err != nil {
+		return dst, err
 	}
-	if err = compare(tmpObj); err != nil {
-		return err
+	if err = compare(dst); err != nil {
+		return dst, err
 	}
 	if !canStream {
-		return Copy(fdst, nil, dstFileName, tmpObj)
+		return dst, Copy(fdst, nil, dstFileName, dst)
 	}
-	return nil
+	return dst, nil
 }
 
 // Rmdirs removes any empty directories (or directories only

--- a/fs/operations_test.go
+++ b/fs/operations_test.go
@@ -748,11 +748,11 @@ func TestRcat(t *testing.T) {
 		path2 := "big_file_from_pipe"
 
 		in := ioutil.NopCloser(strings.NewReader(data1))
-		err := fs.Rcat(r.fremote, path1, in, t1)
+		_, err := fs.Rcat(r.fremote, path1, in, t1)
 		require.NoError(t, err)
 
 		in = ioutil.NopCloser(strings.NewReader(data2))
-		err = fs.Rcat(r.fremote, path2, in, t2)
+		_, err = fs.Rcat(r.fremote, path2, in, t2)
 		require.NoError(t, err)
 
 		file1 := fstest.NewItem(path1, data1, t1)


### PR DESCRIPTION
With this patch, I can write successfully to an encrypted remote on B2, which was not possible previously. In this case it spools the files, of course, but direct streaming also works fine (tested with Dropbox).

I'm a bit weary to merge this right away, because I suspect 1.38 will be around the corner soon. Having `rcat` exposed to a wider audience might be good to fix any additional bugs before accidentally breaking the mount. There's also the issue that all the business-oriented remotes still need to be checked/implemented (#1614). Previously it would just `Put`, but now it will spool, which might be worse. It will be a while before I get a toy credit card to make test accounts with these providers.

My suggestion would be to merge this for 1.39.