### PR TITLE
fuse: implement the systemd notify interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,6 +152,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/okzk/sdnotify"
+  packages = ["."]
+  revision = "ed8ca104421a21947710335006107540e3ecb335"
+
+[[projects]]
+  branch = "master"
   name = "github.com/patrickmn/go-cache"
   packages = ["."]
   revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
@@ -297,6 +303,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "63cb991f1167ff9f656f36bf3bb59831cde5402d70729a5709088ae73388c69e"
+  inputs-digest = "f53d8d2a21862f225ba86e4575a68ce73db8957959ca507e5eded837c5dbcf73"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -144,3 +144,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/patrickmn/go-cache"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/okzk/sdnotify"

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -156,6 +156,14 @@ Assuming only one rclone instance is running, you can reset the cache
 like this:
 
     kill -SIGHUP $(pidof rclone)
+
+### systemd ###
+
+When running rclone ` + commandName + ` as a systemd service, it is possible
+to use Type=notify. In this case the service will enter the started state 
+after the mountpoint has been successfully set up.
+Units having the rclone ` + commandName + ` service specified as a requirement
+will see all files and folders immediately in this mode.
 `,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.CheckArgs(2, 2, command, args)

--- a/vendor/github.com/okzk/sdnotify/LICENSE
+++ b/vendor/github.com/okzk/sdnotify/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 okzk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/okzk/sdnotify/README.md
+++ b/vendor/github.com/okzk/sdnotify/README.md
@@ -1,0 +1,15 @@
+# sdnotify
+
+sd_notify utility for golang.
+
+## Installation
+
+    go get github.com/okzk/sdnotify
+
+## Example
+
+see [sample/main.go](sample/main.go)
+
+## License
+
+MIT

--- a/vendor/github.com/okzk/sdnotify/notify.go
+++ b/vendor/github.com/okzk/sdnotify/notify.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package sdnotify
+
+func SdNotify(state string) error {
+	// do nothing
+	return nil
+}

--- a/vendor/github.com/okzk/sdnotify/notify_linux.go
+++ b/vendor/github.com/okzk/sdnotify/notify_linux.go
@@ -1,0 +1,22 @@
+package sdnotify
+
+import (
+	"net"
+	"os"
+)
+
+func SdNotify(state string) error {
+	name := os.Getenv("NOTIFY_SOCKET")
+	if name == "" {
+		return SdNotifyNoSocket
+	}
+
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: name, Net: "unixgram"})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(state))
+	return err
+}

--- a/vendor/github.com/okzk/sdnotify/sample/main.go
+++ b/vendor/github.com/okzk/sdnotify/sample/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/okzk/sdnotify"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func reload() {
+	// Tells the service manager that the service is reloading its configuration.
+	sdnotify.SdNotifyReloading()
+
+	log.Println("reloading...")
+	time.Sleep(time.Second)
+	log.Println("reloaded.")
+
+	// The service must also send a "READY" notification when it completed reloading its configuration.
+	sdnotify.SdNotifyReady()
+}
+
+func main() {
+	log.Println("starting...")
+	time.Sleep(time.Second)
+	log.Println("started.")
+
+	// Tells the service manager that service startup is finished.
+	sdnotify.SdNotifyReady()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	for sig := range sigCh {
+		if sig == syscall.SIGHUP {
+			reload()
+		} else {
+			break
+		}
+	}
+
+	// Tells the service manager that the service is beginning its shutdown.
+	sdnotify.SdNotifyStopping()
+
+	log.Println("existing...")
+	time.Sleep(time.Second)
+}

--- a/vendor/github.com/okzk/sdnotify/sample/sample.service
+++ b/vendor/github.com/okzk/sdnotify/sample/sample.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=sample
+
+[Service]
+Type=notify
+ExecStart=/path/to/sample
+ExecStop=/bin/kill -SIGTERM $MAINPID
+ExecReload=/bin/kill -SIGHUP $MAINPID
+
+[Install]
+WantedBy = multi-user.target

--- a/vendor/github.com/okzk/sdnotify/util.go
+++ b/vendor/github.com/okzk/sdnotify/util.go
@@ -1,0 +1,21 @@
+package sdnotify
+
+import "errors"
+
+var SdNotifyNoSocket = errors.New("No socket")
+
+func SdNotifyReady() error {
+	return SdNotify("READY=1")
+}
+
+func SdNotifyStopping() error {
+	return SdNotify("STOPPING=1")
+}
+
+func SdNotifyReloading() error {
+	return SdNotify("RELOADING=1")
+}
+
+func SdNotifyStatus(status string) error {
+	return SdNotify("STATUS=" + status)
+}


### PR DESCRIPTION
This change implements the systemd notify interface on linux for the mount and cmount commands.

Before this it was not possible to use systemd service dependencies to wait for the FUSE mount to be active. Services depending on a rclone mount would only see an empty folder.

Now it is possible to use `Type=notify` and the service will be considered started after the fuse mount is ready.