### PR TITLE
serve/restic: Remove log message on Close

### DIFF
--- a/cmd/serve/restic/stdio_conn.go
+++ b/cmd/serve/restic/stdio_conn.go
@@ -1,7 +1,6 @@
 package restic
 
 import (
-	"log"
 	"net"
 	"os"
 )
@@ -34,7 +33,6 @@ func (s *StdioConn) Write(p []byte) (int, error) {
 
 // Close closes both streams.
 func (s *StdioConn) Close() error {
-	log.Printf("Server.Close()\n")
 	err1 := s.stdin.Close()
 	err2 := s.stdout.Close()
 	if err1 != nil {


### PR DESCRIPTION
This commit removes an unneeded log message I accidentally left in the code, I mentioned it here: https://github.com/restic/restic/issues/1561#issuecomment-372829003