### PR TITLE
fstests: add TestInternal

### DIFF
--- a/backend/amazonclouddrive/amazonclouddrive_test.go
+++ b/backend/amazonclouddrive/amazonclouddrive_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -74,4 +74,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/b2/b2_test.go
+++ b/backend/b2/b2_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/box/box_test.go
+++ b/backend/box/box_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -75,4 +75,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/crypt/crypt2_test.go
+++ b/backend/crypt/crypt2_test.go
@@ -72,4 +72,5 @@ func TestFsIsFileNotFound2(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove2(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream2(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge2(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal2(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise2(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/crypt/crypt3_test.go
+++ b/backend/crypt/crypt3_test.go
@@ -72,4 +72,5 @@ func TestFsIsFileNotFound3(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove3(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream3(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge3(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal3(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise3(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/crypt/crypt_test.go
+++ b/backend/crypt/crypt_test.go
@@ -72,4 +72,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/drive/drive_test.go
+++ b/backend/drive/drive_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/dropbox/dropbox_test.go
+++ b/backend/dropbox/dropbox_test.go
@@ -74,4 +74,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/ftp/ftp_test.go
+++ b/backend/ftp/ftp_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/googlecloudstorage/googlecloudstorage_test.go
+++ b/backend/googlecloudstorage/googlecloudstorage_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/hubic/hubic_test.go
+++ b/backend/hubic/hubic_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/local/local_test.go
+++ b/backend/local/local_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/onedrive/onedrive_test.go
+++ b/backend/onedrive/onedrive_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/pcloud/pcloud_test.go
+++ b/backend/pcloud/pcloud_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/qingstor/qingstor_test.go
+++ b/backend/qingstor/qingstor_test.go
@@ -74,4 +74,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/sftp/sftp_test.go
+++ b/backend/sftp/sftp_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/webdav/webdav_test.go
+++ b/backend/webdav/webdav_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/backend/yandex/yandex_test.go
+++ b/backend/yandex/yandex_test.go
@@ -71,4 +71,5 @@ func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }
+func TestInternal(t *testing.T)            { fstests.TestInternal(t) }
 func TestFinalise(t *testing.T)            { fstests.TestFinalise(t) }

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -57,6 +57,13 @@ var (
 	isLocalRemote bool
 )
 
+// InternalTester is an optional interface for Fs which allows to execute internal tests
+//
+// This interface should be implemented in 'backend'_internal_test.go and not in 'backend'.go
+type InternalTester interface {
+	InternalTest(*testing.T)
+}
+
 // ExtraConfigItem describes a config item added on the fly while testing
 type ExtraConfigItem struct{ Name, Key, Value string }
 
@@ -968,6 +975,16 @@ func TestObjectPurge(t *testing.T) {
 
 	err = operations.Purge(remote, "")
 	assert.Error(t, err, "Expecting error after on second purge")
+}
+
+// TestInternal calls InternalTest() on the Fs
+func TestInternal(t *testing.T) {
+	skipIfNotOk(t)
+	if it, ok := remote.(InternalTester); ok {
+		it.InternalTest(t)
+	} else {
+		t.Skipf("%T does not implement InternalTester", remote)
+	}
 }
 
 // TestFinalise tidies up after the previous tests


### PR DESCRIPTION
This adds a `TestInternal` function to `fstests.go` which allows to perform a custom test on the backend `Fs` using the optional `InternalTester` interface.

The interface will allow to create tests which operate on the test remote after the regular fstests, but before cleanup.

My use case is to create tests for the document handling in Google Drive, which can operate on the test remote.

A example implementation of the interface would look like this in `backend/drive/drive_internal_test.go`:
```go
func InternalTestDocumentUpload(t *testing.T) {
     // ...
}
func InternalTestDocumentUpdate(t *testing.T) {
     // ...
}
func (*Fs) InternalTest(t *testing.T) {
    // go1.7+
     t.Run("InternalTestDocumentUpload", InternalTestDocumentUpload)
     t.Run("InternalTestDocumentUpdate", InternalTestDocumentUpdate)
    // go1.6
    InternalTestDocumentUpload(t)
    if t.Failed() {
        return
    }
    InternalTestDocumentUpdate(t)
}
```