### PR TITLE
sftp: add option to enable the use of aes128-cbc cipher

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -154,6 +154,13 @@ or `sha1sum` as well as `echo` are in the remote's PATH.
 
 The only ssh agent supported under Windows is Putty's pageant.
 
+The Go SSH library disables the use of the aes128-cbc cipher by
+default, due to security concerns. This can be re-enabled on a
+per-connection basis by setting the `use_insecure_cipher` setting in
+the configuration file to `true`. Further details on the insecurity of
+this cipher can be found [in this paper]
+(http://www.isg.rhul.ac.uk/~kp/SandPfinal.pdf).
+
 SFTP isn't supported under plan9 until [this
 issue](https://github.com/pkg/sftp/issues/156) is fixed.
 


### PR DESCRIPTION
This PR adds the option to use the insecure `aes128-cbc` cipher. This is disabled by default in the Go `crypto/ssh` library due to security concerns.

Unfortunately, there are still a number of devices and implementations that still mandate the use of this cipher.