### PR TITLE
scripts: make absolute paths consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL = /bin/bash
+SHELL = bash
 TAG := $(shell echo `git describe --abbrev=8 --tags`-`git rev-parse --abbrev-ref HEAD` | sed 's/-\([0-9]\)-/-00\1-/; s/-\([0-9][0-9]\)-/-0\1-/; s/-\(HEAD\|master\)$$//')
 LAST_TAG := $(shell git describe --tags --abbrev=0)
 NEW_TAG := $(shell echo $(LAST_TAG) | perl -lpe 's/v//; $$_ += 0.01; $$_ = sprintf("v%.2f", $$_)')

--- a/bin/decrypt_names.py
+++ b/bin/decrypt_names.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 This is a tool to decrypt file names in rclone logs.
 

--- a/bin/make_manual.py
+++ b/bin/make_manual.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Make single page versions of the documentation for release and
 conversion into man pages etc.

--- a/bin/upload-github
+++ b/bin/upload-github
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Upload a release
 #

--- a/cmd/info/all.sh
+++ b/cmd/info/all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec rclone --check-normalization=true --check-control=true --check-length=true info \
 	/tmp/testInfo \
 	TestAmazonCloudDrive:testInfo \


### PR DESCRIPTION
Change absolute binary paths in scripts to /usr/bin/env or make them relative.
This allows the scripts to be used on linux distributions like NixOS, where binaries are not located in /usr/ or /bin/.