### PR TITLE
Fix `make tarball`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ upload_website:	website
 	rclone -v sync docs/public memstore:www-rclone-org
 
 tarball:
-	git archive -9 --format=tar.gz --prefix=rclone-$(TAG) -o build/rclone-$(TAG).tar.gz $(TAG)
+	git archive -9 --format=tar.gz --prefix=rclone-$(TAG)/ -o build/rclone-$(TAG).tar.gz $(TAG)
 
 sign_upload:
 	cd build && md5sum rclone-* | gpg --clearsign > MD5SUMS


### PR DESCRIPTION
The 1.40 tarball looks wrong:

```
$ wget https://github.com/ncw/rclone/releases/download/v1.40/rclone-v1.40.tar.gz
(...downloading...)
$ tar tf rclone-v1.40.tar.gz | head
rclone-v1.40.appveyor.yml
rclone-v1.40.circleci/
rclone-v1.40.circleci/config.yml
rclone-v1.40.gitignore
rclone-v1.40.pkgr.yml
rclone-v1.40.travis.yml
rclone-v1.40CONTRIBUTING.md
rclone-v1.40COPYING
rclone-v1.40Gopkg.lock
rclone-v1.40Gopkg.toml
```