### PR TITLE
move: add --delete-empty-src-dirs flag - fixes #1854

### DIFF
--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -6,8 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Globals
+var (
+	deleteEmptySrcDirs = false
+)
+
 func init() {
 	cmd.Root.AddCommand(commandDefintion)
+	commandDefintion.Flags().BoolVarP(&deleteEmptySrcDirs, "delete-empty-src-dirs", "", deleteEmptySrcDirs, "Delete empty source dirs after move")
 }
 
 var commandDefintion = &cobra.Command{
@@ -28,6 +34,8 @@ move will be used, otherwise it will copy it (server side if possible)
 into ` + "`dest:path`" + ` then delete the original (if no errors on copy) in
 ` + "`source:path`" + `.
 
+If you want to delete empty source directories after move, use the --delete-empty-src-dirs flag.
+
 **Important**: Since this can cause data loss, test first with the
 --dry-run flag.
 `,
@@ -35,7 +43,8 @@ into ` + "`dest:path`" + ` then delete the original (if no errors on copy) in
 		cmd.CheckArgs(2, 2, command, args)
 		fsrc, fdst := cmd.NewFsSrcDst(args)
 		cmd.Run(true, true, command, func() error {
-			return fs.MoveDir(fdst, fsrc)
+
+			return fs.MoveDir(fdst, fsrc, deleteEmptySrcDirs)
 		})
 	},
 }

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -49,7 +49,7 @@ transfer.
 
 		cmd.Run(true, true, command, func() error {
 			if srcFileName == "" {
-				return fs.MoveDir(fdst, fsrc)
+				return fs.MoveDir(fdst, fsrc, false)
 			}
 			return fs.MoveFile(fdst, fsrc, dstFileName, srcFileName)
 		})

--- a/docs/content/commands/rclone_move.md
+++ b/docs/content/commands/rclone_move.md
@@ -26,6 +26,8 @@ move will be used, otherwise it will copy it (server side if possible)
 into `dest:path` then delete the original (if no errors on copy) in
 `source:path`.
 
+If you want to delete empty source directories after move, use the --delete-empty-source-dirs flag.
+
 **Important**: Since this can cause data loss, test first with the
 --dry-run flag.
 
@@ -37,7 +39,8 @@ rclone move source:path dest:path [flags]
 ### Options
 
 ```
-  -h, --help   help for move
+      --delete-empty-src-dirs   Delete empty dirs after move
+  -h, --help                help for move
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This PR adds a `--delete-empty-src-dirs` flag to the move command. 
If this flag is set then all empty directories in the source are deleted after move.

fixes #1854 