### PR TITLE
onedrive: Overwrite object size value with real size when reading file.

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1079,6 +1079,11 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode == http.StatusOK && resp.ContentLength > 0 && resp.Header.Get("Content-Range") == "" {
+		//Overwrite size with actual size since size readings from Onedrive is unreliable.
+		o.size = resp.ContentLength
+	}
 	return resp.Body, err
 }
 


### PR DESCRIPTION
Because of a bug in the Onedrive API it will sometime report the wrong size. If the size is wrong other remotes that depend on the size might fail. To fix this we overwrite the objects size with the real size from ContentLength header.