### PR TITLE
Add version output at end of the install.sh script

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -170,6 +170,6 @@ case $OS in
     exit 2
 esac
 
-
+printf '\nrclone ${version} has successfully installed.'
 printf '\nNow run "rclone config" for setup. Check https://rclone.org/docs/ for more details.\n\n'
 exit 0

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -170,6 +170,10 @@ case $OS in
     exit 2
 esac
 
-printf '\nrclone ${version} has successfully installed.'
+
+#update version variable post install
+version=`rclone --version 2>>errors | head -n 1`
+
+printf "\n${version} has successfully installed."
 printf '\nNow run "rclone config" for setup. Check https://rclone.org/docs/ for more details.\n\n'
 exit 0


### PR DESCRIPTION
Forced a re-check of the version prior to printing, else it would print the version of the previously installed (or null if not installed prior to running the install script).

Just prints out version on completion of the install script.