### PR TITLE
Fix dedupe description typo

### DIFF
--- a/cmd/dedupe/dedupe.go
+++ b/cmd/dedupe/dedupe.go
@@ -19,7 +19,7 @@ func init() {
 
 var commandDefintion = &cobra.Command{
 	Use:   "dedupe [mode] remote:path",
-	Short: `Interactively find duplicate files delete/rename them.`,
+	Short: `Interactively find duplicate files and delete/rename them.`,
 	Long: `
 By default ` + "`" + `dedupe` + "`" + ` interactively finds duplicate files and offers to
 delete all but one or rename them to be different. Only useful with


### PR DESCRIPTION
Does this trigger the regeneration of the `.md` files that contain that same typo?