### PR TITLE
FAQ: env vars for SSL root certs and DNS resolver

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -125,6 +125,9 @@ curl -o /etc/ssl/certs/ca-certificates.crt https://raw.githubusercontent.com/bag
 ntpclient -s -h pool.ntp.org
 ```
 
+The two environment variables `SSL_CERT_FILE` and `SSL_CERT_DIR`, mentioned in the [x509 pacakge](https://godoc.org/crypto/x509),
+provide an additional way to provide the SSL root certificates.
+
 Note that you may need to add the `--insecure` option to the `curl` command line if it doesn't work without.
 
 ```
@@ -161,3 +164,7 @@ dig www.googleapis.com @8.8.8.8 # resolve with Google's DNS server
 If you are using `systemd-resolved` (default on Arch Linux), ensure it
 is at version 233 or higher. Previous releases contain a bug which
 causes not all domains to be resolved properly.
+
+Additionally with the `GODEBUG=netdns=` environment variable the Go
+resolver decision can be influenced. This also allows to resolve certain
+issues with DNS resolution. See the [name resolution section in the go docs](https://golang.org/pkg/net/#hdr-Name_Resolution).


### PR DESCRIPTION
Added section to FAQ about environment variables, which allow to control
location of SSL root certificate as well as DNS resolver used.

see also comment in #683