### PR TITLE
WIP: Update drive use v3 API

### DIFF
--- a/backend/drive/upload.go
+++ b/backend/drive/upload.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ncw/rclone/fs/fserrors"
 	"github.com/ncw/rclone/lib/readers"
 	"github.com/pkg/errors"
-	"google.golang.org/api/drive/v2"
+	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/googleapi"
 )
 


### PR DESCRIPTION
This is my current state of updating the drive API to v3 (#320)

It should be complete except for Google Docs exports with the vfs package.
The workaround using a HEAD request to determine the size of a exported file in the `Size()` method does not work anymore, because exports are now transferred using chunked-encoding. A solution could be to download the whole file to get the size, but this very expensive and there is no guarantee the content does not change between exports.
Exports using basic operations like copy will succeed nonetheless.

All other tests are passing fine.