### PR TITLE
crypt: added cryptdecode command - #1129

### DIFF
--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/ncw/rclone/cmd/copy"
 	_ "github.com/ncw/rclone/cmd/copyto"
 	_ "github.com/ncw/rclone/cmd/cryptcheck"
+	_ "github.com/ncw/rclone/cmd/cryptdecode"
 	_ "github.com/ncw/rclone/cmd/dbhashsum"
 	_ "github.com/ncw/rclone/cmd/dedupe"
 	_ "github.com/ncw/rclone/cmd/delete"

--- a/cmd/cryptdecode/cryptdecode.go
+++ b/cmd/cryptdecode/cryptdecode.go
@@ -1,0 +1,59 @@
+package cryptdecode
+
+import (
+	"fmt"
+
+	"github.com/ncw/rclone/cmd"
+	"github.com/ncw/rclone/crypt"
+	"github.com/ncw/rclone/fs"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd.Root.AddCommand(commandDefinition)
+}
+
+var commandDefinition = &cobra.Command{
+	Use:   "cryptdecode encryptedremote: encryptedfilename",
+	Short: `Cryptdecode returns unencrypted file names.`,
+	Long: `
+rclone cryptdecode returns unencrypted file names when provided with
+a list of encrypted file names. List limit is 10 items.
+
+use it like this
+
+	rclone cryptdecode encryptedremote: encryptedfilename1 encryptedfilename2
+`,
+	Run: func(command *cobra.Command, args []string) {
+		cmd.CheckArgs(2, 11, command, args)
+		fsrc := cmd.NewFsSrc(args)
+		cmd.Run(false, false, command, func() error {
+			return cryptDecode(fsrc, args[1:])
+		})
+	},
+}
+
+// cryptDecode returns the unencrypted file name
+func cryptDecode(fsrc fs.Fs, args []string) error {
+	// Check if fsrc is a crypt
+	fcrypt, ok := fsrc.(*crypt.Fs)
+	if !ok {
+		return errors.Errorf("%s:%s is not a crypt remote", fsrc.Name(), fsrc.Root())
+	}
+
+	output := ""
+
+	for _, encryptedFileName := range args {
+		fileName, err := fcrypt.DecryptFileName(encryptedFileName)
+		if err != nil {
+			output += fmt.Sprintln(encryptedFileName, "\t", "Failed to decrypt")
+		} else {
+			output += fmt.Sprintln(encryptedFileName, "\t", fileName)
+		}
+	}
+
+	fmt.Printf(output)
+
+	return nil
+}

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -403,6 +403,11 @@ func (f *Fs) UnWrap() fs.Fs {
 	return f.Fs
 }
 
+// DecryptFileName returns a decrypted file name
+func (f *Fs) DecryptFileName(encryptedFileName string) (string, error) {
+	return f.cipher.DecryptFileName(encryptedFileName)
+}
+
 // ComputeHash takes the nonce from o, and encrypts the contents of
 // src with it, and calcuates the hash given by HashType on the fly
 //


### PR DESCRIPTION
This PR implents `cryptdecode` command which takes a crypt remote and a list of encrypted file names as parameters and returns the unencrypted file names.

`rclone cryptdecode encryptedremote: encryptedfilename1 encryptedfilename2`

output

```
iptcju57oi1l1c1mhcym4ctbho 	 file02.txt
pbeg45x31rucld7iv4736ol429 	 Failed to decrypt
``` 

In the above example, `pbeg45x31rucld7iv4736ol429` is an invalid encrypted file name.