### PR TITLE
 allow trailing+leading whitespace for passwords - #1717

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -551,11 +551,15 @@ func checkPassword(password string) (string, error) {
 	if !utf8.ValidString(password) {
 		return "", errors.New("password contains invalid utf8 characters")
 	}
-	// Remove leading+trailing whitespace
-	password = strings.TrimSpace(password)
+	// Check for leading/trailing whitespace
+	trimmedPassword := strings.TrimSpace(password)
+	// Warn user if password has leading+trailing whitespace
+	if len(password) != len(trimmedPassword) {
+		fmt.Fprintln(os.Stderr, "Your password contains leading/trailing whitespace - in previous versions of rclone this was stripped")
+	}
 	// Normalize to reduce weird variations.
 	password = norm.NFKC.String(password)
-	if len(password) == 0 {
+	if len(password) == 0 || len(trimmedPassword) == 0 {
 		return "", errors.New("no characters in password")
 	}
 	return password, nil

--- a/fs/config_read_password.go
+++ b/fs/config_read_password.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -22,5 +21,5 @@ func ReadPassword() string {
 	if err != nil {
 		log.Fatalf("Failed to read password: %v", err)
 	}
-	return strings.TrimSpace(string(line))
+	return string(line)
 }

--- a/fs/config_test.go
+++ b/fs/config_test.go
@@ -107,9 +107,9 @@ func TestReveal(t *testing.T) {
 		in      string
 		wantErr string
 	}{
-		{"YmJiYmJiYmJiYmJiYmJiYp*gcEWbAw", "base64 decode failed: illegal base64 data at input byte 22"},
-		{"aGVsbG8", "input too short"},
-		{"", "input too short"},
+		{"YmJiYmJiYmJiYmJiYmJiYp*gcEWbAw", "base64 decode failed when revealing password - is it obscured?: illegal base64 data at input byte 22"},
+		{"aGVsbG8", "input too short when revealing password - is it obscured?"},
+		{"", "input too short when revealing password - is it obscured?"},
 	} {
 		gotString, gotErr := Reveal(test.in)
 		assert.Equal(t, "", gotString)
@@ -202,9 +202,6 @@ func TestPassword(t *testing.T) {
 
 	// Simple check of wrong passwords
 	hashedKeyCompare(t, "mis", "match", false)
-
-	// Check that passwords match with trimmed whitespace
-	hashedKeyCompare(t, "   abcdef   \t", "abcdef", true)
 
 	// Check that passwords match after unicode normalization
 	hashedKeyCompare(t, "ﬀ\u0041\u030A", "ffÅ", true)


### PR DESCRIPTION
Warn the user if password contains trailing+leading whitespaces.