### PR TITLE
Enhanced documentation for the --drive-shared-with-me option.

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -349,7 +349,9 @@ Size of listing chunk 100-1000. 0 to disable. (default 1000)
 
 #### --drive-shared-with-me ####
 
-Only show files that are shared with me
+Instructs rclone to operate on your "Shared with me" folder (where Google Drive lets you access the files and folders have shared with you).
+
+This works both with the "list" (lsd, lsl, etc) and the "copy" commands (copy, sinc, etc), and probably with other commands too.
 
 #### --drive-skip-gdocs ####
 


### PR DESCRIPTION
As per this rclone forum post: https://forum.rclone.org/t/gdrive-how-to-access-the-shared-with-me-subdirectory-area/4678/6