### PR TITLE
drive: fix upload to existing file

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -824,7 +824,7 @@ func (f *Fs) PutUnchecked(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOpt
 		}
 	} else {
 		// Upload the file in chunks
-		info, err = f.Upload(in, size, createInfo.MimeType, createInfo, remote)
+		info, err = f.Upload(in, size, createInfo.MimeType, "", createInfo, remote)
 		if err != nil {
 			return o, err
 		}
@@ -1503,7 +1503,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 		}
 	} else {
 		// Upload the file in chunks
-		info, err = o.fs.Upload(in, size, updateInfo.MimeType, updateInfo, o.remote)
+		info, err = o.fs.Upload(in, size, updateInfo.MimeType, o.id, updateInfo, o.remote)
 		if err != nil {
 			return err
 		}

--- a/backend/drive/upload.go
+++ b/backend/drive/upload.go
@@ -53,8 +53,7 @@ type resumableUpload struct {
 }
 
 // Upload the io.Reader in of size bytes with contentType and info
-func (f *Fs) Upload(in io.Reader, size int64, contentType string, info *drive.File, remote string) (*drive.File, error) {
-	fileID := info.Id
+func (f *Fs) Upload(in io.Reader, size int64, contentType string, fileID string, info *drive.File, remote string) (*drive.File, error) {
 	params := make(url.Values)
 	params.Set("alt", "json")
 	params.Set("uploadType", "resumable")
@@ -67,7 +66,7 @@ func (f *Fs) Upload(in io.Reader, size int64, contentType string, info *drive.Fi
 	if fileID != "" {
 		params.Set("setModifiedDate", "true")
 		urls += "/{fileId}"
-		method = "PUT"
+		method = "PATCH"
 	}
 	urls += "?" + params.Encode()
 	var res *http.Response


### PR DESCRIPTION
Here is the next fix after changing to API v3 :sweat_smile:

This fixes uploads to existing files for Google Drive introduced by #2007.
Instead of updating the old file a new "Untitled" file would be created in the root folder.