### PR TITLE
move: delete source directory after successful move - fixes #1642

### DIFF
--- a/fs/sync_test.go
+++ b/fs/sync_test.go
@@ -824,7 +824,7 @@ func testServerSideMove(t *testing.T, r *fstest.Run, withFilter bool) {
 	if withFilter {
 		fstest.CheckItems(t, r.Fremote, file2)
 	} else {
-		fstest.CheckItems(t, r.Fremote)
+		fstest.CheckRootDir(t, r.Fremote, false)
 	}
 	fstest.CheckItems(t, FremoteMove, file2, file1, file3u)
 
@@ -843,7 +843,7 @@ func testServerSideMove(t *testing.T, r *fstest.Run, withFilter bool) {
 		fstest.CheckItems(t, FremoteMove, file2)
 	} else {
 		fstest.CheckItems(t, FremoteMove2, file2, file1, file3u)
-		fstest.CheckItems(t, FremoteMove)
+		fstest.CheckRootDir(t, FremoteMove, false)
 	}
 }
 

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -262,6 +262,7 @@ func CheckListingWithPrecision(t *testing.T, f fs.Fs, items []Item, expectedDirs
 		if err != nil && err != fs.ErrorDirNotFound {
 			t.Fatalf("Error listing: %v", err)
 		}
+
 		gotListing = makeListingFromObjects(objs)
 		listingOK = wantListing1 == gotListing || wantListing2 == gotListing
 		if listingOK && (expectedDirs == nil || len(dirs) == len(expectedDirs)) {
@@ -318,6 +319,16 @@ func CheckListing(t *testing.T, f fs.Fs, items []Item) {
 // using a precision of fs.Config.ModifyWindow
 func CheckItems(t *testing.T, f fs.Fs, items ...Item) {
 	CheckListingWithPrecision(t, f, items, nil, fs.Config.ModifyWindow)
+}
+
+// CheckRootDir checks the fs to see if the root dir exists or not
+func CheckRootDir(t *testing.T, f fs.Fs, shouldExist bool) {
+	_, _, err := fs.WalkGetAll(f, "", true, -1)
+	if shouldExist {
+		require.NoError(t, err)
+	} else {
+		assert.EqualError(t, err, fs.ErrorDirNotFound.Error())
+	}
 }
 
 // Time parses a time string or logs a fatal error


### PR DESCRIPTION
This fixes a bug where `rclone move` does not delete the source directory after completion.