### PR TITLE
size: Add --json flag

### DIFF
--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -1,7 +1,9 @@
 package size
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs"
@@ -9,23 +11,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var jsonOutput bool
+
 func init() {
-	cmd.Root.AddCommand(commandDefintion)
+	cmd.Root.AddCommand(commandDefinition)
+	commandDefinition.Flags().BoolVar(&jsonOutput, "json", false, "format output as JSON")
 }
 
-var commandDefintion = &cobra.Command{
+var commandDefinition = &cobra.Command{
 	Use:   "size remote:path",
 	Short: `Prints the total size and number of objects in remote:path.`,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			objects, size, err := operations.Count(fsrc)
+			var err error
+			var results struct {
+				Count int64 `json:"count"`
+				Bytes int64 `json:"bytes"`
+			}
+
+			results.Count, results.Bytes, err = operations.Count(fsrc)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Total objects: %d\n", objects)
-			fmt.Printf("Total size: %s (%d Bytes)\n", fs.SizeSuffix(size).Unit("Bytes"), size)
+
+			if jsonOutput {
+				return json.NewEncoder(os.Stdout).Encode(results)
+			}
+
+			fmt.Printf("Total objects: %d\n", results.Count)
+			fmt.Printf("Total size: %s (%d Bytes)\n", fs.SizeSuffix(results.Bytes).Unit("Bytes"), results.Bytes)
+
 			return nil
 		})
 	},


### PR DESCRIPTION
This makes the output of `rclone size` machine-readable with the `--json` flag:


```
$ ./rclone size --json .
{"count":10583,"bytes":418665191}
```

Closes #2234.