### PR TITLE
 mountlib: log when poll-interval is ineffective

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -196,6 +196,8 @@ func New(f fs.Fs, opt *Options) *VFS {
 	if vfs.Opt.PollInterval > 0 {
 		if do := vfs.f.Features().DirChangeNotify; do != nil {
 			do(vfs.root.ForgetPath, vfs.Opt.PollInterval)
+		} else {
+			fs.Logf(f, "poll-interval is not supported by this remote")
 		}
 	}
 	return vfs


### PR DESCRIPTION
 Notify the user in case poll-interval is used on a unsupported remote