### PR TITLE
sftp: add 'set_modtime' config option for picky SFTP servers

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -147,6 +147,11 @@ Modified times are stored on the server to 1 second precision.
 
 Modified times are used in syncing and are fully supported.
 
+Some SFTP servers disable setting/modifying the file modification time after
+upload (for example, certain configurations of ProFTPd with mod_sftp). If you
+are using one of these servers, you can set the option `set_modtime = false` in
+your RClone backend configuration to disable this behaviour.
+
 ### Limitations ###
 
 SFTP supports checksums if the same login has shell access and `md5sum`

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -812,14 +812,16 @@ func (o *Object) SetModTime(modTime time.Time) error {
 	if err != nil {
 		return errors.Wrap(err, "SetModTime")
 	}
-	err = c.sftpClient.Chtimes(o.path(), modTime, modTime)
-	o.fs.putSftpConnection(&c, err)
-	if err != nil {
-		return errors.Wrap(err, "SetModTime failed")
+	if fs.ConfigFileGetBool(o.fs.name, "set_modtime", true) {
+		err = c.sftpClient.Chtimes(o.path(), modTime, modTime)
+		o.fs.putSftpConnection(&c, err)
+		if err != nil {
+			return errors.Wrap(err, "SetModTime failed")
+		}
 	}
 	err = o.stat()
 	if err != nil {
-		return errors.Wrap(err, "SetModTime failed")
+		return errors.Wrap(err, "SetModTime stat failed")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR lets the SFTP backend support `--no-update-modtime`, for some restricted SFTP servers that prohibit this operation (i.e. certain configurations of ProFTPd with mod_sftp)