### PR TITLE
Fixes #1206 Supporting Arbitrary Stats Filename Lengths

### DIFF
--- a/fs/accounting.go
+++ b/fs/accounting.go
@@ -572,9 +572,11 @@ func (acc *Account) String() string {
 		}
 	}
 	name := []rune(acc.name)
-	if len(name) > 40 {
-		where := len(name) - 37
-		name = append([]rune{'.', '.', '.'}, name[where:]...)
+	if Config.StatsFileNameLength > 0 {
+		if len(name) > Config.StatsFileNameLength {
+			where := len(name) - Config.StatsFileNameLength
+			name = append([]rune{'.', '.', '.'}, name[where:]...)
+		}
 	}
 
 	if Config.DataRateUnit == "bits" {

--- a/fs/config.go
+++ b/fs/config.go
@@ -114,6 +114,7 @@ var (
 	userAgent             = StringP("user-agent", "", "rclone/"+Version, "Set the user-agent to a specified string. The default is rclone/ version")
 	immutable             = BoolP("immutable", "", false, "Do not modify files. Fail if existing files have been modified.")
 	autoConfirm           = BoolP("auto-confirm", "", false, "If enabled, do not request console confirmation.")
+	statsFileNameLength   = IntP("stats-file-name-length", "", 40, "Max file name length in stats. 0 for no limit")
 	streamingUploadCutoff = SizeSuffix(100 * 1024)
 	dump                  DumpFlags
 	logLevel              = LogLevelNotice
@@ -255,6 +256,7 @@ type ConfigInfo struct {
 	Immutable             bool
 	AutoConfirm           bool
 	StreamingUploadCutoff SizeSuffix
+	StatsFileNameLength   int
 }
 
 // Return the path to the configuration file
@@ -392,6 +394,7 @@ func LoadConfig() {
 	Config.TPSLimitBurst = *tpsLimitBurst
 	Config.Immutable = *immutable
 	Config.AutoConfirm = *autoConfirm
+	Config.StatsFileNameLength = *statsFileNameLength
 	Config.BufferSize = bufferSize
 	Config.StreamingUploadCutoff = streamingUploadCutoff
 	Config.Dump = dump


### PR DESCRIPTION
Added a config option to specify the printed file name length for stats.

I didn't update the various documentation .md files because I figured you would want to change the flag text and or description wording.