### PR TITLE
flags: remove --no-traverse flag because it is obsolete - fixes #1813

### DIFF
--- a/MANUAL.html
+++ b/MANUAL.html
@@ -195,7 +195,6 @@ destpath/two.txt</code></pre>
 <pre><code>destpath/sourcepath/one.txt
 destpath/sourcepath/two.txt</code></pre>
 <p>If you are familiar with <code>rsync</code>, rclone always works as if you had written a trailing / - meaning &quot;copy the contents of this directory&quot;. This applies to all commands and whether you are talking about the source or destination.</p>
-<p>See the <code>--no-traverse</code> option for controlling whether rclone lists the destination directory or not.</p>
 <pre><code>rclone copy source:path dest:path [flags]</code></pre>
 <h3 id="options-1">Options</h3>
 <pre><code>  -h, --help   help for copy</code></pre>
@@ -972,7 +971,7 @@ ffmpeg - | rclone rcat --checksum remote:path/to/file</code></pre>
 <pre><code>rclone copy remote:test.jpg /tmp/download</code></pre>
 <p>The file <code>test.jpg</code> will be placed inside <code>/tmp/download</code>.</p>
 <p>This is equivalent to specifying</p>
-<pre><code>rclone copy --no-traverse --files-from /tmp/files remote: /tmp/download</code></pre>
+<pre><code>rclone copy --files-from /tmp/files remote: /tmp/download</code></pre>
 <p>Where <code>/tmp/files</code> contains the single line</p>
 <pre><code>test.jpg</code></pre>
 <p>It is recommended to use <code>copy</code> when copying individual files, not <code>sync</code>. They have pretty much the same effect but <code>copy</code> will use a lot less memory.</p>
@@ -1162,7 +1161,7 @@ rclone sync /path/to/files remote:current-backup</code></pre>
 <p>If you use this flag, and the remote supports server side copy or server side move, and the source and destination have a compatible hash, then this will track renames during <code>sync</code>, <code>copy</code>, and <code>move</code> operations and perform renaming server-side.</p>
 <p>Files will be matched by size and hash - if both match then a rename will be considered.</p>
 <p>If the destination does not support server-side copy or move, rclone will fall back to the default behaviour and log an error level message to the console.</p>
-<p>Note that <code>--track-renames</code> is incompatible with <code>--no-traverse</code> and that it uses extra memory to keep track of all the rename candidates.</p>
+<p>Note that <code>--track-renames</code> uses extra memory to keep track of all the rename candidates.</p>
 <p>Note also that <code>--track-renames</code> is incompatible with <code>--delete-before</code> and will select <code>--delete-after</code> instead of <code>--delete-during</code>.</p>
 <h3 id="delete-beforeduringafter">--delete-(before,during,after)</h3>
 <p>This option allows you to specify when files on your destination are deleted when you sync folders.</p>
@@ -1266,11 +1265,6 @@ export RCLONE_CONFIG_PASS</code></pre>
 <p><code>--no-check-certificate</code> controls whether a client verifies the server's certificate chain and host name. If <code>--no-check-certificate</code> is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.</p>
 <p>This option defaults to <code>false</code>.</p>
 <p><strong>This should be used only for testing.</strong></p>
-<h3 id="no-traverse">--no-traverse</h3>
-<p>The <code>--no-traverse</code> flag controls whether the destination file system is traversed when using the <code>copy</code> or <code>move</code> commands. <code>--no-traverse</code> is not compatible with <code>sync</code> and will be ignored if you supply it with <code>sync</code>.</p>
-<p>If you are only copying a small number of files and/or have a large number of files on the destination then <code>--no-traverse</code> will stop rclone listing the destination and save time.</p>
-<p>However, if you are copying a large number of files, especially if you are doing a copy where lots of the files haven't changed and won't need copying then you shouldn't use <code>--no-traverse</code>.</p>
-<p>It can also be used to reduce the memory usage of rclone when copying - <code>rclone --no-traverse copy src dst</code> won't load either the source or destination listings into memory so will use the minimum amount of memory.</p>
 <h2 id="filtering">Filtering</h2>
 <p>For the filtering options</p>
 <ul>

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -296,9 +296,6 @@ written a trailing / - meaning "copy the contents of this directory".
 This applies to all commands and whether you are talking about the
 source or destination.
 
