### PR TITLE
rclone: implement exit codes - #1136

### DIFF
--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -72,7 +72,7 @@ func cryptCheck(fdst, fsrc fs.Fs) error {
 		underlyingDst := cryptDst.UnWrap()
 		underlyingHash, err := underlyingDst.Hash(hashType)
 		if err != nil {
-			fs.Stats.Error()
+			fs.Stats.Error(err)
 			fs.Errorf(dst, "Error reading hash from underlying %v: %v", underlyingDst, err)
 			return true, false
 		}
@@ -81,7 +81,7 @@ func cryptCheck(fdst, fsrc fs.Fs) error {
 		}
 		cryptHash, err := fcrypt.ComputeHash(cryptDst, src, hashType)
 		if err != nil {
-			fs.Stats.Error()
+			fs.Stats.Error(err)
 			fs.Errorf(dst, "Error computing hash: %v", err)
 			return true, false
 		}
@@ -89,8 +89,9 @@ func cryptCheck(fdst, fsrc fs.Fs) error {
 			return false, true
 		}
 		if cryptHash != underlyingHash {
-			fs.Stats.Error()
-			fs.Errorf(src, "hashes differ (%s:%s) %q vs (%s:%s) %q", fdst.Name(), fdst.Root(), cryptHash, fsrc.Name(), fsrc.Root(), underlyingHash)
+			err = errors.Errorf("hashes differ (%s:%s) %q vs (%s:%s) %q", fdst.Name(), fdst.Root(), cryptHash, fsrc.Name(), fsrc.Root(), underlyingHash)
+			fs.Stats.Error(err)
+			fs.Errorf(src, err.Error())
 			return true, false
 		}
 		fs.Debugf(src, "OK")

--- a/cmd/ls2/ls2.go
+++ b/cmd/ls2/ls2.go
@@ -27,7 +27,7 @@ var commandDefintion = &cobra.Command{
 		cmd.Run(false, false, command, func() error {
 			return fs.Walk(fsrc, "", false, fs.ConfigMaxDepth(recurse), func(path string, entries fs.DirEntries, err error) error {
 				if err != nil {
-					fs.Stats.Error()
+					fs.Stats.Error(err)
 					fs.Errorf(path, "error listing: %v", err)
 					return nil
 				}

--- a/cmd/lsjson/lsjson.go
+++ b/cmd/lsjson/lsjson.go
@@ -85,7 +85,7 @@ can be processed line by line as each item is written one to a line.
 			first := true
 			err := fs.Walk(fsrc, "", false, fs.ConfigMaxDepth(recurse), func(dirPath string, entries fs.DirEntries, err error) error {
 				if err != nil {
-					fs.Stats.Error()
+					fs.Stats.Error(err)
 					fs.Errorf(dirPath, "error listing: %v", err)
 					return nil
 				}

--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -142,7 +142,7 @@ type indexData struct {
 
 // error returns an http.StatusInternalServerError and logs the error
 func internalError(what interface{}, w http.ResponseWriter, text string, err error) {
-	fs.Stats.Error()
+	fs.Stats.Error(err)
 	fs.Errorf(what, "%s: %v", text, err)
 	http.Error(w, text+".", http.StatusInternalServerError)
 }

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1023,6 +1023,16 @@ when starting a retry so the user can see that any previous error
 messages may not be valid after the retry. If rclone has done a retry
 it will log a high priority message if the retry was successful.
 
+### List of exit codes ###
+  * `0` - success
+  * `1` - Syntax or usage error
+  * `2` - Error not otherwise categorised
+  * `3` - Directory not found
+  * `4` - File not found
+  * `5` - Temporary error (one that more retries might fix) (Retry errors)
+  * `6` - Less serious errors (like 461 errors from dropbox) (NoRetry errors)
+  * `7` - Fatal error (one that more retries won't fix, like account suspended) (Fatal errors)
+
 Environment Variables
 ---------------------
 

--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -169,6 +169,7 @@ type StatsInfo struct {
 	lock         sync.RWMutex
 	bytes        int64
 	errors       int64
+	lastError    error
 	checks       int64
 	checking     stringSet
 	transfers    int64
@@ -251,6 +252,13 @@ func (s *StatsInfo) GetErrors() int64 {
 	return s.errors
 }
 
+// GetLastError returns the lastError
+func (s *StatsInfo) GetLastError() error {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.lastError
+}
+
 // ResetCounters sets the counters (bytes, checks, errors, transfers) to 0
 func (s *StatsInfo) ResetCounters() {
 	s.lock.RLock()
@@ -275,11 +283,12 @@ func (s *StatsInfo) Errored() bool {
 	return s.errors != 0
 }
 
-// Error adds a single error into the stats
-func (s *StatsInfo) Error() {
+// Error adds a single error into the stats and assigns lastError
+func (s *StatsInfo) Error(err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.errors++
+	s.lastError = err
 }
 
 // Checking adds a check into the stats

--- a/fs/march.go
+++ b/fs/march.go
@@ -342,14 +342,14 @@ func (m *march) processJob(job listDirJob) (jobs []listDirJob) {
 	wg.Wait()
 	if srcListErr != nil {
 		Errorf(job.srcRemote, "error reading source directory: %v", srcListErr)
-		Stats.Error()
+		Stats.Error(srcListErr)
 		return nil
 	}
 	if dstListErr == ErrorDirNotFound {
 		// Copy the stuff anyway
 	} else if dstListErr != nil {
 		Errorf(job.dstRemote, "error reading destination directory: %v", dstListErr)
-		Stats.Error()
+		Stats.Error(dstListErr)
 		return nil
 	}
 

--- a/fs/sync.go
+++ b/fs/sync.go
@@ -885,7 +885,7 @@ func MoveDir(fdst, fsrc Fs) error {
 			Infof(fdst, "Server side directory move succeeded")
 			return nil
 		default:
-			Stats.Error()
+			Stats.Error(err)
 			Errorf(fdst, "Server side directory move failed: %v", err)
 			return err
 		}

--- a/fs/sync_test.go
+++ b/fs/sync_test.go
@@ -580,7 +580,7 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 	)
 
 	fs.Stats.ResetCounters()
-	fs.Stats.Error()
+	fs.Stats.Error(nil)
 	err := fs.Sync(r.Fremote, r.Flocal)
 	assert.Equal(t, fs.ErrorNotDeleting, err)
 

--- a/fs/walk.go
+++ b/fs/walk.go
@@ -134,7 +134,7 @@ func walk(f Fs, path string, includeAll bool, maxLevel int, fn WalkFunc, listDir
 					// NB once we have passed entries to fn we mustn't touch it again
 					if err != nil && err != ErrorSkipDir {
 						traversing.Done()
-						Stats.Error()
+						Stats.Error(err)
 						Errorf(job.remote, "error listing: %v", err)
 						closeQuit()
 						// Send error to error channel if space


### PR DESCRIPTION
This PR implements exit codes as specified in [this comment](https://github.com/ncw/rclone/issues/1136#issuecomment-280131615) by @ncw. [#1136]

I've tried to make the changes as concise as possible, only affecting `cmd/cmd.go`.
I have a few issues with [L300](https://github.com/ncw/rclone/commit/f45dcd2a9db897b34a5d4c30237a5d01014cad38#diff-f8528230b76c77a45f085693ebe846d5R300): there's no error to examine but we know an error was caught somewhere up the chain. I've tagged those errors with the `Error not otherwise categorised` exit code.