### PR TITLE
Allow using alternate auth for swift

### DIFF
--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -42,33 +42,39 @@ Choose a number from below, or type in your own value
    \ "b2"
  4 / Box
    \ "box"
- 5 / Dropbox
+ 5 / Cache a remote
+   \ "cache"
+ 6 / Dropbox
    \ "dropbox"
- 6 / Encrypt/Decrypt a remote
+ 7 / Encrypt/Decrypt a remote
    \ "crypt"
- 7 / FTP Connection
+ 8 / FTP Connection
    \ "ftp"
- 8 / Google Cloud Storage (this is not Google Drive)
+ 9 / Google Cloud Storage (this is not Google Drive)
    \ "google cloud storage"
- 9 / Google Drive
+10 / Google Drive
    \ "drive"
-10 / Hubic
+11 / Hubic
    \ "hubic"
-11 / Local Disk
+12 / Local Disk
    \ "local"
-12 / Microsoft Azure Blob Storage
+13 / Microsoft Azure Blob Storage
    \ "azureblob"
-13 / Microsoft OneDrive
+14 / Microsoft OneDrive
    \ "onedrive"
-14 / Openstack Swift (Rackspace Cloud Files, Memset Memstore, OVH)
+15 / Openstack Swift (Rackspace Cloud Files, Memset Memstore, OVH)
    \ "swift"
-15 / QingClound Object Storage
+16 / Pcloud
+   \ "pcloud"
+17 / QingClound Object Storage
    \ "qingstor"
-16 / SSH/SFTP Connection
+18 / SSH/SFTP Connection
    \ "sftp"
-17 / Yandex Disk
+19 / Webdav
+   \ "webdav"
+20 / Yandex Disk
    \ "yandex"
-18 / http Connection
+21 / http Connection
    \ "http"
 Storage> swift
 Get swift credentials from environment variables in standard OpenStack form.
@@ -77,12 +83,12 @@ Choose a number from below, or type in your own value
    \ "false"
  2 / Get swift credentials from environment vars. Leave other fields blank if using this.
    \ "true"
-env_auth> 1
-User name to log in.
-user> user_name
-API key or password.
-key> password_or_api_key
-Authentication URL for server.
+env_auth> true
+User name to log in (OS_USERNAME).
+user> 
+API key or password (OS_PASSWORD).
+key> 
+Authentication URL for server (OS_AUTH_URL).
 Choose a number from below, or type in your own value
  1 / Rackspace US
    \ "https://auth.api.rackspacecloud.com/v1.0"
@@ -96,24 +102,26 @@ Choose a number from below, or type in your own value
    \ "https://auth.storage.memset.com/v2.0"
  6 / OVH
    \ "https://auth.cloud.ovh.net/v2.0"
-auth> 1
+auth> 
 User ID to log in - optional - most swift systems use user and leave this blank (v3 auth) (OS_USER_ID).
-user_id> user_id
-User domain - optional (v3 auth)
-domain> Default
-Tenant name - optional for v1 auth, this or tenant_id required otherwise
-tenant> tenant_name
+user_id> 
+User domain - optional (v3 auth) (OS_USER_DOMAIN_NAME)
+domain> 
+Tenant name - optional for v1 auth, this or tenant_id required otherwise (OS_TENANT_NAME or OS_PROJECT_NAME)
+tenant> 
 Tenant ID - optional for v1 auth, this or tenant required otherwise (OS_TENANT_ID)
-tenant_id>
-Tenant domain - optional (v3 auth)
-tenant_domain>
-Region name - optional
-region>
-Storage URL - optional
-storage_url>
-AuthVersion - optional - set to (1,2,3) if your auth URL has no version
-auth_version>
-Endpoint type to choose from the service catalogue
+tenant_id> 
+Tenant domain - optional (v3 auth) (OS_PROJECT_DOMAIN_NAME)
+tenant_domain> 
+Region name - optional (OS_REGION_NAME)
+region> 
+Storage URL - optional (OS_STORAGE_URL)
+storage_url> 
+Auth Token from alternate authentication - optional (OS_AUTH_TOKEN)
+auth_token> 
+AuthVersion - optional - set to (1,2,3) if your auth URL has no version (ST_AUTH_VERSION)
+auth_version> 
+Endpoint type to choose from the service catalogue (OS_ENDPOINT_TYPE)
 Choose a number from below, or type in your own value
  1 / Public (default, choose this if not sure)
    \ "public"
