### PR TITLE
S3: Add ETag support - fixes #523

### DIFF
--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -89,7 +89,7 @@ func cryptCheck(fdst, fsrc fs.Fs) error {
 			return false, true
 		}
 		if cryptHash != underlyingHash {
-			err = errors.Errorf("hashes differ (%s:%s) %q vs (%s:%s) %q", fdst.Name(), fdst.Root(), cryptHash, fsrc.Name(), fsrc.Root(), underlyingHash)
+			err = errors.Errorf("hashes differ (%s:%s) %q vs (%s:%s) %q", fsrc.Name(), fsrc.Root(), cryptHash, fdst.Name(), fdst.Root(), underlyingHash)
 			fs.Stats.Error(err)
 			fs.Errorf(src, err.Error())
 			return true, false

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -210,7 +210,7 @@ func (r *results) checkStreaming() {
 
 	contents := "thinking of test strings is hard"
 	buf := bytes.NewBufferString(contents)
-	hashIn := fs.NewMultiHasher()
+	hashIn := fs.NewMultiHasher(int64(buf.Len()))
 	in := io.TeeReader(buf, hashIn)
 
 	objIn := fs.NewStaticObjectInfo("checkStreamingTest", time.Now(), -1, true, nil, r.f)

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -494,7 +494,7 @@ func (f *Fs) ComputeHash(o *Object, src fs.Object, hashType fs.HashType) (hash s
 	}
 
 	// pipe into hash
-	m := fs.NewMultiHasher()
+	m := fs.NewMultiHasher(o.UnWrap().Size())
 	_, err = io.Copy(m, out)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to hash data")

--- a/fs/hash_test.go
+++ b/fs/hash_test.go
@@ -68,6 +68,7 @@ var hashTestSet = []hashTest{
 			fs.HashMD5:     "bf13fc19e5151ac57d4252e0e0f87abe",
 			fs.HashSHA1:    "3ab6543c08a75f292a5ecedac87ec41642d12166",
 			fs.HashDropbox: "214d2fcf3566e94c99ad2f59bd993daca46d8521a0c447adf4b324f53fddc0c7",
+			fs.HashS3ETag:  "bf13fc19e5151ac57d4252e0e0f87abe0001",
 		},
 	},
 	// Empty data set
@@ -77,13 +78,14 @@ var hashTestSet = []hashTest{
 			fs.HashMD5:     "d41d8cd98f00b204e9800998ecf8427e",
 			fs.HashSHA1:    "da39a3ee5e6b4b0d3255bfef95601890afd80709",
 			fs.HashDropbox: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			fs.HashS3ETag:  "d41d8cd98f00b204e9800998ecf8427e0001",
 		},
 	},
 }
 
 func TestMultiHasher(t *testing.T) {
 	for _, test := range hashTestSet {
-		mh := fs.NewMultiHasher()
+		mh := fs.NewMultiHasher(int64(len(test.input)))
 		n, err := io.Copy(mh, bytes.NewBuffer(test.input))
 		require.NoError(t, err)
 		assert.Len(t, test.input, int(n))
@@ -105,7 +107,7 @@ func TestMultiHasher(t *testing.T) {
 func TestMultiHasherTypes(t *testing.T) {
 	h := fs.HashSHA1
 	for _, test := range hashTestSet {
-		mh, err := fs.NewMultiHasherTypes(fs.NewHashSet(h))
+		mh, err := fs.NewMultiHasherTypes(fs.NewHashSet(h), int64(len(test.input)))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,7 +122,7 @@ func TestMultiHasherTypes(t *testing.T) {
 
 func TestHashStream(t *testing.T) {
 	for _, test := range hashTestSet {
-		sums, err := fs.HashStream(bytes.NewBuffer(test.input))
+		sums, err := fs.HashStream(bytes.NewBuffer(test.input), int64(len(test.input)))
 		require.NoError(t, err)
 		for k, v := range sums {
 			expect, ok := test.output[k]
@@ -139,7 +141,7 @@ func TestHashStream(t *testing.T) {
 func TestHashStreamTypes(t *testing.T) {
 	h := fs.HashSHA1
 	for _, test := range hashTestSet {
-		sums, err := fs.HashStreamTypes(bytes.NewBuffer(test.input), fs.NewHashSet(h))
+		sums, err := fs.HashStreamTypes(bytes.NewBuffer(test.input), fs.NewHashSet(h), int64(len(test.input)))
 		require.NoError(t, err)
 		assert.Len(t, sums, 1)
 		assert.Equal(t, sums[h], test.output[h])

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -1592,7 +1592,7 @@ func Rcat(fdst Fs, dstFileName string, in io.ReadCloser, modTime time.Time) (dst
 	}()
 
 	hashOption := &HashesOption{Hashes: fdst.Hashes()}
-	hash, err := NewMultiHasherTypes(fdst.Hashes())
+	hash, err := NewMultiHasherTypes(fdst.Hashes(), -1)
 	if err != nil {
 		return nil, err
 	}

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -85,8 +85,8 @@ func NewItem(Path, Content string, modTime time.Time) Item {
 		ModTime: modTime,
 		Size:    int64(len(Content)),
 	}
-	hash := fs.NewMultiHasher()
 	buf := bytes.NewBufferString(Content)
+	hash := fs.NewMultiHasher(int64(buf.Len()))
 	_, err := io.Copy(hash, buf)
 	if err != nil {
 		log.Fatalf("Failed to create item: %v", err)

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -282,7 +282,7 @@ func testPut(t *testing.T, file *fstest.Item) string {
 again:
 	contents := fstest.RandomString(100)
 	buf := bytes.NewBufferString(contents)
-	hash := fs.NewMultiHasher()
+	hash := fs.NewMultiHasher(int64(buf.Len()))
 	in := io.TeeReader(buf, hash)
 
 	file.Size = int64(buf.Len())
@@ -817,7 +817,7 @@ func TestObjectUpdate(t *testing.T) {
 	skipIfNotOk(t)
 	contents := fstest.RandomString(200)
 	buf := bytes.NewBufferString(contents)
-	hash := fs.NewMultiHasher()
+	hash := fs.NewMultiHasher(int64(buf.Len()))
 	in := io.TeeReader(buf, hash)
 
 	file1.Size = int64(buf.Len())
@@ -896,7 +896,7 @@ again:
 	contentSize := 100
 	contents := fstest.RandomString(contentSize)
 	buf := bytes.NewBufferString(contents)
-	hash := fs.NewMultiHasher()
+	hash := fs.NewMultiHasher(int64(buf.Len()))
 	in := io.TeeReader(buf, hash)
 
 	file.Size = -1

--- a/local/local.go
+++ b/local/local.go
@@ -576,7 +576,7 @@ func (o *Object) Hash(r fs.HashType) (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "hash: failed to open")
 		}
-		o.hashes, err = fs.HashStream(in)
+		o.hashes, err = fs.HashStream(in, o.size)
 		closeErr := in.Close()
 		if err != nil {
 			return "", errors.Wrap(err, "hash: failed to read")
@@ -694,7 +694,7 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 		// don't attempt to make checksums
 		return fd, err
 	}
-	hash, err := fs.NewMultiHasherTypes(hashes)
+	hash, err := fs.NewMultiHasherTypes(hashes, o.size)
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +734,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	}
 
 	// Calculate the hash of the object we are reading as we go along
-	hash, err := fs.NewMultiHasherTypes(hashes)
+	hash, err := fs.NewMultiHasherTypes(hashes, src.Size())
 	if err != nil {
 		return err
 	}

--- a/s3/s3etag/s3etag.go
+++ b/s3/s3etag/s3etag.go
@@ -1,0 +1,141 @@
+// Package s3etag implements the AWS ETag hash as described in
+//
+// http://permalink.gmane.org/gmane.comp.file-systems.s3.s3tools/583
+package s3etag
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"hash"
+
+	"github.com/ncw/rclone/s3/s3sizes"
+)
+
+const (
+	hashSize          = 32
+	partCountSize     = 4
+	size              = hashSize + partCountSize
+	hashReturnedError = "hash function returned error"
+)
+
+type digest struct {
+	n           int64 // bytes written into blockHash so far
+	blockHash   hash.Hash
+	totalHash   hash.Hash
+	sumCalled   bool
+	writtenMore bool
+	partSize    int64
+	partCount   uint16
+}
+
+// New returns a new hash.Hash computing the S3ETag checksum.
+func New(size int64) hash.Hash {
+	partSize := s3sizes.PartSize(size)
+	d := &digest{
+		partSize: partSize,
+	}
+	d.Reset()
+	return d
+}
+
+// Reset resets the Hash to its initial state.
+func (d *digest) Reset() {
+	d.n = 0
+	d.totalHash = md5.New()
+	d.blockHash = md5.New()
+	d.sumCalled = false
+	d.writtenMore = false
+	d.partCount = 1
+}
+
+// writeBlockHash writes the current block hash into the total hash
+func (d *digest) writeBlockHash() {
+	blockHash := d.blockHash.Sum(nil)
+	_, err := d.totalHash.Write(blockHash)
+	if err != nil {
+		panic(hashReturnedError)
+	}
+	// reset counters for blockhash
+	d.n = 0
+	d.blockHash.Reset()
+}
+
+// Write writes len(p) bytes from p to the underlying data stream. It returns
+// the number of bytes written from p (0 <= n <= len(p)) and any error
+// encountered that caused the write to stop early. Write must return a non-nil
+// error if it returns n < len(p). Write must not modify the slice data, even
+// temporarily.
+//
+// Implementations must not retain p.
+func (d *digest) Write(p []byte) (n int, err error) {
+	n = len(p)
+	for len(p) > 0 {
+		if d.n == d.partSize {
+			d.writeBlockHash()
+			d.partCount++
+		}
+		d.writtenMore = true
+		toWrite := d.partSize - d.n
+		if toWrite > int64(len(p)) {
+			toWrite = int64(len(p))
+		}
+		_, err = d.blockHash.Write(p[:toWrite])
+		if err != nil {
+			panic(hashReturnedError)
+		}
+		d.n += toWrite
+		p = p[toWrite:]
+		// Accumulate the total hash
+	}
+	return n, nil
+}
+
+// Sum appends the current hash to b and returns the resulting slice.
+// It does not change the underlying hash state.
+//
+// TODO(ncw) Sum() can only be called once for this type of hash.
+// If you call Sum(), then Write() then Sum() it will result in
+// a panic.  Calling Write() then Sum(), then Sum() is OK.
+func (d *digest) Sum(b []byte) []byte {
+	if d.sumCalled && d.writtenMore {
+		panic("digest.Sum() called more than once")
+	}
+	d.sumCalled = true
+	d.writtenMore = false
+	if d.partCount > 1 {
+		if d.n != 0 {
+			d.writeBlockHash()
+		}
+		b = d.totalHash.Sum(b)
+	} else {
+		b = d.blockHash.Sum(b)
+	}
+	c := make([]byte, 2)
+	binary.BigEndian.PutUint16(c, d.partCount)
+	return append(b, c...)
+}
+
+// Size returns the number of bytes Sum will return.
+func (d *digest) Size() int {
+	return size
+}
+
+// BlockSize returns the hash's underlying block size.
+// The Write method must be able to accept any amount
+// of data, but it may operate more efficiently if all writes
+// are a multiple of the block size.
+func (d *digest) BlockSize() int {
+	return d.blockHash.BlockSize()
+}
+
+// Sum returns the S3 ETag checksum of the data.
+func Sum(data []byte) [size]byte {
+	d := New(int64(len(data)))
+	_, _ = d.Write(data)
+	var out [size]byte
+	d.Sum(out[:0])
+	return out
+}
+
+// must implement this interface
+var _ hash.Hash = (*digest)(nil)

--- a/s3/s3etag/s3etag_test.go
+++ b/s3/s3etag/s3etag_test.go
@@ -1,0 +1,86 @@
+package s3etag_test
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/ncw/rclone/s3/s3etag"
+	"github.com/stretchr/testify/assert"
+)
+
+func testChunk(t *testing.T, chunk int) {
+	data := make([]byte, chunk)
+	for i := 0; i < chunk; i++ {
+		data[i] = 'A'
+	}
+	for _, test := range []struct {
+		n    int
+		want string
+	}{
+		{0, "d41d8cd98f00b204e9800998ecf8427e0001"},
+		{1, "7fc56270e7a70fa81a5935b72eacbe290001"},
+		{2, "3b98e2dffc6cb06a89dcb0d5c60a02060001"},
+		{4096, "82a7348c2e03731109d0cf45a7325b880001"},
+		{4194303, "641df9678a8c9a1527879c6852fe91730001"},
+		{4194304, "4a31ac3594cb245c08e134ec06b3057e0001"},
+		{4194305, "66816f4e9f5e61a7925026675e63ad4f0001"},
+		{8388607, "bc229508beb212045c0708355548ee720002"},
+		{8388608, "6ebd5a9ae5b0bccec7a57598aa48b6af0002"},
+		{8388609, "c1c497519ddb7926871193810877832b0002"},
+	} {
+		s := s3etag.New(int64(test.n))
+		var toWrite int
+		for toWrite = test.n; toWrite >= chunk; toWrite -= chunk {
+			n, err := s.Write(data)
+			assert.Nil(t, err)
+			assert.Equal(t, chunk, n)
+		}
+		n, err := s.Write(data[:toWrite])
+		assert.Nil(t, err)
+		assert.Equal(t, toWrite, n)
+		got := hex.EncodeToString(s.Sum(nil))
+		assert.Equal(t, test.want, got, fmt.Sprintf("when testing length %d", n))
+	}
+}
+
+func TestHashChunk16M(t *testing.T)  { testChunk(t, 16*1024*1024) }
+func TestHashChunk8M(t *testing.T)   { testChunk(t, 8*1024*1024) }
+func TestHashChunk4M(t *testing.T)   { testChunk(t, 4*1024*1024) }
+func TestHashChunk2M(t *testing.T)   { testChunk(t, 2*1024*1024) }
+func TestHashChunk1M(t *testing.T)   { testChunk(t, 1*1024*1024) }
+func TestHashChunk64k(t *testing.T)  { testChunk(t, 64*1024) }
+func TestHashChunk32k(t *testing.T)  { testChunk(t, 32*1024) }
+func TestHashChunk2048(t *testing.T) { testChunk(t, 2048) }
+func TestHashChunk2047(t *testing.T) { testChunk(t, 2047) }
+
+func TestSumCalledTwice(t *testing.T) {
+	s := s3etag.New(-1)
+	assert.NotPanics(t, func() { s.Sum(nil) })
+	s.Reset()
+	assert.NotPanics(t, func() { s.Sum(nil) })
+	assert.NotPanics(t, func() { s.Sum(nil) })
+	_, _ = s.Write([]byte{1})
+	assert.Panics(t, func() { s.Sum(nil) })
+}
+
+func TestSize(t *testing.T) {
+	s := s3etag.New(-1)
+	assert.Equal(t, 36, s.Size())
+}
+
+func TestBlockSize(t *testing.T) {
+	s := s3etag.New(-1)
+	assert.Equal(t, 64, s.BlockSize())
+}
+
+func TestSum(t *testing.T) {
+	assert.Equal(t,
+		[36]byte{
+			0x7f, 0xc5, 0x62, 0x70, 0xe7, 0xa7, 0x0f, 0xa8,
+			0x1a, 0x59, 0x35, 0xb7, 0x2e, 0xac, 0xbe, 0x29,
+			0x00, 0x01,
+		},
+		s3etag.Sum([]byte{'A'}),
+	)
+}

--- a/s3/s3sizes/s3sizes.go
+++ b/s3/s3sizes/s3sizes.go
@@ -1,0 +1,30 @@
+package s3sizes
+
+import (
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+// Constants
+const (
+	maxFileSize = 5 * 1024 * 1024 * 1024 * 1024 // largest possible upload file size
+)
+
+// PartSize returns a recommended partition size for S3 uploads, based on the
+// totalSize of the file; specify a totalSize of -1 when the file size is unknown.
+//
+// The returned partition size is also recommended for calculating the S3 ETag hash.
+func PartSize(totalSize int64) int64 {
+	partSize := s3manager.MinUploadPartSize
+
+	if totalSize == -1 {
+		// Make parts as small as possible while still being able to upload to the
+		// S3 file size limit. Rounded up to nearest MB.
+		partSize = (((maxFileSize / s3manager.MaxUploadParts) >> 20) + 1) << 20
+	} else if totalSize/partSize >= s3manager.MaxUploadParts {
+		// Adjust PartSize until the number of parts is small enough.
+		// Calculate partition size rounded up to the nearest MB
+		partSize = (((totalSize / s3manager.MaxUploadParts) >> 20) + 1) << 20
+	}
+
+	return partSize
+}

--- a/vfs/read.go
+++ b/vfs/read.go
@@ -38,7 +38,7 @@ func newReadFileHandle(f *File, o fs.Object) (*ReadFileHandle, error) {
 	var hash *fs.MultiHasher
 	var err error
 	if !f.d.vfs.Opt.NoChecksum {
-		hash, err = fs.NewMultiHasherTypes(o.Fs().Hashes())
+		hash, err = fs.NewMultiHasherTypes(o.Fs().Hashes(), o.Size())
 		if err != nil {
 			fs.Errorf(o.Fs(), "newReadFileHandle hash error: %v", err)
 		}


### PR DESCRIPTION
Thanks for a great utility!  I have been happily using rclone for a few months now.  I noticed a missing use case, which this PR addresses: as a backup operator, I want to (crypt) check the large files that rclone copies to S3.  (rclone only recognizes S3's ETag as an MD5 sum for small files, and so does not check the hashes of large files.)  

This PR adds full ETag support to rclone's local and S3 file systems, allowing rclone to (crypt) check large files on S3. It also removes MD5 support from the S3 file system to avoid cases where S3's MD5 algorithm might be chosen even though ETag would be the better choice.

The core algorithm is in the new s3etag.go file.

This PR also updates all of the hash-construction calls, to include file-size info.  This info is required by the new S3 ETag, since the algorithm is dependent on the partition count, and ultimately on the file size. 
 The partition-info is **not** saved as metadata with the remote file: the particular partition scheme is assumed by rclone.  (This means that rclone can (crypt) check the result of an rclone sync, but cannot (crypt) check a bucket that has been recopied to S3 by some tool other than rclone.  The recopy will use a different partitioning scheme, resulting in different ETags.) 