### PR TITLE
Minor format and URL changes to IBM COS Documentation content.

### DIFF
--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -26,7 +26,7 @@ Rclone is a command line program to sync files and directories to and from:
 * {{< provider name="Google Drive" home="https://www.google.com/drive/" config="/drive/" >}}
 * {{< provider name="HTTP" home="https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol" config="/http/" >}}
 * {{< provider name="Hubic" home="https://hubic.com/" config="/hubic/" >}}
-* {{< provider name="IBM COS S3" home="http://https://www.ibm.com/cloud/object-storage" config="/s3/" >}}
+* {{< provider name="IBM COS S3" home="http://www.ibm.com/cloud/object-storage" config="/s3/" >}}
 * {{< provider name="Memset Memstore" home="https://www.memset.com/cloud/storage/" config="/swift/" >}}
 * {{< provider name="Microsoft Azure Blob Storage" home="https://azure.microsoft.com/en-us/services/storage/blobs/" config="/azureblob/" >}}
 * {{< provider name="Microsoft OneDrive" home="https://onedrive.live.com/" config="/onedrive/" >}}

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -650,7 +650,7 @@ To configure access to IBM COS S3, follow the steps below:
 12. Review the displayed configuration and accept to save the "remote" then quit. The config file should look like this
 ```
 	env_auth = false
-	access_key_id = msRoDENqLymO37eaOA1s
+	access_key_id = <>
 	secret_access_key = <>
 	region = other-v4-signature
 	endpoint = s3-api.us-geo.objectstorage.softlayer.net

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -503,7 +503,7 @@ rclone copy /path/to/files spaces:my-new-space
 ```
 
 ### IBM COS (S3) ###
-Information stored with IBM Cloud Object Storage is encrypted and dispersed across multiple geographic locations, and accessed through an implementation of the S3 API. This service makes use of the distributed storage technologies provided by IBM’s Cloud Object Storage System (formerly Cleversafe). For more information visit: (https://www.ibm.com/cloud/object-storage)
+Information stored with IBM Cloud Object Storage is encrypted and dispersed across multiple geographic locations, and accessed through an implementation of the S3 API. This service makes use of the distributed storage technologies provided by IBM’s Cloud Object Storage System (formerly Cleversafe). For more information visit: (http://www.ibm.com/cloud/object-storage)
 
 To configure access to IBM COS S3, follow the steps below:
 
@@ -575,7 +575,7 @@ To configure access to IBM COS S3, follow the steps below:
 	region> 16
 ```
 
-7. Enter the endpoint FQDN.
+7. Enter the endpoint FQDN. 
 ```
 	Leave blank if using AWS to use the default endpoint for the region.
 	Specify if using an S3 clone such as Ceph.
@@ -599,7 +599,7 @@ To configure access to IBM COS S3, follow the steps below:
 	location_constraint> us-standard
 ```
 
-9. Specify a canned ACL.
+9. Specify a canned ACL. IBM COS on Bluemix(IBM Cloud) supports "public-read" and "private". IBM COS Infrastrucure on Bluemix(IBM Cloud) supports all the canned ACLs. On-Prem COS supports all the canned ACLs.
 ```
 	Canned ACL used when creating buckets and/or storing objects in S3.
 	For more info visit https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
@@ -647,13 +647,10 @@ To configure access to IBM COS S3, follow the steps below:
 	storage_class>
 ```
 
-12. Review the displayed configuration and accept to save the "remote" then quit.
+12. Review the displayed configuration and accept to save the "remote" then quit. The config file should look like this
 ```
-	Remote config
-	--------------------
-	[IBM-COS-XREGION]
 	env_auth = false
-	access_key_id = <>
+	access_key_id = msRoDENqLymO37eaOA1s
 	secret_access_key = <>
 	region = other-v4-signature
 	endpoint = s3-api.us-geo.objectstorage.softlayer.net
@@ -661,29 +658,7 @@ To configure access to IBM COS S3, follow the steps below:
 	acl = private
 	server_side_encryption = 
 	storage_class =
-	--------------------
-	y) Yes this is OK
-	e) Edit this remote
-	d) Delete this remote
-	y/e/d> y
-	Remote config
-	Current remotes:
-
-	Name                 Type
-	====                 ====
-	IBM-COS-XREGION      s3
-
-	e) Edit existing remote
-	n) New remote
-	d) Delete remote
-	r) Rename remote
-	c) Copy remote
-	s) Set configuration password
-	q) Quit config
-	e/n/d/r/c/s/q> q
 ```
-
-
 
 13. Execute rclone commands
 ```
@@ -703,7 +678,6 @@ To configure access to IBM COS S3, follow the steps below:
 	6)	Delete a file on remote.
 		rclone delete IBM-COS-XREGION:newbucket/file.txt
 ```
-
 
 ### Minio ###
 


### PR DESCRIPTION
We noticed a few things with the website and the links. The website format was a little messy. Formatted test so that hugo can process correctly. Also noticed mangled URL on the main page that links to IBM COS. Made these changes in this branch. 