### PR TITLE
Small fixes to docs.md

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1056,8 +1056,8 @@ file to see what the values are (the config file can be found by
 looking at the help for `--config` in `rclone help`).
 
 To find the name of the environment variable, you need to set, take
-`RCLONE_` + name of remote + `_` + name of config file option and make
-it all uppercase.
+`RCLONE_CONFIG_` + name of remote + `_` + name of config file option
+and make it all uppercase.
 
 For example, to configure an S3 remote named `mys3:` without a config
 file (using unix ways of setting environment variables):

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -256,7 +256,7 @@ you might want to pass `--suffix` with today's date.
 
 Local address to bind to for outgoing connections.  This can be an
 IPv4 address (1.2.3.4), an IPv6 address (1234::789A) or host name.  If
-the host name doesn't resolve or resoves to more than one IP address
+the host name doesn't resolve or resolves to more than one IP address
 it will give an error.
 
 ### --bwlimit=BANDWIDTH_SPEC ###


### PR DESCRIPTION
resoves -> resolves

Per-remote environment variables start with `RCLONE_CONFIG_`.