### PR TITLE
cryptdecode: added option to return encrypted file names. Fixes #1923

### DIFF
--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -445,6 +445,11 @@ func (f *Fs) UnWrap() fs.Fs {
 	return f.Fs
 }
 
+// EncryptFileName returns an encrypted file name
+func (f *Fs) EncryptFileName(fileName string) string {
+	return f.cipher.EncryptFileName(fileName)
+}
+
 // DecryptFileName returns a decrypted file name
 func (f *Fs) DecryptFileName(encryptedFileName string) (string, error) {
 	return f.cipher.DecryptFileName(encryptedFileName)


### PR DESCRIPTION
This pull request adds a `--reverse` flag to the `cryptdecode` command. When this flag is supplied the command returns encrypted file names. 
