### PR TITLE
cache: enable internal tests and fix race condition for them

### DIFF
--- a/cache/cache_internal_test.go
+++ b/cache/cache_internal_test.go
@@ -224,7 +224,6 @@ func TestInternalLargeWrittenContentMatches(t *testing.T) {
 }
 
 func TestInternalLargeWrittenContentMatches2(t *testing.T) {
-	t.Skip("FIXME disabled because it is unreliable")
 	cryptFs, boltDb := newLocalCacheCryptFs(t, "tilwcm2-local", "tilwcm2-cache", "tilwcm2-crypt", true, nil)
 	defer cleanupFs(t, cryptFs, boltDb)
 
@@ -534,14 +533,12 @@ func readDataFromObj(t *testing.T, co fs.Object, offset, end int64, useSeek bool
 }
 
 func cleanupFs(t *testing.T, f fs.Fs, b *cache.Persistent) {
-	t.Skip("FIXME disabled because it is unreliable")
 	err := f.Features().Purge()
 	require.NoError(t, err)
 	b.Close()
 }
 
 func newLocalCacheCryptFs(t *testing.T, localRemote, cacheRemote, cryptRemote string, purge bool, cfg map[string]string) (fs.Fs, *cache.Persistent) {
-	t.Skip("FIXME disabled because it is unreliable")
 	fstest.Initialise()
 	dbPath := filepath.Join(fs.CacheDir, "cache-backend", cacheRemote+".db")
 	boltDb, err := cache.GetPersistent(dbPath, &cache.Features{PurgeDb: true})
@@ -628,7 +625,6 @@ func newLocalCacheCryptFs(t *testing.T, localRemote, cacheRemote, cryptRemote st
 }
 
 func newLocalCacheFs(t *testing.T, localRemote, cacheRemote string, cfg map[string]string) (fs.Fs, *cache.Persistent) {
-	t.Skip("FIXME disabled because it is unreliable")
 	fstest.Initialise()
 	dbPath := filepath.Join(fs.CacheDir, "cache-backend", cacheRemote+".db")
 	boltDb, err := cache.GetPersistent(dbPath, &cache.Features{PurgeDb: true})

--- a/cache/storage_persistent.go
+++ b/cache/storage_persistent.go
@@ -528,6 +528,10 @@ func (b *Persistent) CleanChunksBySize(maxSize int64) {
 	})
 
 	if err != nil {
+		if err == bolt.ErrDatabaseNotOpen {
+			// we're likely a late janitor and we need to end quietly as there's no guarantee of what exists anymore
+			return
+		}
 		fs.Errorf("cache", "cleanup failed: %v", err)
 	}
 }


### PR DESCRIPTION
Testing on CI pipelines before merge multiple times now. Had issues with a recent push and would like to avoid putting bad tests until these tests are more stable