### PR TITLE
rc: add cache remote statistics

### DIFF
--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -431,7 +431,27 @@ Params:
 `,
 	})
 
+	rc.Add(rc.Call{
+		Path:  "cache/stats",
+		Fn:    f.httpStats,
+		Title: "Get cache stats",
+		Help: `
+Show statistics for the cache remote.
+`,
+	})
+
 	return f, fsErr
+}
+
+func (f *Fs) httpStats(in rc.Params) (out rc.Params, err error) {
+	out = make(rc.Params)
+	m, err := f.Stats()
+	if err != nil {
+		return out, errors.Errorf("error while getting cache stats")
+	}
+	out["status"] = "ok"
+	out["stats"] = m
+	return out, nil
 }
 
 func (f *Fs) httpExpireRemote(in rc.Params) (out rc.Params, err error) {


### PR DESCRIPTION
this PR adds cache statistics to the rc commands. "rclone cachestats" will not work while the cache remote is mounted (DB is locked)