### PR TITLE
filter: warn the user if he use --include and --exclude together fixes #1764

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -167,6 +167,9 @@ type.
   * `--filter`
   * `--filter-from`
 
+**Important** You should not use `--include*` together with `--exclude*`. 
+It may produce different results than you expected. In that case try to use: `--filter*`.
+
 Note that all the options of the same type are processed together in
 the order above, regardless of what order they were placed on the
 command line.

--- a/fs/filter.go
+++ b/fs/filter.go
@@ -156,6 +156,7 @@ func NewFilter() (f *Filter, err error) {
 		MaxSize:        int64(maxSize),
 	}
 	addImplicitExclude := false
+	foundExcludeRule := false
 
 	if includeRule != nil {
 		for _, rule := range *includeRule {
@@ -183,6 +184,7 @@ func NewFilter() (f *Filter, err error) {
 			if err != nil {
 				return nil, err
 			}
+			foundExcludeRule = true
 		}
 	}
 	if excludeFrom != nil {
@@ -193,8 +195,14 @@ func NewFilter() (f *Filter, err error) {
 			if err != nil {
 				return nil, err
 			}
+			foundExcludeRule = true
 		}
 	}
+
+	if addImplicitExclude && foundExcludeRule {
+		Infof(nil, "Using --filter is recommended instead of both --include and --exclude as the order they are parsed in is indeterminate")
+	}
+
 	if filterRule != nil {
 		for _, rule := range *filterRule {
 			err = f.AddRule(rule)


### PR DESCRIPTION
Rclone now warns user about using --include and --exclude filters together. 