-See the `--no-traverse` option for controlling whether rclone lists
-the destination directory or not.
-
 
 ```
 rclone copy source:path dest:path [flags]
@@ -2216,7 +2213,7 @@ The file `test.jpg` will be placed inside `/tmp/download`.
 
 This is equivalent to specifying
 
-    rclone copy --no-traverse --files-from /tmp/files remote: /tmp/download
+    rclone copy --files-from /tmp/files remote: /tmp/download
 
 Where `/tmp/files` contains the single line
 
@@ -2783,8 +2780,8 @@ If the destination does not support server-side copy or move, rclone
 will fall back to the default behaviour and log an error level message
 to the console.
 
-Note that `--track-renames` is incompatible with `--no-traverse` and
-that it uses extra memory to keep track of all the rename candidates.
+Note that `--track-renames` uses extra memory to keep track of all
+the rename candidates.
 
 Note also that `--track-renames` is incompatible with
 `--delete-before` and will select `--delete-after` instead of
@@ -3048,26 +3045,6 @@ In this mode, TLS is susceptible to man-in-the-middle attacks.
 This option defaults to `false`.
 
 **This should be used only for testing.**
-
-### --no-traverse ###
-
-The `--no-traverse` flag controls whether the destination file system
-is traversed when using the `copy` or `move` commands.
-`--no-traverse` is not compatible with `sync` and will be ignored if
-you supply it with `sync`.
-
-If you are only copying a small number of files and/or have a large
-number of files on the destination then `--no-traverse` will stop
-rclone listing the destination and save time.
-
-However, if you are copying a large number of files, especially if you
-are doing a copy where lots of the files haven't changed and won't
-need copying then you shouldn't use `--no-traverse`.
-
-It can also be used to reduce the memory usage of rclone when copying
-- `rclone --no-traverse copy src dst` won't load either the source or
-destination listings into memory so will use the minimum amount of
-memory.
 
 Filtering
 ---------

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -299,9 +299,6 @@ written a trailing / - meaning "copy the contents of this directory".
 This applies to all commands and whether you are talking about the
 source or destination.
 
-See the --no-traverse option for controlling whether rclone lists the
-destination directory or not.
-
     rclone copy source:path dest:path [flags]
 
 Options
@@ -1940,7 +1937,7 @@ The file test.jpg will be placed inside /tmp/download.
 
 This is equivalent to specifying
 
-    rclone copy --no-traverse --files-from /tmp/files remote: /tmp/download
+    rclone copy --files-from /tmp/files remote: /tmp/download
 
 Where /tmp/files contains the single line
 
@@ -2499,8 +2496,8 @@ If the destination does not support server-side copy or move, rclone
 will fall back to the default behaviour and log an error level message
 to the console.
 
-Note that --track-renames is incompatible with --no-traverse and that it
-uses extra memory to keep track of all the rename candidates.
+Note that --track-renames uses extra memory to keep track of all
+the rename candidates.
 
 Note also that --track-renames is incompatible with --delete-before and
 will select --delete-after instead of --delete-during.
@@ -2753,25 +2750,6 @@ attacks.
 This option defaults to false.
 
 THIS SHOULD BE USED ONLY FOR TESTING.
-
---no-traverse
-
-The --no-traverse flag controls whether the destination file system is
-traversed when using the copy or move commands. --no-traverse is not
-compatible with sync and will be ignored if you supply it with sync.
-
-If you are only copying a small number of files and/or have a large
-number of files on the destination then --no-traverse will stop rclone
-listing the destination and save time.
-
-However, if you are copying a large number of files, especially if you
-are doing a copy where lots of the files haven't changed and won't need
-copying then you shouldn't use --no-traverse.
-
-It can also be used to reduce the memory usage of rclone when copying -
-rclone --no-traverse copy src dst won't load either the source or
-destination listings into memory so will use the minimum amount of
-memory.
 
 
 Filtering

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -166,8 +166,6 @@ func newFsSrc(remote string) (fs.Fs, string) {
 			fs.Stats.Error(err)
 			log.Fatalf("Failed to limit to single file %q: %v", remote, err)
 		}
-		// Set --no-traverse as only one file
-		fs.Config.NoTraverse = true
 	}
 	return f, fileName
 }

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -49,9 +49,6 @@ If you are familiar with ` + "`rsync`" + `, rclone always works as if you had
 written a trailing / - meaning "copy the contents of this directory".
 This applies to all commands and whether you are talking about the
 source or destination.
-
-See the ` + "`--no-traverse`" + ` option for controlling whether rclone lists
-the destination directory or not.
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)

--- a/docs/content/commands/rclone.md
+++ b/docs/content/commands/rclone.md
@@ -143,7 +143,6 @@ rclone [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_authorize.md
+++ b/docs/content/commands/rclone_authorize.md
@@ -113,7 +113,6 @@ rclone authorize [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_cachestats.md
+++ b/docs/content/commands/rclone_cachestats.md
@@ -112,7 +112,6 @@ rclone cachestats source: [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_cat.md
+++ b/docs/content/commands/rclone_cat.md
@@ -134,7 +134,6 @@ rclone cat remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_check.md
+++ b/docs/content/commands/rclone_check.md
@@ -123,7 +123,6 @@ rclone check source:path dest:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_cleanup.md
+++ b/docs/content/commands/rclone_cleanup.md
@@ -113,7 +113,6 @@ rclone cleanup remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config.md
+++ b/docs/content/commands/rclone_config.md
@@ -113,7 +113,6 @@ rclone config [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_create.md
+++ b/docs/content/commands/rclone_config_create.md
@@ -118,7 +118,6 @@ rclone config create <name> <type> [<key> <value>]* [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_delete.md
+++ b/docs/content/commands/rclone_config_delete.md
@@ -110,7 +110,6 @@ rclone config delete <name> [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_dump.md
+++ b/docs/content/commands/rclone_config_dump.md
@@ -110,7 +110,6 @@ rclone config dump [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_edit.md
+++ b/docs/content/commands/rclone_config_edit.md
@@ -113,7 +113,6 @@ rclone config edit [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_file.md
+++ b/docs/content/commands/rclone_config_file.md
@@ -110,7 +110,6 @@ rclone config file [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_password.md
+++ b/docs/content/commands/rclone_config_password.md
@@ -117,7 +117,6 @@ rclone config password <name> [<key> <value>]+ [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_providers.md
+++ b/docs/content/commands/rclone_config_providers.md
@@ -110,7 +110,6 @@ rclone config providers [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_show.md
+++ b/docs/content/commands/rclone_config_show.md
@@ -110,7 +110,6 @@ rclone config show [<remote>] [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_config_update.md
+++ b/docs/content/commands/rclone_config_update.md
@@ -117,7 +117,6 @@ rclone config update <name> [<key> <value>]+ [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_copy.md
+++ b/docs/content/commands/rclone_copy.md
@@ -48,10 +48,6 @@ written a trailing / - meaning "copy the contents of this directory".
 This applies to all commands and whether you are talking about the
 source or destination.
 
-See the `--no-traverse` option for controlling whether rclone lists
-the destination directory or not.
-
-
 ```
 rclone copy source:path dest:path [flags]
 ```
@@ -149,7 +145,6 @@ rclone copy source:path dest:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_copyto.md
+++ b/docs/content/commands/rclone_copyto.md
@@ -136,7 +136,6 @@ rclone copyto source:path dest:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_cryptcheck.md
+++ b/docs/content/commands/rclone_cryptcheck.md
@@ -133,7 +133,6 @@ rclone cryptcheck remote:path cryptedremote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_cryptdecode.md
+++ b/docs/content/commands/rclone_cryptdecode.md
@@ -117,7 +117,6 @@ rclone cryptdecode encryptedremote: encryptedfilename [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_dbhashsum.md
+++ b/docs/content/commands/rclone_dbhashsum.md
@@ -115,7 +115,6 @@ rclone dbhashsum remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_dedupe.md
+++ b/docs/content/commands/rclone_dedupe.md
@@ -190,7 +190,6 @@ rclone dedupe [mode] remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_delete.md
+++ b/docs/content/commands/rclone_delete.md
@@ -127,7 +127,6 @@ rclone delete remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_genautocomplete.md
+++ b/docs/content/commands/rclone_genautocomplete.md
@@ -109,7 +109,6 @@ Run with --help to list the supported shells.
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_genautocomplete_bash.md
+++ b/docs/content/commands/rclone_genautocomplete_bash.md
@@ -125,7 +125,6 @@ rclone genautocomplete bash [output_file] [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_genautocomplete_zsh.md
+++ b/docs/content/commands/rclone_genautocomplete_zsh.md
@@ -125,7 +125,6 @@ rclone genautocomplete zsh [output_file] [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_gendocs.md
+++ b/docs/content/commands/rclone_gendocs.md
@@ -113,7 +113,6 @@ rclone gendocs output_directory [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_listremotes.md
+++ b/docs/content/commands/rclone_listremotes.md
@@ -115,7 +115,6 @@ rclone listremotes [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_ls.md
+++ b/docs/content/commands/rclone_ls.md
@@ -110,7 +110,6 @@ rclone ls remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_lsd.md
+++ b/docs/content/commands/rclone_lsd.md
@@ -110,7 +110,6 @@ rclone lsd remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_lsjson.md
+++ b/docs/content/commands/rclone_lsjson.md
@@ -138,7 +138,6 @@ rclone lsjson remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_lsl.md
+++ b/docs/content/commands/rclone_lsl.md
@@ -110,7 +110,6 @@ rclone lsl remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_md5sum.md
+++ b/docs/content/commands/rclone_md5sum.md
@@ -113,7 +113,6 @@ rclone md5sum remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_mkdir.md
+++ b/docs/content/commands/rclone_mkdir.md
@@ -110,7 +110,6 @@ rclone mkdir remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -328,7 +328,6 @@ rclone mount remote:path /path/to/mountpoint [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_move.md
+++ b/docs/content/commands/rclone_move.md
@@ -130,7 +130,6 @@ rclone move source:path dest:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_moveto.md
+++ b/docs/content/commands/rclone_moveto.md
@@ -139,7 +139,6 @@ rclone moveto source:path dest:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_ncdu.md
+++ b/docs/content/commands/rclone_ncdu.md
@@ -134,7 +134,6 @@ rclone ncdu remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_obscure.md
+++ b/docs/content/commands/rclone_obscure.md
@@ -110,7 +110,6 @@ rclone obscure password [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_purge.md
+++ b/docs/content/commands/rclone_purge.md
@@ -114,7 +114,6 @@ rclone purge remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_rcat.md
+++ b/docs/content/commands/rclone_rcat.md
@@ -132,7 +132,6 @@ rclone rcat remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_rmdir.md
+++ b/docs/content/commands/rclone_rmdir.md
@@ -112,7 +112,6 @@ rclone rmdir remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_rmdirs.md
+++ b/docs/content/commands/rclone_rmdirs.md
@@ -120,7 +120,6 @@ rclone rmdirs remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_serve.md
+++ b/docs/content/commands/rclone_serve.md
@@ -116,7 +116,6 @@ rclone serve <protocol> [opts] <remote> [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_serve_http.md
+++ b/docs/content/commands/rclone_serve_http.md
@@ -242,7 +242,6 @@ rclone serve http remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_serve_webdav.md
+++ b/docs/content/commands/rclone_serve_webdav.md
@@ -236,7 +236,6 @@ rclone serve webdav remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_sha1sum.md
+++ b/docs/content/commands/rclone_sha1sum.md
@@ -113,7 +113,6 @@ rclone sha1sum remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_size.md
+++ b/docs/content/commands/rclone_size.md
@@ -110,7 +110,6 @@ rclone size remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_sync.md
+++ b/docs/content/commands/rclone_sync.md
@@ -129,7 +129,6 @@ rclone sync source:path dest:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_touch.md
+++ b/docs/content/commands/rclone_touch.md
@@ -112,7 +112,6 @@ rclone touch remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_tree.md
+++ b/docs/content/commands/rclone_tree.md
@@ -153,7 +153,6 @@ rclone tree remote:path [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/commands/rclone_version.md
+++ b/docs/content/commands/rclone_version.md
@@ -110,7 +110,6 @@ rclone version [flags]
       --modify-window duration              Max time diff to be considered the same (default 1ns)
       --no-check-certificate                Do not verify the server SSL certificate. Insecure.
       --no-gzip-encoding                    Don't set Accept-Encoding: gzip.
-      --no-traverse                         Don't traverse destination file system on copy.
       --no-update-modtime                   Don't update destination mod-time if files identical.
       --old-sync-method                     Deprecated - use --fast-list instead
   -x, --one-file-system                     Don't cross filesystem boundaries.

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -118,7 +118,7 @@ The file `test.jpg` will be placed inside `/tmp/download`.
 
 This is equivalent to specifying
 
-    rclone copy --no-traverse --files-from /tmp/files remote: /tmp/download
+    rclone copy --files-from /tmp/files remote: /tmp/download
 
 Where `/tmp/files` contains the single line
 
@@ -685,8 +685,8 @@ If the destination does not support server-side copy or move, rclone
 will fall back to the default behaviour and log an error level message
 to the console.
 
-Note that `--track-renames` is incompatible with `--no-traverse` and
-that it uses extra memory to keep track of all the rename candidates.
+Note that `--track-renames` uses extra memory to keep track of all
+the rename candidates.
 
 Note also that `--track-renames` is incompatible with
 `--delete-before` and will select `--delete-after` instead of
@@ -950,26 +950,6 @@ In this mode, TLS is susceptible to man-in-the-middle attacks.
 This option defaults to `false`.
 
 **This should be used only for testing.**
-
-### --no-traverse ###
-
-The `--no-traverse` flag controls whether the destination file system
-is traversed when using the `copy` or `move` commands.
-`--no-traverse` is not compatible with `sync` and will be ignored if
-you supply it with `sync`.
-
-If you are only copying a small number of files and/or have a large
-number of files on the destination then `--no-traverse` will stop
-rclone listing the destination and save time.
-
-However, if you are copying a large number of files, especially if you
-are doing a copy where lots of the files haven't changed and won't
-need copying then you shouldn't use `--no-traverse`.
-
-It can also be used to reduce the memory usage of rclone when copying
-- `rclone --no-traverse copy src dst` won't load either the source or
-destination listings into memory so will use the minimum amount of
-memory.
 
 Filtering
 ---------

--- a/fs/config.go
+++ b/fs/config.go
@@ -102,7 +102,6 @@ var (
 	maxDepth              = IntP("max-depth", "", -1, "If set limits the recursion depth to this.")
 	ignoreSize            = BoolP("ignore-size", "", false, "Ignore size when skipping use mod-time or checksum.")
 	ignoreChecksum        = BoolP("ignore-checksum", "", false, "Skip post copy check of checksums.")
-	noTraverse            = BoolP("no-traverse", "", false, "Don't traverse destination file system on copy.")
 	noUpdateModTime       = BoolP("no-update-modtime", "", false, "Don't update destination mod-time if files identical.")
 	backupDir             = StringP("backup-dir", "", "", "Make backups into hierarchy based in DIR.")
 	suffix                = StringP("suffix", "", "", "Suffix for use with --backup-dir.")
@@ -241,7 +240,6 @@ type ConfigInfo struct {
 	MaxDepth              int
 	IgnoreSize            bool
 	IgnoreChecksum        bool
-	NoTraverse            bool
 	NoUpdateModTime       bool
 	DataRateUnit          string
 	BackupDir             string
@@ -383,7 +381,6 @@ func LoadConfig() {
 	Config.MaxDepth = *maxDepth
 	Config.IgnoreSize = *ignoreSize
 	Config.IgnoreChecksum = *ignoreChecksum
-	Config.NoTraverse = *noTraverse
 	Config.NoUpdateModTime = *noUpdateModTime
 	Config.BackupDir = *backupDir
 	Config.Suffix = *suffix

--- a/fs/sync_test.go
+++ b/fs/sync_test.go
@@ -44,41 +44,6 @@ func TestCopy(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 }
 
-// Now with --no-traverse
-func TestCopyNoTraverse(t *testing.T) {
-	r := fstest.NewRun(t)
-	defer r.Finalise()
-
-	fs.Config.NoTraverse = true
-	defer func() { fs.Config.NoTraverse = false }()
-
-	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
-
-	err := fs.CopyDir(r.Fremote, r.Flocal)
-	require.NoError(t, err)
-
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
-}
-
-// Now with --no-traverse
-func TestSyncNoTraverse(t *testing.T) {
-	r := fstest.NewRun(t)
-	defer r.Finalise()
-
-	fs.Config.NoTraverse = true
-	defer func() { fs.Config.NoTraverse = false }()
-
-	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
-
-	fs.Stats.ResetCounters()
-	err := fs.Sync(r.Fremote, r.Flocal)
-	require.NoError(t, err)
-
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
-}
-
 // Test copy with depth
 func TestCopyWithDepth(t *testing.T) {
 	r := fstest.NewRun(t)


### PR DESCRIPTION
Fixes:
https://github.com/ncw/rclone/issues/1813

Signed-off-by: Ernest Borowski <er.borowski@gmail.com>