### PR TITLE
stats: show the amount of data transferred in kb/mb - fixes #1167

### DIFF
--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -561,7 +561,7 @@ func (acc *Account) ETA() (eta time.Duration, ok bool) {
 // String produces stats for this file
 func (acc *Account) String() string {
 	a, b := acc.Progress()
-	_, cur := acc.Speed()
+	bps, cur := acc.Speed()
 	eta, etaok := acc.ETA()
 	etas := "-"
 	if etaok {
@@ -581,13 +581,16 @@ func (acc *Account) String() string {
 		cur = cur * 8
 	}
 
-	done := ""
+	done := fmt.Sprintf("%2s/%s", SizeSuffix(a), SizeSuffix(b))
 	if b > 0 {
-		done = fmt.Sprintf("%2d%% done, ", int(100*float64(a)/float64(b)))
+		done += fmt.Sprintf(" %2d%% done, ", int(100*float64(a)/float64(b)))
+	} else {
+		done += " 0%% done, "
 	}
-	return fmt.Sprintf("%45s: %s%s, ETA: %s",
+	return fmt.Sprintf("%45s: %s%s / %s, ETA: %s",
 		string(name),
 		done,
+		SizeSuffix(bps).Unit(strings.Title(Config.DataRateUnit)+"/s"),
 		SizeSuffix(cur).Unit(strings.Title(Config.DataRateUnit)+"/s"),
 		etas,
 	)


### PR DESCRIPTION
This PR enhances stats by adding the amount of data transferred vs the file size (in kb/mb/gb) and the current file transfer speed.
The transfer stats before:
```
4ea6039cadcc6860.mp4: 64% done, 2.049 MBytes/s, ETA: 17s
```
The improved transfer stats:
```
4ea6039cadcc6860.mp4: 64.438M/99.533M 64% done, 1.988 MBytes/s / 2.088 MBytes/s, ETA: 14s
```
**64.438M/99.533M** amount of data transferred in kb/mb/gb
**1.988 MBytes/s** current file transfer speed

I did not include the buffer stats (as requested https://github.com/ncw/rclone/issues/1167#issuecomment-281671324)
Fixes #1167 