### PR TITLE
s3: set session token when using STS

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -240,12 +240,14 @@ There are two ways to supply `rclone` with a set of AWS
 credentials. In order of precedence:
 
  - Directly in the rclone configuration file (as configured by `rclone config`)
-   - set `access_key_id` and `secret_access_key`
+   - set `access_key_id` and `secret_access_key`. `session_token` can be
+     optionally set when using AWS STS.
  - Runtime configuration:
    - set `env_auth` to `true` in the config file
    - Exporting the following environment variables before running `rclone`
      - Access Key ID: `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY`
      - Secret Access Key: `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY`
+     - Session Token: `AWS_SESSION_TOKEN`
    - Running `rclone` on an EC2 instance with an IAM role
 
 If none of these option actually end up providing `rclone` with AWS

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,6 +313,7 @@ func s3Connection(name string) (*s3.S3, *session.Session, error) {
 	v := credentials.Value{
 		AccessKeyID:     fs.ConfigFileGet(name, "access_key_id"),
 		SecretAccessKey: fs.ConfigFileGet(name, "secret_access_key"),
+		SessionToken:    fs.ConfigFileGet(name, "session_token"),
 	}
 
 	// first provider to supply a credential set "wins"


### PR DESCRIPTION
This is useful when using federated tokens in AWS