### PR TITLE
[crypt] Changed max filename length documentation to 143

### DIFF
--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -228,7 +228,7 @@ Off
 Standard
 
   * file names encrypted
-  * file names can't be as long (~156 characters)
+  * file names can't be as long (~143 characters)
   * can use sub paths and copy single files
   * directory structure visible
   * identical files names will have identical uploaded names


### PR DESCRIPTION
As discussed in #2040 a fix for the documentation