### PR TITLE
drive: add new command 'about' to get quota info from a remote

### DIFF
--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -1312,6 +1312,18 @@ func (f *Fs) CleanUp() error {
 	return do()
 }
 
+// About gets quota information from the Fs
+func (f *Fs) About() error {
+	f.CleanUpCache(false)
+
+	do := f.Fs.Features().About
+	if do == nil {
+		return nil
+	}
+
+	return do()
+}
+
 // Stats returns stats about the cache storage
 func (f *Fs) Stats() (map[string]map[string]interface{}, error) {
 	return f.cache.Stats()
@@ -1437,4 +1449,5 @@ var (
 	_ fs.Wrapper           = (*Fs)(nil)
 	_ fs.ListRer           = (*Fs)(nil)
 	_ fs.DirChangeNotifier = (*Fs)(nil)
+	_ fs.Abouter           = (*Fs)(nil)
 )

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1047,6 +1047,29 @@ func (f *Fs) CleanUp() error {
 	return nil
 }
 
+// About gets quota information
+func (f *Fs) About() error {
+	var about *drive.About
+	var err error
+	err = f.pacer.Call(func() (bool, error) {
+		about, err = f.svc.About.Get().Fields("storageQuota").Do()
+		return shouldRetry(err)
+	})
+	if err != nil {
+		fs.Errorf(f, "Failed to get Drive storageQuota: %v", err)
+		return nil
+	}
+	quota := float64(about.StorageQuota.Limit) / (1 << 30)
+	usagetotal := float64(about.StorageQuota.Usage) / (1 << 30)
+	usagedrive := float64(about.StorageQuota.UsageInDrive) / (1 << 30)
+	usagetrash := float64(about.StorageQuota.UsageInDriveTrash) / (1 << 30)
+	fmt.Printf("Quota: %.0f GiB | Used: %.1f GiB (Trash: %.1f GiB) | Available: %.1f GiB | Usage: %d%%\n",
+		quota, usagedrive, usagetrash, quota-usagedrive, int((usagedrive/quota)*100))
+	fmt.Printf("Space used in other Google services (such as Gmail): %.2f GiB\n",
+		usagetotal-usagedrive)
+	return nil
+}
+
 // Move src to this remote using server side move operations.
 //
 // This is stored with the remote path given

--- a/cmd/about/about.go
+++ b/cmd/about/about.go
@@ -1,0 +1,27 @@
+package about
+
+import (
+	"github.com/ncw/rclone/cmd"
+	"github.com/ncw/rclone/fs/operations"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd.Root.AddCommand(commandDefintion)
+}
+
+var commandDefintion = &cobra.Command{
+	Use:   "about remote:",
+	Short: `Get quota information from the remote.`,
+	Long: `
+Get quota information from the remote, like bytes used/free/quota and bytes
+used in the trash. Not supported by all remotes.
+`,
+	Run: func(command *cobra.Command, args []string) {
+		cmd.CheckArgs(1, 1, command, args)
+		fsrc := cmd.NewFsSrc(args)
+		cmd.Run(true, false, command, func() error {
+			return operations.About(fsrc)
+		})
+	},
+}

--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -4,6 +4,7 @@ package all
 import (
 	// Active commands
 	_ "github.com/ncw/rclone/cmd"
+	_ "github.com/ncw/rclone/cmd/about"
 	_ "github.com/ncw/rclone/cmd/authorize"
 	_ "github.com/ncw/rclone/cmd/cachestats"
 	_ "github.com/ncw/rclone/cmd/cat"

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -98,6 +98,7 @@ The main rclone commands with most used first
 * [rclone moveto](/commands/rclone_moveto/)	- Move file or directory from source to dest.
 * [rclone obscure](/commands/rclone_obscure/)	- Obscure password for use in the rclone.conf
 * [rclone cryptcheck](/commands/rclone_cryptcheck/)	- Check the integrity of a crypted remote.
+* [rclone about](/commands/rclone_about/)	- Get quota information from the remote.
 
 See the [commands index](/commands/) for the full list.
 

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -278,6 +278,14 @@ If you wish to empty your trash you can use the `rclone cleanup remote:`
 command which will permanently delete all your trashed files. This command
 does not take any path arguments.
 
+### Quota information ###
+
+To view your current quota you can use the `rclone about remote:`
+command which will display your usage limit (quota), the usage in Google
+Drive, the size of all files in the Trash and the space used by other
+Google services such as Gmail. This command does not take any path
+arguments.
+
 ### Specific options ###
 
 Here are the command line options specific to this cloud storage

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -119,27 +119,27 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some
 operations more efficient.
 
-| Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR | StreamUpload |
-| ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|:------------:|
-| Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | No  |
-| Amazon S3                    | No    | Yes  | No   | No      | No      | Yes   | Yes          |
-| Backblaze B2                 | No    | No   | No   | No      | Yes     | Yes   | Yes          |
-| Box                          | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes |
-| Dropbox                      | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes |
-| FTP                          | No    | No   | Yes  | Yes     | No      | No    | Yes          |
-| Google Cloud Storage         | Yes   | Yes  | No   | No      | No      | Yes   | Yes          |
-| Google Drive                 | Yes   | Yes  | Yes  | Yes     | Yes     | No    | Yes          |
-| HTTP                         | No    | No   | No   | No      | No      | No    | No           |
-| Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   | Yes          |
-| Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   | No           |
-| Microsoft OneDrive           | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No [#575](https://github.com/ncw/rclone/issues/575) | No | No |
-| Openstack Swift              | Yes † | Yes  | No   | No      | No      | Yes   | Yes          |
-| pCloud                       | Yes   | Yes  | Yes  | Yes     | Yes     | No    | No           |
-| QingStor                     | No    | Yes  | No   | No      | No      | Yes   | No           |
-| SFTP                         | No    | No   | Yes  | Yes     | No      | No    | Yes          |
-| WebDAV                       | Yes   | Yes  | Yes  | Yes     | No      | No    | Yes ‡        |
-| Yandex Disk                  | Yes   | No   | No   | No      | Yes     | Yes   | Yes          |
-| The local filesystem         | Yes   | No   | Yes  | Yes     | No      | No    | Yes          |
+| Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR | StreamUpload | About |
+| ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|:------------:|:-----:|
+| Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | No  | No |
+| Amazon S3                    | No    | Yes  | No   | No      | No      | Yes   | Yes          | No    |
+| Backblaze B2                 | No    | No   | No   | No      | Yes     | Yes   | Yes          | No    |
+| Box                          | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes | No |
+| Dropbox                      | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes | No |
+| FTP                          | No    | No   | Yes  | Yes     | No      | No    | Yes          | No    |
+| Google Cloud Storage         | Yes   | Yes  | No   | No      | No      | Yes   | Yes          | No    |
+| Google Drive                 | Yes   | Yes  | Yes  | Yes     | Yes     | No    | Yes          | Yes   |
+| HTTP                         | No    | No   | No   | No      | No      | No    | No           | No    |
+| Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   | Yes          | No    |
+| Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   | No           | No    |
+| Microsoft OneDrive           | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No [#575](https://github.com/ncw/rclone/issues/575) | No | No | No |
+| Openstack Swift              | Yes † | Yes  | No   | No      | No      | Yes   | Yes          | No    |
+| pCloud                       | Yes   | Yes  | Yes  | Yes     | Yes     | No    | No           | No    |
+| QingStor                     | No    | Yes  | No   | No      | No      | Yes   | No           | No    |
+| SFTP                         | No    | No   | Yes  | Yes     | No      | No    | Yes          | No    |
+| WebDAV                       | Yes   | Yes  | Yes  | Yes     | No      | No    | Yes ‡        | No    |
+| Yandex Disk                  | Yes   | No   | No   | No      | Yes     | Yes   | Yes          | No    |
+| The local filesystem         | Yes   | No   | Yes  | Yes     | No      | No    | Yes          | No    |
 
 ### Purge ###
 
@@ -196,3 +196,11 @@ See the [rclone docs](/docs/#fast-list) for more details.
 Some remotes allow files to be uploaded without knowing the file size
 in advance. This allows certain operations to work without spooling the
 file to local disk first, e.g. `rclone rcat`.
+
+### About ###
+
+This is used to fetch quota information from the remote, like bytes
+used/free/quota and bytes used in the trash.
+
+If the server can't do `About` then `rclone about` will return an
+error.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -365,6 +365,9 @@ type Features struct {
 	// Don't implement this unless you have a more efficient way
 	// of listing recursively that doing a directory traversal.
 	ListR ListRFn
+
+	// Get quota information from the Fs
+	About func() error
 }
 
 // Disable nil's out the named feature.  If it isn't found then it
@@ -451,6 +454,9 @@ func (ft *Features) Fill(f Fs) *Features {
 	if do, ok := f.(ListRer); ok {
 		ft.ListR = do.ListR
 	}
+	if do, ok := f.(Abouter); ok {
+		ft.About = do.About
+	}
 	return ft.DisableList(Config.DisableFeatures)
 }
 
@@ -503,6 +509,9 @@ func (ft *Features) Mask(f Fs) *Features {
 	}
 	if mask.ListR == nil {
 		ft.ListR = nil
+	}
+	if mask.About == nil {
+		ft.About = nil
 	}
 	return ft.DisableList(Config.DisableFeatures)
 }
@@ -670,6 +679,12 @@ type ListRer interface {
 	// Don't implement this unless you have a more efficient way
 	// of listing recursively that doing a directory traversal.
 	ListR(dir string, callback ListRCallback) error
+}
+
+// Abouter is an optional interface for Fs
+type Abouter interface {
+	// Get quota information from the Fs
+	About() error
 }
 
 // ObjectsChan is a channel of Objects

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1303,6 +1303,19 @@ func CleanUp(f fs.Fs) error {
 	return doCleanUp()
 }
 
+// About gets quota information from the remote
+func About(f fs.Fs) error {
+	doAbout := f.Features().About
+	if doAbout == nil {
+		return errors.Errorf("%v doesn't support about", f)
+	}
+	if fs.Config.DryRun {
+		fs.Logf(f, "Not running about as --dry-run set")
+		return nil
+	}
+	return doAbout()
+}
+
 // wrap a Reader and a Closer together into a ReadCloser
 type readCloser struct {
 	io.Reader


### PR DESCRIPTION
I have tried to implement a new rclone command called `about` that fetches quota information from a remote (it only works with Google Drive at the moment). My main motivation behind this was a colleague of mine who requested this feature; other users have expressed a similar interest in #1138 and #1564.

The command output looks like this:

```
$ rclone about gdrive:
Quota: 15 GiB | Used: 5.6 GiB (Trash: 0.0 GiB) | Available: 9.4 GiB | Usage: 37%
Space used in other Google services (such as Gmail): 0.05 GiB
```

With no previous knowledge of Go programming I relied on reading up earlier pull requests and their corresponding commits to get an idea about how such a feature could be added to rclone. As such, my attempt is probably a bit amateurish so please forgive any mistakes you may spot. Having said that, I _did_ try to follow the 'Contributing to rclone' document and actually ran the unit tests for the remote I modified (there were a few SKIPs but the rest PASSed).

One thing that's unclear to me is whether I need to add a file under `docs/content/commands` for the `about` command. The existing files contain the line `Auto generated by spf13/cobra` so I guess there's a script that creates them automatically?