### PR TITLE
b2: implement streaming upload of files with unknown length (see #1614)

### DIFF
--- a/fs/operations.go
+++ b/fs/operations.go
@@ -122,7 +122,7 @@ func Equal(src ObjectInfo, dst Object) bool {
 func equal(src ObjectInfo, dst Object, sizeOnly, checkSum bool) bool {
 	if !Config.IgnoreSize {
 		if src.Size() != dst.Size() {
-			Debugf(src, "Sizes differ")
+			Debugf(src, "Sizes differ (src %d vs dst %d)", src.Size(), dst.Size())
 			return false
 		}
 	}


### PR DESCRIPTION
Together with #1684 this would be the last patch needed to make #1614 complete – and thus #1672 mergable.

About the patch:
* the patch adds some complexity, because b2 requires at least two chunks for large uploads and everything is configurable. I also wanted to avoid in RAM copies of chunks.
* being able to read exactly one 1 chunk is not enough, we need at least one byte more. It's certainly an edge case and it appears no one tried to upload exactly chunk-sized files yet. The old code `size >= int64(uploadCutoff)` was off by one, too!
* I found that trying to handle both cases of upload/streaming in one function puts if/else all over the place and makes for a tougher read. Splitting them has a lot of code duplication, which I combated by pulling stuff into two extra functions. They don't really feel like nice logical units, though I am not sure this would be the idiomatic approach.
* I enhanced the `sizes differ` error message because it came up during development (I forgot to `buf = buf[:n]` at some point, and the message was rather unhelpful if I count wrong or upload wrong)
* the speed estimates will not be accurate because of the reading of the initial block. I guess I could place `AccountByPart` earlier, which would fix the "large stream" case. It will show up as 0 Byte/s for the "smaller than chunkSize" streaming case.

The patch passes the integration tests, although they only cover the first two. I tested rcat with:
*  `size <= StreamingUploadCutoff`
* `StreamingUploadCutoff < size < b2ChunkSize`
* `size = b2ChunkSize`
* `b2ChunkSize < size` and `transfers = 1`
* `b2ChunkSize < size` and `transfers = 4`

Didn't test:
* `b2ChunkSize < size < StreamingUploadCutoff` (would incur double buffer, I believe)

Anyway, I'm fine with this not being merged for 1.38, although I do have to admit it would be pretty awesome :)