### PR TITLE
add ChangeNotify and drive support for it

### DIFF
--- a/backend/amazonclouddrive/amazonclouddrive.go
+++ b/backend/amazonclouddrive/amazonclouddrive.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -1207,20 +1206,19 @@ func (o *Object) MimeType() string {
 	return ""
 }
 
-// DirChangeNotify polls for changes from the remote and hands the path to the
-// given function. Only changes that can be resolved to a path through the
-// DirCache will handled.
+// ChangeNotify calls the passed function with a path that has had changes.
+// If the implementation uses polling, it should adhere to the given interval.
 //
 // Automatically restarts itself in case of unexpected behaviour of the remote.
 //
 // Close the returned channel to stop being notified.
-func (f *Fs) DirChangeNotify(notifyFunc func(string), pollInterval time.Duration) chan bool {
+func (f *Fs) ChangeNotify(notifyFunc func(string, fs.EntryType), pollInterval time.Duration) chan bool {
 	checkpoint := config.FileGet(f.name, "checkpoint")
 
 	quit := make(chan bool)
 	go func() {
 		for {
-			checkpoint = f.dirchangeNotifyRunner(notifyFunc, checkpoint)
+			checkpoint = f.changeNotifyRunner(notifyFunc, checkpoint)
 			if err := config.SetValueAndSave(f.name, "checkpoint", checkpoint); err != nil {
 				fs.Debugf(f, "Unable to save checkpoint: %v", err)
 			}
@@ -1234,7 +1232,7 @@ func (f *Fs) DirChangeNotify(notifyFunc func(string), pollInterval time.Duration
 	return quit
 }
 
-func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), checkpoint string) string {
+func (f *Fs) changeNotifyRunner(notifyFunc func(string, fs.EntryType), checkpoint string) string {
 	var err error
 	var resp *http.Response
 	var reachedEnd bool
@@ -1251,7 +1249,7 @@ func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), checkpoint string) s
 				return err
 			}
 
-			pathsToClear := make([]string, 0)
+			pathsToClear := make(map[string]fs.EntryType)
 			csCount++
 			nodeCount += len(changeSet.Nodes)
 			if changeSet.End {
@@ -1262,20 +1260,32 @@ func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), checkpoint string) s
 			}
 			for _, node := range changeSet.Nodes {
 				if path, ok := f.dirCache.GetInv(*node.Id); ok {
-					pathsToClear = append(pathsToClear, path)
+					pathsToClear[path] = fs.EntryDirectory
+					if node.IsFile() {
+						pathsToClear[path] = fs.EntryObject
+					}
+
+					if node.IsFile() {
+						// translate the parent dir of this object
+						if len(node.Parents) > 0 {
+							if path, ok := f.dirCache.GetInv(node.Parents[0]); ok {
+								// and append the drive file name to compute the full file name
+								if len(path) > 0 {
+									path = path + "/" + *node.Name
+								} else {
+									path = *node.Name
+								}
+								// this will now clear the actual file too
+								pathsToClear[path] = fs.EntryObject
+							}
+						} else { // a true root object that is changed
+							pathsToClear[*node.Name] = fs.EntryObject
+						}
+					}
 				}
 			}
