### PR TITLE
link: allow creating public link to files and folders - closes #1562

### DIFF
--- a/backend/amazonclouddrive/amazonclouddrive_test.go
+++ b/backend/amazonclouddrive/amazonclouddrive_test.go
@@ -71,6 +71,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -71,6 +71,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/b2/b2_test.go
+++ b/backend/b2/b2_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/box/box_test.go
+++ b/backend/box/box_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -72,6 +72,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/crypt/crypt2_test.go
+++ b/backend/crypt/crypt2_test.go
@@ -69,6 +69,7 @@ func TestObjectUpdate2(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable2(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile2(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound2(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink2(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove2(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream2(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge2(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/crypt/crypt3_test.go
+++ b/backend/crypt/crypt3_test.go
@@ -69,6 +69,7 @@ func TestObjectUpdate3(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable3(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile3(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound3(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink3(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove3(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream3(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge3(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/crypt/crypt_test.go
+++ b/backend/crypt/crypt_test.go
@@ -69,6 +69,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1092,20 +1092,20 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 }
 
 // PublicLink adds a "readable by anyone with link" permission on the given file or folder.
-func (f *Fs) PublicLink(fileName string) (link string, err error) {
+func (f *Fs) PublicLink(remote string) (link string, err error) {
 	id := ""
-	if fileName == "" || strings.HasSuffix(fileName, "/") {
-		dir := strings.TrimRight(fileName, "/")
+	if remote == "" || strings.HasSuffix(remote, "/") {
+		dir := strings.TrimRight(remote, "/")
 		fs.Debugf(f, "attempting to share directory '%s'", dir)
 		id, err = f.dirCache.FindDir(dir, false)
 		if err != nil {
 			return
 		}
 	} else {
-		fs.Debugf(f, "attempting to share single file '%s'", fileName)
+		fs.Debugf(f, "attempting to share single file '%s'", remote)
 		o := &Object{
 			fs:     f,
-			remote: fileName,
+			remote: remote,
 		}
 		if err = o.readMetaData(); err != nil {
 			return

--- a/backend/drive/drive_test.go
+++ b/backend/drive/drive_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -645,9 +645,9 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 }
 
 // PublicLink adds a "readable by anyone with link" permission on the given file or folder.
-func (f *Fs) PublicLink(fileName string) (link string, err error) {
-	absPath := "/" + path.Join(f.Root(), fileName)
-	fs.Debugf(f, "attempting to share '%s' (absolute path: %s)", fileName, absPath)
+func (f *Fs) PublicLink(remote string) (link string, err error) {
+	absPath := "/" + path.Join(f.Root(), remote)
+	fs.Debugf(f, "attempting to share '%s' (absolute path: %s)", remote, absPath)
 	createArg := sharing.CreateSharedLinkWithSettingsArg{
 		Path: absPath,
 	}
@@ -672,7 +672,7 @@ func (f *Fs) PublicLink(fileName string) (link string, err error) {
 			return
 		}
 		if len(listRes.Links) == 0 {
-			err = errors.New("Dropbox says the sharing link already exists, but list came back empty.")
+			err = errors.New("Dropbox says the sharing link already exists, but list came back empty")
 			return
 		}
 		linkRes = listRes.Links[0]

--- a/backend/dropbox/dropbox_test.go
+++ b/backend/dropbox/dropbox_test.go
@@ -71,6 +71,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/ftp/ftp_test.go
+++ b/backend/ftp/ftp_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/googlecloudstorage/googlecloudstorage_test.go
+++ b/backend/googlecloudstorage/googlecloudstorage_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/hubic/hubic_test.go
+++ b/backend/hubic/hubic_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/local/local_test.go
+++ b/backend/local/local_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/onedrive/onedrive_test.go
+++ b/backend/onedrive/onedrive_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/pcloud/pcloud_test.go
+++ b/backend/pcloud/pcloud_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/qingstor/qingstor_test.go
+++ b/backend/qingstor/qingstor_test.go
@@ -71,6 +71,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/sftp/sftp_test.go
+++ b/backend/sftp/sftp_test.go
@@ -71,6 +71,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/webdav/webdav_test.go
+++ b/backend/webdav/webdav_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/backend/yandex/yandex_test.go
+++ b/backend/yandex/yandex_test.go
@@ -68,6 +68,7 @@ func TestObjectUpdate(t *testing.T)        { fstests.TestObjectUpdate(t) }
 func TestObjectStorable(t *testing.T)      { fstests.TestObjectStorable(t) }
 func TestFsIsFile(t *testing.T)            { fstests.TestFsIsFile(t) }
 func TestFsIsFileNotFound(t *testing.T)    { fstests.TestFsIsFileNotFound(t) }
+func TestPublicLink(t *testing.T)          { fstests.TestPublicLink(t) }
 func TestObjectRemove(t *testing.T)        { fstests.TestObjectRemove(t) }
 func TestFsPutStream(t *testing.T)         { fstests.TestFsPutStream(t) }
 func TestObjectPurge(t *testing.T)         { fstests.TestObjectPurge(t) }

--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/ncw/rclone/cmd/genautocomplete"
 	_ "github.com/ncw/rclone/cmd/gendocs"
 	_ "github.com/ncw/rclone/cmd/info"
+	_ "github.com/ncw/rclone/cmd/link"
 	_ "github.com/ncw/rclone/cmd/listremotes"
 	_ "github.com/ncw/rclone/cmd/ls"
 	_ "github.com/ncw/rclone/cmd/lsd"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -244,6 +244,16 @@ func NewFsSrc(args []string) fs.Fs {
 	return fsrc
 }
 
+// NewFsSrcWithFile creates a new src fs, optionally pointing to a file, from the arguments
+func NewFsSrcWithFile(args []string) (fs.Fs, string) {
+	srcRemote, fileName := fspath.RemoteSplit(args[0])
+	fsrc, err := fs.NewFs(srcRemote)
+	if err != nil {
+		log.Fatalf("Failed to create file system for %q: %v", srcRemote, err)
+	}
+	return fsrc, fileName
+}
+
 // NewFsDst creates a new dst fs from the arguments
 //
 // Dst fs-es can't point to single files

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -141,10 +141,10 @@ func ShowVersion() {
 	fmt.Printf("- go version: %s\n", runtime.Version())
 }
 
-// newFsFile creates a dst Fs from a name but may point to a file.
+// NewFsFile creates a dst Fs from a name but may point to a file.
 //
 // It returns a string with the file name if points to a file
-func newFsFile(remote string) (fs.Fs, string) {
+func NewFsFile(remote string) (fs.Fs, string) {
 	fsInfo, configName, fsPath, err := fs.ParseRemote(remote)
 	if err != nil {
 		fs.CountError(err)
@@ -169,7 +169,7 @@ func newFsFile(remote string) (fs.Fs, string) {
 //
 // This can point to a file
 func newFsSrc(remote string) (fs.Fs, string) {
-	f, fileName := newFsFile(remote)
+	f, fileName := NewFsFile(remote)
 	if fileName != "" {
 		if !filter.Active.InActive() {
 			err := errors.Errorf("Can't limit to single files when using filters: %v", remote)
@@ -242,16 +242,6 @@ func NewFsSrc(args []string) fs.Fs {
 	fsrc, _ := newFsSrc(args[0])
 	fs.CalculateModifyWindow(fsrc)
 	return fsrc
-}
-
-// NewFsSrcWithFile creates a new src fs, optionally pointing to a file, from the arguments
-func NewFsSrcWithFile(args []string) (fs.Fs, string) {
-	srcRemote, fileName := fspath.RemoteSplit(args[0])
-	fsrc, err := fs.NewFs(srcRemote)
-	if err != nil {
-		log.Fatalf("Failed to create file system for %q: %v", srcRemote, err)
-	}
-	return fsrc, fileName
 }
 
 // NewFsDst creates a new dst fs from the arguments

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -1,0 +1,41 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/ncw/rclone/cmd"
+	"github.com/ncw/rclone/fs/operations"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd.Root.AddCommand(commandDefintion)
+}
+
+var commandDefintion = &cobra.Command{
+	Use:   "link remote:path",
+	Short: `Generate public link to file/folder.`,
+	Long: `
+rclone link will create or retrieve a public link to the given file or folder.
+
+    rclone link remote:path/to/file
+    rclone link remote:path/to/folder/
+
+If successful, the last line of the output will contain the link. Exact
+capabilities depend on the remote, but the link will always be created with
+the least constraints – e.g. no expiry, no password protection, accessible
+without account.
+`,
+	Run: func(command *cobra.Command, args []string) {
+		cmd.CheckArgs(1, 1, command, args)
+		fsrc, srcFileName := cmd.NewFsSrcWithFile(args)
+		cmd.Run(false, false, command, func() error {
+			link, err := operations.PublicLink(fsrc, srcFileName)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("public link:\n%s\n", link)
+			return nil
+		})
+	},
+}

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -28,9 +28,9 @@ without account.
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
-		fsrc, srcFileName := cmd.NewFsSrcWithFile(args)
+		fsrc, remote := cmd.NewFsFile(args[0])
 		cmd.Run(false, false, command, func() error {
-			link, err := operations.PublicLink(fsrc, srcFileName)
+			link, err := operations.PublicLink(fsrc, remote)
 			if err != nil {
 				return err
 			}

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -34,7 +34,7 @@ without account.
 			if err != nil {
 				return err
 			}
-			fmt.Printf("public link:\n%s\n", link)
+			fmt.Println(link)
 			return nil
 		})
 	},

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -119,27 +119,27 @@ All the remotes support a basic set of features, but there are some
 optional features supported by some remotes used to make some
 operations more efficient.
 
-| Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR | StreamUpload |
-| ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|:------------:|
-| Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | No  |
-| Amazon S3                    | No    | Yes  | No   | No      | No      | Yes   | Yes          |
-| Backblaze B2                 | No    | No   | No   | No      | Yes     | Yes   | Yes          |
-| Box                          | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes |
-| Dropbox                      | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes |
-| FTP                          | No    | No   | Yes  | Yes     | No      | No    | Yes          |
-| Google Cloud Storage         | Yes   | Yes  | No   | No      | No      | Yes   | Yes          |
-| Google Drive                 | Yes   | Yes  | Yes  | Yes     | Yes     | No    | Yes          |
-| HTTP                         | No    | No   | No   | No      | No      | No    | No           |
-| Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   | Yes          |
-| Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   | No           |
-| Microsoft OneDrive           | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No [#575](https://github.com/ncw/rclone/issues/575) | No | No |
-| Openstack Swift              | Yes † | Yes  | No   | No      | No      | Yes   | Yes          |
-| pCloud                       | Yes   | Yes  | Yes  | Yes     | Yes     | No    | No           |
-| QingStor                     | No    | Yes  | No   | No      | No      | Yes   | No           |
-| SFTP                         | No    | No   | Yes  | Yes     | No      | No    | Yes          |
-| WebDAV                       | Yes   | Yes  | Yes  | Yes     | No      | No    | Yes ‡        |
-| Yandex Disk                  | Yes   | No   | No   | No      | Yes     | Yes   | Yes          |
-| The local filesystem         | Yes   | No   | Yes  | Yes     | No      | No    | Yes          |
+| Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR | StreamUpload | LinkSharing |
+| ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|:------------:|:------------:|
+| Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | No  | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Amazon S3                    | No    | Yes  | No   | No      | No      | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Backblaze B2                 | No    | No   | No   | No      | Yes     | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Box                          | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Dropbox                      | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No  | Yes | Yes |
+| FTP                          | No    | No   | Yes  | Yes     | No      | No    | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Google Cloud Storage         | Yes   | Yes  | No   | No      | No      | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Google Drive                 | Yes   | Yes  | Yes  | Yes     | Yes     | No    | Yes          | Yes         |
+| HTTP                         | No    | No   | No   | No      | No      | No    | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Microsoft OneDrive           | Yes   | Yes  | Yes  | No [#197](https://github.com/ncw/rclone/issues/197) | No [#575](https://github.com/ncw/rclone/issues/575) | No | No | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Openstack Swift              | Yes † | Yes  | No   | No      | No      | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| pCloud                       | Yes   | Yes  | Yes  | Yes     | Yes     | No    | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| QingStor                     | No    | Yes  | No   | No      | No      | Yes   | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| SFTP                         | No    | No   | Yes  | Yes     | No      | No    | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| WebDAV                       | Yes   | Yes  | Yes  | Yes     | No      | No    | Yes ‡        | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| Yandex Disk                  | Yes   | No   | No   | No      | Yes     | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) |
+| The local filesystem         | Yes   | No   | Yes  | Yes     | No      | No    | Yes          | No          |
 
 ### Purge ###
 
@@ -196,3 +196,9 @@ See the [rclone docs](/docs/#fast-list) for more details.
 Some remotes allow files to be uploaded without knowing the file size
 in advance. This allows certain operations to work without spooling the
 file to local disk first, e.g. `rclone rcat`.
+
+### LinkSharing ###
+
+Sets the necessary permissions on a file or folder and prints a link
+that allows others to access them, even if they don't have an account
+on the particular cloud provider.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -329,7 +329,7 @@ type Features struct {
 	DirCacheFlush func()
 
 	// PublicLink generates a public link to the remote path (usually readable by anyone)
-	PublicLink func(fileName string) (string, error)
+	PublicLink func(remote string) (string, error)
 
 	// Put in to the remote path with the modTime given of the given size
 	//
@@ -651,7 +651,7 @@ type PutStreamer interface {
 // PublicLinker is an optional interface for Fs
 type PublicLinker interface {
 	// PublicLink generates a public link to the remote path (usually readable by anyone)
-	PublicLink(fileName string) (string, error)
+	PublicLink(remote string) (string, error)
 }
 
 // MergeDirser is an option interface for Fs

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -328,6 +328,9 @@ type Features struct {
 	// as an optional interface
 	DirCacheFlush func()
 
+	// PublicLink generates a public link to the remote path (usually readable by anyone)
+	PublicLink func(fileName string) (string, error)
+
 	// Put in to the remote path with the modTime given of the given size
 	//
 	// May create the object even if it returns an error - if so
@@ -442,6 +445,9 @@ func (ft *Features) Fill(f Fs) *Features {
 	}
 	if do, ok := f.(DirCacheFlusher); ok {
 		ft.DirCacheFlush = do.DirCacheFlush
+	}
+	if do, ok := f.(PublicLinker); ok {
+		ft.PublicLink = do.PublicLink
 	}
 	if do, ok := f.(PutUncheckeder); ok {
 		ft.PutUnchecked = do.PutUnchecked
@@ -640,6 +646,12 @@ type PutStreamer interface {
 	// will return the object and the error, otherwise will return
 	// nil and the error
 	PutStream(in io.Reader, src ObjectInfo, options ...OpenOption) (Object, error)
+}
+
+// PublicLinker is an optional interface for Fs
+type PublicLinker interface {
+	// PublicLink generates a public link to the remote path (usually readable by anyone)
+	PublicLink(fileName string) (string, error)
 }
 
 // MergeDirser is an option interface for Fs

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1471,12 +1471,12 @@ func Rcat(fdst fs.Fs, dstFileName string, in io.ReadCloser, modTime time.Time) (
 }
 
 // PublicLink adds a "readable by anyone with link" permission on the given file or folder.
-func PublicLink(f fs.Fs, fileName string) (string, error) {
+func PublicLink(f fs.Fs, remote string) (string, error) {
 	doPublicLink := f.Features().PublicLink
 	if doPublicLink == nil {
 		return "", errors.Errorf("%v doesn't support public links", f)
 	}
-	return doPublicLink(fileName)
+	return doPublicLink(remote)
 }
 
 // Rmdirs removes any empty directories (or directories only

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1470,6 +1470,15 @@ func Rcat(fdst fs.Fs, dstFileName string, in io.ReadCloser, modTime time.Time) (
 	return dst, nil
 }
 
+// PublicLink adds a "readable by anyone with link" permission on the given file or folder.
+func PublicLink(f fs.Fs, fileName string) (string, error) {
+	doPublicLink := f.Features().PublicLink
+	if doPublicLink == nil {
+		return "", errors.Errorf("%v doesn't support public links", f)
+	}
+	return doPublicLink(fileName)
+}
+
 // Rmdirs removes any empty directories (or directories only
 // containing empty directories) under f, including f.
 func Rmdirs(f fs.Fs, dir string, leaveRoot bool) error {

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -929,6 +929,62 @@ func TestFsIsFileNotFound(t *testing.T) {
 	fstest.CheckListing(t, fileRemote, []fstest.Item{})
 }
 
+// TestPublicLink tests creation of sharable, public links
+func TestPublicLink(t *testing.T) {
+	skipIfNotOk(t)
+
+	doPublicLink := remote.Features().PublicLink
+	if doPublicLink == nil {
+		t.Skip("FS has no PublicLinker interface")
+	}
+
+	// if object not found
+	link, err := doPublicLink(file1.Path + "_does_not_exist")
+	require.Error(t, err, "Expected to get error when file doesn't exist")
+	require.Equal(t, "", link, "Expected link to be empty on error")
+
+	// sharing file for the first time
+	link1, err := doPublicLink(file1.Path)
+	require.NoError(t, err)
+	require.NotEqual(t, "", link1, "Link should not be empty")
+
+	link2, err := doPublicLink(file2.Path)
+	require.NoError(t, err)
+	require.NotEqual(t, "", link2, "Link should not be empty")
+
+	require.NotEqual(t, link1, link2, "Links to different files should differ")
+
+	// sharing file for the 2nd time
+	link1, err = doPublicLink(file1.Path)
+	require.NoError(t, err)
+	require.NotEqual(t, "", link1, "Link should not be empty")
+
+	// sharing directory for the first time
+	path := path.Dir(file2.Path) + "/"
+	link3, err := doPublicLink(path)
+	require.NoError(t, err)
+	require.NotEqual(t, "", link3, "Link should not be empty")
+
+	// sharing directory for the second time
+	link3, err = doPublicLink(path)
+	require.NoError(t, err)
+	require.NotEqual(t, "", link3, "Link should not be empty")
+
+	// sharing the "root" directory in a subremote
+	subRemote, _, removeSubRemote, err := fstest.RandomRemote(RemoteName, false)
+	require.NoError(t, err)
+	defer removeSubRemote()
+	// ensure sub remote isn't empty
+	buf := bytes.NewBufferString("somecontent")
+	obji := object.NewStaticObjectInfo("somefile", time.Now(), int64(buf.Len()), true, nil, nil)
+	_, err = subRemote.Put(buf, obji)
+	require.NoError(t, err)
+
+	link4, err := subRemote.Features().PublicLink("")
+	require.NoError(t, err, "Sharing root in a sub-remote should work")
+	require.NotEqual(t, "", link4, "Link should not be empty")
+}
+
 // TestObjectRemove tests Remove
 func TestObjectRemove(t *testing.T) {
 	skipIfNotOk(t)

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -960,7 +960,7 @@ func TestPublicLink(t *testing.T) {
 	require.NotEqual(t, "", link1, "Link should not be empty")
 
 	// sharing directory for the first time
-	path := path.Dir(file2.Path) + "/"
+	path := path.Dir(file2.Path)
 	link3, err := doPublicLink(path)
 	require.NoError(t, err)
 	require.NotEqual(t, "", link3, "Link should not be empty")


### PR DESCRIPTION
For now only Google Drive and Dropbox are included.

The goal of this command is to quickly get a sharable link to hand to friends. Drive supports full ACLs, Dropbox offers password protection and automatic expiry (paid accounts). Not sure if it makes sense to implement these provider specific features. The most likeliest feature to add would probably to "unshare", which could be equally universal.

It's an optional interface for `Fs`, although it would probably fit nicely on `Object` as well. As it is now, it supports sharing directories. Getting dir sharing to work via `Object` would likely benefit from having a standardized `Directory` type first. I haven't surveyed the other storage providers yet, so maybe demanding directory sharing through the integration tests will have to change.

Note that the Google Drive intergration test fails for me at `TestObjectRemove`, even on master.

There is one edge case in the Drive implementation that I left unsolved: on a team drive, if I lack permissions (i.e. `canShare: false`) this implementation will bail. Instead, it could check what permissions the file/dir already has, and return the link if they are already sufficient. I'd revisit this if someone actually runs into this issue.

As always, I am happy to address any feedback.