### PR TITLE
copy/move: detect file size change during copy/move - fixes #1250

### DIFF
--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -1,10 +1,22 @@
 package local
 
 import (
+	"os"
+	"path"
 	"testing"
+	"time"
 
+	"github.com/ncw/rclone/fs/hash"
+	"github.com/ncw/rclone/fstest"
+	"github.com/ncw/rclone/lib/readers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestMain drives the tests
+func TestMain(m *testing.M) {
+	fstest.TestMain(m)
+}
 
 func TestMapper(t *testing.T) {
 	m := newMapper()
@@ -17,4 +29,34 @@ func TestMapper(t *testing.T) {
 	})
 	assert.Equal(t, "potato", m.Load("potato"))
 	assert.Equal(t, "-r?'a´o¨", m.Load("-r'áö"))
+
+	// Test copy with source file that's updating
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+	filePath := "sub dir/local test"
+	r.WriteFile(filePath, "content", time.Now())
+
+	fd, err := os.Open(path.Join(r.LocalName, filePath))
+	if err != nil {
+		t.Fatalf("failed opening file %q: %v", filePath, err)
+	}
+
+	fi, err := fd.Stat()
+	o := &Object{size: fi.Size(), modTime: fi.ModTime()}
+	wrappedFd := readers.NewLimitedReadCloser(fd, -1)
+	hash, err := hash.NewMultiHasherTypes(hash.Supported)
+	in := localOpenFile{
+		o:    o,
+		in:   wrappedFd,
+		hash: hash,
+		fd:   fd,
+	}
+
+	buf := make([]byte, 1)
+	_, err = in.Read(buf)
+	require.NoError(t, err)
+
+	r.WriteFile(filePath, "content updated", time.Now())
+	_, err = in.Read(buf)
+	require.Errorf(t, err, "can't copy - source file is being updated")
 }


### PR DESCRIPTION
This PR adds an extra check in the local backend that compares the local file size and modtime to the stored object's size and modtime to ensure that local files are not being modified during upload.