-
-			notified := false
-			lastNotifiedPath := ""
-			sort.Strings(pathsToClear)
-			for _, path := range pathsToClear {
-				if notified && strings.HasPrefix(path+"/", lastNotifiedPath+"/") {
-					continue
-				}
-				lastNotifiedPath = path
-				notified = true
-				notifyFunc(path)
+			for path, entryType := range pathsToClear {
+				notifyFunc(path, entryType)
 			}
 
 			return nil
@@ -1303,10 +1313,10 @@ var (
 	_ fs.Fs     = (*Fs)(nil)
 	_ fs.Purger = (*Fs)(nil)
 	//	_ fs.Copier   = (*Fs)(nil)
-	_ fs.Mover             = (*Fs)(nil)
-	_ fs.DirMover          = (*Fs)(nil)
-	_ fs.DirCacheFlusher   = (*Fs)(nil)
-	_ fs.DirChangeNotifier = (*Fs)(nil)
-	_ fs.Object            = (*Object)(nil)
-	_ fs.MimeTyper         = &Object{}
+	_ fs.Mover           = (*Fs)(nil)
+	_ fs.DirMover        = (*Fs)(nil)
+	_ fs.DirCacheFlusher = (*Fs)(nil)
+	_ fs.ChangeNotifier  = (*Fs)(nil)
+	_ fs.Object          = (*Object)(nil)
+	_ fs.MimeTyper       = &Object{}
 )

--- a/backend/amazonclouddrive/amazonclouddrive_test.go
+++ b/backend/amazonclouddrive/amazonclouddrive_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -54,7 +54,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/b2/b2_test.go
+++ b/backend/b2/b2_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/box/box_test.go
+++ b/backend/box/box_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -55,7 +55,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/cache/handle.go
+++ b/backend/cache/handle.go
@@ -658,7 +658,7 @@ func (b *backgroundWriter) run() {
 		if err != nil {
 			fs.Errorf(parentCd, "background upload: cache expire error: %v", err)
 		}
-		b.fs.notifyDirChange(remote)
+		b.fs.notifyChange(remote, fs.EntryObject)
 		fs.Infof(remote, "finished background upload")
 		b.notify(remote, BackgroundUploadCompleted, nil)
 	}

--- a/backend/cache/handle.go
+++ b/backend/cache/handle.go
@@ -658,7 +658,7 @@ func (b *backgroundWriter) run() {
 		if err != nil {
 			fs.Errorf(parentCd, "background upload: cache expire error: %v", err)
 		}
-		b.fs.notifyChange(remote, fs.EntryObject)
+		b.fs.notifyChangeUpstream(remote, fs.EntryObject)
 		fs.Infof(remote, "finished background upload")
 		b.notify(remote, BackgroundUploadCompleted, nil)
 	}

--- a/backend/cache/object.go
+++ b/backend/cache/object.go
@@ -274,8 +274,8 @@ func (o *Object) Remove() error {
 	_ = o.CacheFs.cache.removePendingUpload(o.abs())
 	parentCd := NewDirectory(o.CacheFs, cleanPath(path.Dir(o.Remote())))
 	_ = o.CacheFs.cache.ExpireDir(parentCd)
-	// advertise to DirChangeNotify if wrapped doesn't do that
-	o.CacheFs.notifyDirChangeUpstreamIfNeeded(parentCd.Remote())
+	// advertise to ChangeNotify if wrapped doesn't do that
+	o.CacheFs.notifyChangeUpstreamIfNeeded(parentCd.Remote(), fs.EntryDirectory)
 
 	return nil
 }

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -143,18 +143,18 @@ func NewFs(name, rpath string) (fs.Fs, error) {
 		CanHaveEmptyDirectories: true,
 	}).Fill(f).Mask(wrappedFs).WrapsFs(f, wrappedFs)
 
