### PR TITLE
cryptdecode: use Cipher instead of NewFs

### DIFF
--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -91,6 +91,8 @@ type Cipher interface {
 	EncryptedSize(int64) int64
 	// DecryptedSize calculates the size of the data when decrypted
 	DecryptedSize(int64) (int64, error)
+	// NameEncryptionMode returns the used mode for name handling
+	NameEncryptionMode() NameEncryptionMode
 }
 
 // NameEncryptionMode is the type of file name encryption in use
@@ -545,6 +547,10 @@ func (c *cipher) DecryptDirName(in string) (string, error) {
 		return in, nil
 	}
 	return c.decryptFileName(in)
+}
+
+func (c *cipher) NameEncryptionMode() NameEncryptionMode {
+	return c.mode
 }
 
 // nonce is an NACL secretbox nonce

--- a/cmd/cryptdecode/cryptdecode.go
+++ b/cmd/cryptdecode/cryptdecode.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fs/config/flags"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -39,40 +38,29 @@ use it like this
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 11, command, args)
-		fsrc := cmd.NewFsSrc(args)
-		if Reverse {
-			cmd.Run(false, false, command, func() error {
-				return cryptEncode(fsrc, args[1:])
-			})
-		} else {
-			cmd.Run(false, false, command, func() error {
-				return cryptDecode(fsrc, args[1:])
-			})
-		}
+		cmd.Run(false, false, command, func() error {
+			_, configName, _, err := fs.ParseRemote(args[0])
+			if err != nil {
+				return err
+			}
+			cipher, err := crypt.NewCipher(configName)
+			if err != nil {
+				return err
+			}
+			if Reverse {
+				return cryptEncode(cipher, args[1:])
+			}
+			return cryptDecode(cipher, args[1:])
+		})
 	},
 }
 
-// Check if fsrc is a crypt
-func assertCryptFs(fsrc fs.Fs) (*crypt.Fs, error) {
-	fcrypt, ok := fsrc.(*crypt.Fs)
-	if !ok {
-		return nil, errors.Errorf("%s:%s is not a crypt remote", fsrc.Name(), fsrc.Root())
-	}
-	return fcrypt, nil
-}
-
 // cryptDecode returns the unencrypted file name
-func cryptDecode(fsrc fs.Fs, args []string) error {
-	fcrypt, err := assertCryptFs(fsrc)
-
-	if err != nil {
-		return err
-	}
-
+func cryptDecode(cipher crypt.Cipher, args []string) error {
 	output := ""
 
 	for _, encryptedFileName := range args {
-		fileName, err := fcrypt.DecryptFileName(encryptedFileName)
+		fileName, err := cipher.DecryptFileName(encryptedFileName)
 		if err != nil {
 			output += fmt.Sprintln(encryptedFileName, "\t", "Failed to decrypt")
 		} else {
@@ -86,17 +74,11 @@ func cryptDecode(fsrc fs.Fs, args []string) error {
 }
 
 // cryptEncode returns the encrypted file name
-func cryptEncode(fsrc fs.Fs, args []string) error {
-	fcrypt, err := assertCryptFs(fsrc)
-
-	if err != nil {
-		return err
-	}
-
+func cryptEncode(cipher crypt.Cipher, args []string) error {
 	output := ""
 
 	for _, fileName := range args {
-		encryptedFileName := fcrypt.EncryptFileName(fileName)
+		encryptedFileName := cipher.EncryptFileName(fileName)
 		output += fmt.Sprintln(fileName, "\t", encryptedFileName)
 	}
 

--- a/cmd/cryptdecode/cryptdecode.go
+++ b/cmd/cryptdecode/cryptdecode.go
@@ -1,6 +1,7 @@
 package cryptdecode
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ncw/rclone/backend/crypt"
@@ -39,9 +40,12 @@ use it like this
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 11, command, args)
 		cmd.Run(false, false, command, func() error {
-			_, configName, _, err := fs.ParseRemote(args[0])
+			fsInfo, configName, _, err := fs.ParseRemote(args[0])
 			if err != nil {
 				return err
+			}
+			if fsInfo.Name != "crypt" {
+				return errors.New("The remote needs to be of type \"crypt\"")
 			}
 			cipher, err := crypt.NewCipher(configName)
 			if err != nil {


### PR DESCRIPTION
This adds a `NewCipher` function to the crypt backend, which contains the `Cipher` specific code from `NewFs`.

The `NewCipher` function will be used by `cryptdecode` to encode and decode names without constructing the wrapped remote.

This fixes #2075