### PR TITLE
sftp: Add option to disable remote hash check command execution

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -151,6 +151,10 @@ Modified times are used in syncing and are fully supported.
 
 SFTP supports checksums if the same login has shell access and `md5sum`
 or `sha1sum` as well as `echo` are in the remote's PATH.
+This remote check can be disabled by setting the configuration option
+`disable_hashcheck`. This may be required if you're connecting to SFTP servers
+which are not under your control, and to which the execution of remote commands
+is prohibited.
 
 The only ssh agent supported under Windows is Putty's pageant.
 

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -70,6 +70,10 @@ func init() {
 					Help:  "Enables the use of the aes128-cbc cipher.",
 				},
 			},
+		}, {
+			Name:     "disable_hashcheck",
+			Help:     "Disable the exectution of SSH commands to determine if remote file hashing is available, leave blank unless you know what you are doing.",
+			Optional: true,
 		}},
 	}
 	fs.Register(fsi)
@@ -611,6 +615,11 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 func (f *Fs) Hashes() fs.HashSet {
 	if f.cachedHashes != nil {
 		return *f.cachedHashes
+	}
+
+	hashcheckDisabled := fs.ConfigFileGetBool(f.name, "disable_hashcheck")
+	if hashcheckDisabled {
+		return fs.HashSet(fs.HashNone)
 	}
 
 	c, err := f.getSftpConnection()


### PR DESCRIPTION
This PR adds the `disable_hashcheck` option to the SFTP backend. This _may_ be required if you’re connecting to a remote SFTP server which is not under your control. The default hash checking code will open an SSH connection and attempt to execute commands to determine if remote hashes are available. This can cause alerts to be generated in the remote server log if the user account/server is configured for SFTP-only access.

Some particularly security-conscious remote system admins view any attempt to execute commands as a hostile activity, and so this provides the friendly and accommodating rclone user a way to disable this functionality.