@@ -121,21 +129,24 @@ Choose a number from below, or type in your own value
    \ "internal"
  3 / Admin
    \ "admin"
-endpoint_type>
+endpoint_type> 
 Remote config
 --------------------
-[remote]
-env_auth = false
-user = user_name
-key = password_or_api_key
-auth = https://auth.api.rackspacecloud.com/v1.0
-domain = Default
-tenant =
-tenant_domain =
-region =
-storage_url =
-auth_version =
-endpoint_type =
+[test]
+env_auth = true
+user = 
+key = 
+auth = 
+user_id = 
+domain = 
+tenant = 
+tenant_id = 
+tenant_domain = 
+region = 
+storage_url = 
+auth_token = 
+auth_version = 
+endpoint_type = 
 --------------------
 y) Yes this is OK
 e) Edit this remote
@@ -207,6 +218,17 @@ using standard OpenStack environment variables.  There is [a list of
 the
 variables](https://godoc.org/github.com/ncw/swift#Connection.ApplyEnvironment)
 in the docs for the swift library.
+
+### Using an alternate authentication method ###
+
+If your OpenStack installation uses a non-standard authentication method
+that might not be yet supported by rclone or the underlying swift library, 
+you can authenticate externally (e.g. calling manually the `openstack` 
+commands to get a token). Then, you just need to pass the two 
+configuration variables ``auth_token`` and ``storage_url``. 
+If they are both provided, the other variables are ignored. rclone will 
+not try to authenticate but instead assume it is already authenticated 
+and use these two variables to access the OpenStack installation.
 
 #### Using rclone without a config file ####
 

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -210,18 +210,20 @@ func swiftConnection(name string) (*swift.Connection, error) {
 			return nil, errors.Wrap(err, "failed to read environment variables")
 		}
 	}
-	if c.UserName == "" && c.UserId == "" {
-		return nil, errors.New("user name or user id not found")
-	}
-	if c.ApiKey == "" {
-		return nil, errors.New("key not found")
-	}
-	if c.AuthUrl == "" {
-		return nil, errors.New("auth not found")
-	}
-	err := c.Authenticate()
-	if err != nil {
-		return nil, err
+	if c.AuthToken == "" {
+		if c.UserName == "" && c.UserId == "" {
+			return nil, errors.New("user name or user id not found")
+		}
+		if c.ApiKey == "" {
+			return nil, errors.New("key not found")
+		}
+		if c.AuthUrl == "" {
+			return nil, errors.New("auth not found")
+		}
+		err := c.Authenticate()
+		if err != nil {
+			return nil, err
+		}	
 	}
 	return c, nil
 }


### PR DESCRIPTION
In our environment, we have a different identity provider (via tokens) to access swift. For this reason, even providing the correct passwords, projects, tenants, ... I wasn't able to connect to my swift installation.

However, the swift library allows for an alternate authentication: https://godoc.org/github.com/ncw/swift#Connection.ApplyEnvironment
where only two variables are needed:
```
OS_STORAGE_URL - storage URL from alternate authentication
OS_AUTH_TOKEN - Auth Token from alternate authentication
```
however currently rclone is always checking the username, password, ... and always trying to authenticate.

In this PR, I check if the two variables above are set from the environment (when `env_auth` is `true`) and in this case skip the authentication and just let the underlying library do its job, by using the alternate authorization.
With this patch, I am now able to connect to my swift installation, after using an external authentication script to get the token.
In the environment, I just need to have something like
```
export OS_AUTH_TOKEN=<MY_TOKEN>
export OS_STORAGE_URL=https://<server>:<port>/v1/AUTH_<project_id>
```
