### PR TITLE
vfs: write 0 bytes when flushing unwritten handles to avoid race conditions in FUSE - fixes #1181

### DIFF
--- a/vfs/write.go
+++ b/vfs/write.go
@@ -231,9 +231,9 @@ func (fh *WriteFileHandle) Flush() error {
 	// If Write hasn't been called then ignore the Flush - Release
 	// will pick it up
 	if !fh.writeCalled {
-		fs.Debugf(fh.remote, "WriteFileHandle.Flush ignoring flush on unwritten handle")
-		return nil
-
+		fs.Debugf(fh.remote, "WriteFileHandle.Flush unwritten handle, writing 0 bytes to avoid race conditions")
+		_, err := fh.writeAt([]byte{}, fh.offset)
+		return err
 	}
 	err := fh.close()
 	if err != nil {


### PR DESCRIPTION
I am aware that more or less the same change is needed for the `read_write.go`, but I wanted to get some feedback on this before copying over the work.

I tried rsync, touch, cp, and `echo bla > bla` and they all still work. `touch bla && rm bla` stops being racy for me. Tested dropbox and drive remotes only so far.

I wonder if we need to change the logic to not use `writeCalled`, for cases where the syscalls would be roughly: open → flush → flush → write → flush/release. Previously this likely worked, because we would ignore the flush twice, but now we actually issue a write and thus the 2nd flush closes. I don't know of any program that works like that, though.