### PR TITLE
move: fixed root source directories getting deleted after move - fixes #1849

### DIFF
--- a/fs/sync.go
+++ b/fs/sync.go
@@ -697,18 +697,10 @@ func (s *syncCopyMove) run() error {
 		}
 	}
 
-	// if DoMove, delete fsrc directory after
+	// if DoMove, delete empty fsrc subdirectories after
 	if s.DoMove {
-		//first delete any subdirectories in fsrc
+		//delete empty subdirectories that were part of the move
 		s.processError(deleteEmptyDirectories(s.fsrc, s.srcEmptyDirs))
-		//delete fsrc dir
-		s.processError(func() error {
-			err := TryRmdir(s.fsrc, "")
-			if err != nil {
-				Debugf(logDirName(s.fsrc, ""), "Failed to Rmdir: %v", err)
-			}
-			return nil
-		}())
 	}
 	return s.currentError()
 }

--- a/fs/sync_test.go
+++ b/fs/sync_test.go
@@ -824,7 +824,7 @@ func testServerSideMove(t *testing.T, r *fstest.Run, withFilter bool) {
 	if withFilter {
 		fstest.CheckItems(t, r.Fremote, file2)
 	} else {
-		fstest.CheckRootDir(t, r.Fremote, false)
+		fstest.CheckItems(t, r.Fremote)
 	}
 	fstest.CheckItems(t, FremoteMove, file2, file1, file3u)
 
@@ -843,7 +843,7 @@ func testServerSideMove(t *testing.T, r *fstest.Run, withFilter bool) {
 		fstest.CheckItems(t, FremoteMove, file2)
 	} else {
 		fstest.CheckItems(t, FremoteMove2, file2, file1, file3u)
-		fstest.CheckRootDir(t, FremoteMove, false)
+		fstest.CheckItems(t, FremoteMove)
 	}
 }
 

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -325,16 +325,6 @@ func CheckItems(t *testing.T, f fs.Fs, items ...Item) {
 	CheckListingWithPrecision(t, f, items, nil, fs.Config.ModifyWindow)
 }
 
-// CheckRootDir checks the fs to see if the root dir exists or not
-func CheckRootDir(t *testing.T, f fs.Fs, shouldExist bool) {
-	_, _, err := fs.WalkGetAll(f, "", true, -1)
-	if shouldExist {
-		require.NoError(t, err)
-	} else {
-		assert.EqualError(t, err, fs.ErrorDirNotFound.Error())
-	}
-}
-
 // Time parses a time string or logs a fatal error
 func Time(timeString string) time.Time {
 	t, err := time.Parse(time.RFC3339Nano, timeString)


### PR DESCRIPTION
This fixes the bug where root source directories get deleted after move (caused by ace9a3492438)

In this PR, deletion after a successful move is limited to directories involved in the move. The root directory does get deleted.

