### PR TITLE
amazonclouddrive: remove unnecessary notifies from DirChangeNotify

### DIFF
--- a/backend/amazonclouddrive/amazonclouddrive.go
+++ b/backend/amazonclouddrive/amazonclouddrive.go
@@ -1264,21 +1264,17 @@ func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), checkpoint string) s
 				if path, ok := f.dirCache.GetInv(*node.Id); ok {
 					pathsToClear = append(pathsToClear, path)
 				}
-
-				for _, parent := range node.Parents {
-					if path, ok := f.dirCache.GetInv(parent); ok {
-						pathsToClear = append(pathsToClear, path)
-					}
-				}
 			}
 
+			notified := false
 			lastNotifiedPath := ""
 			sort.Strings(pathsToClear)
 			for _, path := range pathsToClear {
-				if lastNotifiedPath != "" && (path == lastNotifiedPath || strings.HasPrefix(path+"/", lastNotifiedPath)) {
+				if notified && strings.HasPrefix(path+"/", lastNotifiedPath+"/") {
 					continue
 				}
 				lastNotifiedPath = path
+				notified = true
 				notifyFunc(path)
 			}
 


### PR DESCRIPTION
It is unnecessary to notify the node.Parents, because a cahnge event is
generated for all involved files and folders in a move from d1/f1 to
d2/f1. There will be a event for d1, d2 and f1.

Additionally a duplicate notification is resolved when them empty string
is in pathsToClear.

Related to #2006