-	doDirChangeNotify := wrappedFs.Features().DirChangeNotify
-	if doDirChangeNotify != nil {
-		f.features.DirChangeNotify = func(notifyFunc func(string), pollInterval time.Duration) chan bool {
-			wrappedNotifyFunc := func(path string) {
+	doChangeNotify := wrappedFs.Features().ChangeNotify
+	if doChangeNotify != nil {
+		f.features.ChangeNotify = func(notifyFunc func(string, fs.EntryType), pollInterval time.Duration) chan bool {
+			wrappedNotifyFunc := func(path string, entryType fs.EntryType) {
 				decrypted, err := f.DecryptFileName(path)
 				if err != nil {
-					fs.Logf(f, "DirChangeNotify was unable to decrypt %q: %s", path, err)
+					fs.Logf(f, "ChangeNotify was unable to decrypt %q: %s", path, err)
 					return
 				}
-				notifyFunc(decrypted)
+				notifyFunc(decrypted, entryType)
 			}
-			return doDirChangeNotify(wrappedNotifyFunc, pollInterval)
+			return doChangeNotify(wrappedNotifyFunc, pollInterval)
 		}
 	}
 

--- a/backend/crypt/crypt2_test.go
+++ b/backend/crypt/crypt2_test.go
@@ -52,7 +52,7 @@ func TestFsMove2(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove2(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull2(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision2(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify2(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify2(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString2(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs2(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote2(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/crypt/crypt3_test.go
+++ b/backend/crypt/crypt3_test.go
@@ -52,7 +52,7 @@ func TestFsMove3(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove3(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull3(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision3(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify3(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify3(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString3(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs3(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote3(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/crypt/crypt_test.go
+++ b/backend/crypt/crypt_test.go
@@ -52,7 +52,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1182,14 +1181,13 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 	return nil
 }
 
-// DirChangeNotify polls for changes from the remote and hands the path to the
-// given function. Only changes that can be resolved to a path through the
-// DirCache will handled.
+// ChangeNotify calls the passed function with a path that has had changes.
+// If the implementation uses polling, it should adhere to the given interval.
 //
 // Automatically restarts itself in case of unexpected behaviour of the remote.
 //
 // Close the returned channel to stop being notified.
-func (f *Fs) DirChangeNotify(notifyFunc func(string), pollInterval time.Duration) chan bool {
+func (f *Fs) ChangeNotify(notifyFunc func(string, fs.EntryType), pollInterval time.Duration) chan bool {
 	quit := make(chan bool)
 	go func() {
 		select {
@@ -1197,7 +1195,7 @@ func (f *Fs) DirChangeNotify(notifyFunc func(string), pollInterval time.Duration
 			return
 		default:
 			for {
-				f.dirchangeNotifyRunner(notifyFunc, pollInterval)
+				f.changeNotifyRunner(notifyFunc, pollInterval)
 				fs.Debugf(f, "Notify listener service ran into issues, restarting shortly.")
 				time.Sleep(pollInterval)
 			}
@@ -1206,11 +1204,8 @@ func (f *Fs) DirChangeNotify(notifyFunc func(string), pollInterval time.Duration
 	return quit
 }
 
-func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), pollInterval time.Duration) {
+func (f *Fs) changeNotifyRunner(notifyFunc func(string, fs.EntryType), pollInterval time.Duration) {
 	var err error
-	var changeList *drive.ChangeList
-	var pageToken string
-
 	var startPageToken *drive.StartPageToken
 	err = f.pacer.Call(func() (bool, error) {
 		startPageToken, err = f.svc.Changes.GetStartPageToken().SupportsTeamDrives(f.isTeamDrive).Do()
@@ -1220,12 +1215,14 @@ func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), pollInterval time.Du
 		fs.Debugf(f, "Failed to get StartPageToken: %v", err)
 		return
 	}
-	pageToken = startPageToken.StartPageToken
+	pageToken := startPageToken.StartPageToken
 
 	for {
 		fs.Debugf(f, "Checking for changes on remote")
+		var changeList *drive.ChangeList
+
 		err = f.pacer.Call(func() (bool, error) {
-			changesCall := f.svc.Changes.List(pageToken).Fields("nextPageToken,newStartPageToken,changes(fileId,file/parents)")
+			changesCall := f.svc.Changes.List(pageToken).Fields("nextPageToken,newStartPageToken,changes(fileId,file(name,parents,mimeType))")
 			if *driveListChunk > 0 {
 				changesCall = changesCall.PageSize(*driveListChunk)
 			}
@@ -1237,28 +1234,35 @@ func (f *Fs) dirchangeNotifyRunner(notifyFunc func(string), pollInterval time.Du
 			return
 		}
 
-		pathsToClear := make([]string, 0)
+		pathsToClear := make(map[string]fs.EntryType)
 		for _, change := range changeList.Changes {
 			if path, ok := f.dirCache.GetInv(change.FileId); ok {
-				pathsToClear = append(pathsToClear, path)
+				pathsToClear[path] = fs.EntryDirectory
+				if change.File != nil && change.File.MimeType != driveFolderType {
+					pathsToClear[path] = fs.EntryObject
+				}
 			}
 
-			if change.File != nil {
-				for _, parent := range change.File.Parents {
-					if path, ok := f.dirCache.GetInv(parent); ok {
-						pathsToClear = append(pathsToClear, path)
+			if change.File != nil && change.File.MimeType != driveFolderType {
+				// translate the parent dir of this object
+				if len(change.File.Parents) > 0 {
+					if path, ok := f.dirCache.GetInv(change.File.Parents[0]); ok {
+						// and append the drive file name to compute the full file name
+						if len(path) > 0 {
+							path = path + "/" + change.File.Name
+						} else {
+							path = change.File.Name
+						}
+						// this will now clear the actual file too
+						pathsToClear[path] = fs.EntryObject
 					}
+				} else { // a true root object that is changed
+					pathsToClear[change.File.Name] = fs.EntryObject
 				}
 			}
 		}
-		lastNotifiedPath := ""
-		sort.Strings(pathsToClear)
-		for _, path := range pathsToClear {
-			if lastNotifiedPath != "" && (path == lastNotifiedPath || strings.HasPrefix(path+"/", lastNotifiedPath)) {
-				continue
-			}
-			lastNotifiedPath = path
-			notifyFunc(path)
+		for path, entryType := range pathsToClear {
+			notifyFunc(path, entryType)
 		}
 
 		if changeList.NewStartPageToken != "" {
@@ -1567,17 +1571,17 @@ func (o *Object) MimeType() string {
 
 // Check the interfaces are satisfied
 var (
-	_ fs.Fs                = (*Fs)(nil)
-	_ fs.Purger            = (*Fs)(nil)
-	_ fs.CleanUpper        = (*Fs)(nil)
-	_ fs.PutStreamer       = (*Fs)(nil)
-	_ fs.Copier            = (*Fs)(nil)
-	_ fs.Mover             = (*Fs)(nil)
-	_ fs.DirMover          = (*Fs)(nil)
-	_ fs.DirCacheFlusher   = (*Fs)(nil)
-	_ fs.DirChangeNotifier = (*Fs)(nil)
-	_ fs.PutUncheckeder    = (*Fs)(nil)
-	_ fs.MergeDirser       = (*Fs)(nil)
-	_ fs.Object            = (*Object)(nil)
-	_ fs.MimeTyper         = &Object{}
+	_ fs.Fs              = (*Fs)(nil)
+	_ fs.Purger          = (*Fs)(nil)
+	_ fs.CleanUpper      = (*Fs)(nil)
+	_ fs.PutStreamer     = (*Fs)(nil)
+	_ fs.Copier          = (*Fs)(nil)
+	_ fs.Mover           = (*Fs)(nil)
+	_ fs.DirMover        = (*Fs)(nil)
+	_ fs.DirCacheFlusher = (*Fs)(nil)
+	_ fs.ChangeNotifier  = (*Fs)(nil)
+	_ fs.PutUncheckeder  = (*Fs)(nil)
+	_ fs.MergeDirser     = (*Fs)(nil)
+	_ fs.Object          = (*Object)(nil)
+	_ fs.MimeTyper       = &Object{}
 )

--- a/backend/drive/drive_test.go
+++ b/backend/drive/drive_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/dropbox/dropbox_test.go
+++ b/backend/dropbox/dropbox_test.go
@@ -54,7 +54,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/ftp/ftp_test.go
+++ b/backend/ftp/ftp_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/googlecloudstorage/googlecloudstorage_test.go
+++ b/backend/googlecloudstorage/googlecloudstorage_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/hubic/hubic_test.go
+++ b/backend/hubic/hubic_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/local/local_test.go
+++ b/backend/local/local_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/onedrive/onedrive_test.go
+++ b/backend/onedrive/onedrive_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/pcloud/pcloud_test.go
+++ b/backend/pcloud/pcloud_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/qingstor/qingstor_test.go
+++ b/backend/qingstor/qingstor_test.go
@@ -54,7 +54,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/sftp/sftp_test.go
+++ b/backend/sftp/sftp_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/webdav/webdav_test.go
+++ b/backend/webdav/webdav_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/backend/yandex/yandex_test.go
+++ b/backend/yandex/yandex_test.go
@@ -51,7 +51,7 @@ func TestFsMove(t *testing.T)              { fstests.TestFsMove(t) }
 func TestFsDirMove(t *testing.T)           { fstests.TestFsDirMove(t) }
 func TestFsRmdirFull(t *testing.T)         { fstests.TestFsRmdirFull(t) }
 func TestFsPrecision(t *testing.T)         { fstests.TestFsPrecision(t) }
-func TestFsDirChangeNotify(t *testing.T)   { fstests.TestFsDirChangeNotify(t) }
+func TestFsChangeNotify(t *testing.T)      { fstests.TestFsChangeNotify(t) }
 func TestObjectString(t *testing.T)        { fstests.TestObjectString(t) }
 func TestObjectFs(t *testing.T)            { fstests.TestObjectFs(t) }
 func TestObjectRemote(t *testing.T)        { fstests.TestObjectRemote(t) }

--- a/cmd/mountlib/mounttest/dir.go
+++ b/cmd/mountlib/mounttest/dir.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ncw/rclone/fs"
 )
 
 // TestDirLs checks out listing
@@ -178,11 +179,11 @@ func TestDirCacheFlush(t *testing.T) {
 	require.NoError(t, err)
 
 	// expect newly created "subdir" on remote to not show up
-	root.ForgetPath("otherdir")
+	root.ForgetPath("otherdir", fs.EntryDirectory)
 	run.readLocal(t, localDm, "")
 	assert.Equal(t, dm, localDm, "expected vs fuse mount")
 
-	root.ForgetPath("dir")
+	root.ForgetPath("dir", fs.EntryDirectory)
 	dm = newDirMap("otherdir/|otherdir/file 1|dir/|dir/file 1|dir/subdir/")
 	run.readLocal(t, localDm, "")
 	assert.Equal(t, dm, localDm, "expected vs fuse mount")

--- a/cmd/mountlib/mounttest/dir.go
+++ b/cmd/mountlib/mounttest/dir.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ncw/rclone/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ncw/rclone/fs"
 )
 
 // TestDirLs checks out listing

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -712,19 +712,24 @@ func TestFsChangeNotify(t *testing.T) {
 	}, time.Second)
 	defer func() { close(quitChannel) }()
 
-	err = operations.Mkdir(remote, "dir/subdir")
-	require.NoError(t, err)
+	for _, idx := range []int{1, 3, 2} {
+		err = operations.Mkdir(remote, fmt.Sprintf("dir/subdir%d", idx))
+		require.NoError(t, err)
+	}
 
 	contents := fstest.RandomString(100)
 	buf := bytes.NewBufferString(contents)
-	obji := object.NewStaticObjectInfo("dir/file", time.Now(), int64(buf.Len()), true, nil, nil)
-	_, err = remote.Put(buf, obji)
-	require.NoError(t, err)
+
+	for _, idx := range []int{2, 4, 3} {
+		obji := object.NewStaticObjectInfo(fmt.Sprintf("dir/file%d", idx), time.Now(), int64(buf.Len()), true, nil, nil)
+		_, err = remote.Put(buf, obji)
+		require.NoError(t, err)
+	}
 
 	time.Sleep(3 * time.Second)
 
-	assert.Equal(t, []string{"dir/subdir"}, dirChanges)
-	assert.Equal(t, []string{"dir/file"}, objChanges)
+	assert.Equal(t, []string{"dir/subdir1", "dir/subdir3", "dir/subdir2"}, dirChanges)
+	assert.Equal(t, []string{"dir/file2", "dir/file4", "dir/file3"}, objChanges)
 }
 
 // TestObjectString tests the Object String method

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -94,7 +94,7 @@ func (d *Dir) Node() Node {
 // ForgetAll ensures the directory and all its children are purged
 // from the cache.
 func (d *Dir) ForgetAll() {
-	d.ForgetPath("")
+	d.ForgetPath("", fs.EntryDirectory)
 }
 
 // ForgetPath clears the cache for itself and all subdirectories if
@@ -102,9 +102,13 @@ func (d *Dir) ForgetAll() {
 // directory it is called from.
 // It is not possible to traverse the directory tree upwards, i.e.
 // you cannot clear the cache for the Dir's ancestors or siblings.
-func (d *Dir) ForgetPath(relativePath string) {
+func (d *Dir) ForgetPath(relativePath string, entryType fs.EntryType) {
+	// if we are requested to forget a file, we use its parent
 	absPath := path.Join(d.path, relativePath)
-	if absPath == "." {
+	if entryType != fs.EntryDirectory {
+		absPath = path.Dir(absPath)
+	}
+	if absPath == "." || absPath == "/" {
 		absPath = ""
 	}
 

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ncw/rclone/fs"
 )
 
 func dirCreate(t *testing.T, r *fstest.Run) (*VFS, *Dir, fstest.Item) {

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ncw/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ncw/rclone/fs"
 )
 
 func dirCreate(t *testing.T, r *fstest.Run) (*VFS, *Dir, fstest.Item) {
@@ -113,11 +114,11 @@ func TestDirForgetPath(t *testing.T) {
 	assert.Equal(t, 1, len(root.items))
 	assert.Equal(t, 1, len(dir.items))
 
-	root.ForgetPath("dir")
+	root.ForgetPath("dir", fs.EntryDirectory)
 	assert.Equal(t, 1, len(root.items))
 	assert.Equal(t, 0, len(dir.items))
 
-	root.ForgetPath("not/in/cache")
+	root.ForgetPath("not/in/cache", fs.EntryDirectory)
 	assert.Equal(t, 1, len(root.items))
 	assert.Equal(t, 0, len(dir.items))
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -217,7 +217,7 @@ func New(f fs.Fs, opt *Options) *VFS {
 
 	// Start polling if required
 	if vfs.Opt.PollInterval > 0 {
-		if do := vfs.f.Features().DirChangeNotify; do != nil {
+		if do := vfs.f.Features().ChangeNotify; do != nil {
 			do(vfs.root.ForgetPath, vfs.Opt.PollInterval)
 		} else {
 			fs.Infof(f, "poll-interval is not supported by this remote")


### PR DESCRIPTION
Hi @ncw 

I've added a new feature which is similar to DirChangeNotify to fs. The reason for an almost identical feature is to keep the workflows of DirChangeNotify unchanged.

The main difference would be in its implementation. It should return both files and directories once per poll interval and make no assumptions about how would they be needed. 

I've also added support for it in drive. I'll take a look at other cloud providers if they could make use of it.

Let me know what you think. The diff in drive is ugly but I just refactored the code a bit as the drive integration would be identical in both of them.