### PR TITLE
s3: add support for ECS task IAM roles

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -51,7 +51,7 @@ Choose a number from below, or type in your own value
 13 / Yandex Disk
    \ "yandex"
 Storage> 2
-Get AWS credentials from runtime (environment variables or EC2 meta data if no env vars). Only applies if access_key_id and secret_access_key is blank.
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars). Only applies if access_key_id and secret_access_key is blank.
 Choose a number from below, or type in your own value
  1 / Enter AWS credentials in the next step
    \ "false"
@@ -248,6 +248,7 @@ credentials. In order of precedence:
      - Access Key ID: `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY`
      - Secret Access Key: `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY`
      - Session Token: `AWS_SESSION_TOKEN`
+   - Running `rclone` in an ECS task with an IAM role
    - Running `rclone` on an EC2 instance with an IAM role
 
 If none of these option actually end up providing `rclone` with AWS
@@ -358,7 +359,7 @@ Choose a number from below
 10) s3
 11) yandex
 type> 10
-Get AWS credentials from runtime (environment variables or EC2 meta data if no env vars). Only applies if access_key_id and secret_access_key is blank.
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars). Only applies if access_key_id and secret_access_key is blank.
 Choose a number from below, or type in your own value
  * Enter AWS credentials in the next step
  1) false
@@ -551,7 +552,7 @@ Choose a number from below, or type in your own value
    \ "s3"
 [snip]
 Storage> s3
-Get AWS credentials from runtime (environment variables or EC2 meta data if no env vars). Only applies if access_key_id and secret_access_key is blank.
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars). Only applies if access_key_id and secret_access_key is blank.
 Choose a number from below, or type in your own value
  1 / Enter AWS credentials in the next step
    \ "false"


### PR DESCRIPTION
ECS container IAM metadata is in a different place than EC2 IAM metadata.
Use defaults' RemoteCredProvider function to query the standard locations
for the credentials.

Give the ECS role precedence over the role available from the underlying
EC2 instance.