### PR TITLE
access sharepoint over webdav using cookie authentication

### DIFF
--- a/backend/webdav/odrvcookie/fetch.go
+++ b/backend/webdav/odrvcookie/fetch.go
@@ -1,0 +1,176 @@
+// Package odrvcookie can fetch authentication cookies for a sharepoint webdav endpoint
+package odrvcookie
+
+import (
+	"bytes"
+	"encoding/xml"
+	"html/template"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// CookieAuth hold the authentication information
+// These are username and password as well as the authentication endpoint
+type CookieAuth struct {
+	user     string
+	pass     string
+	endpoint string
+}
+
+// CookieResponse contains the requested cookies
+type CookieResponse struct {
+	RtFa    http.Cookie
+	FedAuth http.Cookie
+}
+
+// SuccessResponse hold a response from the sharepoint webdav
+type SuccessResponse struct {
+	XMLName xml.Name            `xml:"Envelope"`
+	Succ    SuccessResponseBody `xml:"Body"`
+}
+
+// SuccessResponseBody is the body of a success response, it holds the token
+type SuccessResponseBody struct {
+	XMLName xml.Name
+	Type    string    `xml:"RequestSecurityTokenResponse>TokenType"`
+	Created time.Time `xml:"RequestSecurityTokenResponse>Lifetime>Created"`
+	Expires time.Time `xml:"RequestSecurityTokenResponse>Lifetime>Expires"`
+	Token   string    `xml:"RequestSecurityTokenResponse>RequestedSecurityToken>BinarySecurityToken"`
+}
+
+// reqString is a template that gets populated with the user data in order to retrieve a "BinarySecurityToken"
+const reqString = `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+xmlns:a="http://www.w3.org/2005/08/addressing"
+xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+<s:Header>
+<a:Action s:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</a:Action>
+<a:ReplyTo>
+<a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+</a:ReplyTo>
+<a:To s:mustUnderstand="1">https://login.microsoftonline.com/extSTS.srf</a:To>
+<o:Security s:mustUnderstand="1"
+ xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+<o:UsernameToken>
+  <o:Username>{{ .Username }}</o:Username>
+  <o:Password>{{ .Password }}</o:Password>
+</o:UsernameToken>
+</o:Security>
+</s:Header>
+<s:Body>
+<t:RequestSecurityToken xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust">
+<wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+  <a:EndpointReference>
+    <a:Address>{{ .Address }}</a:Address>
+  </a:EndpointReference>
+</wsp:AppliesTo>
+<t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
+<t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
+<t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>
+</t:RequestSecurityToken>
+</s:Body>
+</s:Envelope>`
+
+// New creates a new CookieAuth struct
+func New(pUser, pPass, pEndpoint string) CookieAuth {
+	retStruct := CookieAuth{
+		user:     pUser,
+		pass:     pPass,
+		endpoint: pEndpoint,
+	}
+
+	return retStruct
+}
+
+// Cookies creates a CookieResponse. It fetches the auth token and then
+// retrieves the Cookies
+func (ca *CookieAuth) Cookies() (CookieResponse, error) {
+	return ca.getSPCookie(ca.getSPToken())
+}
+
+func (ca *CookieAuth) getSPCookie(conf *SuccessResponse) (CookieResponse, error) {
+	spRoot, err := url.Parse(ca.endpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	u, err := url.Parse("https://" + spRoot.Host + "/_forms/default.aspx?wa=wsignin1.0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// To authenticate with davfs or anything else we need two cookies (rtFa and FedAuth)
+	// In order to get them we use the token we got earlier and a cookieJar
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client := &http.Client{
+		Jar: jar,
+	}
+
+	// Send the previously aquired Token as a Post parameter
+	if _, err = client.Post(u.String(), "text/xml", strings.NewReader(conf.Succ.Token)); err != nil {
+		log.Fatal(err)
+	}
+
+	cookieResponse := CookieResponse{}
+	for _, cookie := range jar.Cookies(u) {
+		if (cookie.Name == "rtFa") || (cookie.Name == "FedAuth") {
+			switch cookie.Name {
+			case "rtFa":
+				cookieResponse.RtFa = *cookie
+			case "FedAuth":
+				cookieResponse.FedAuth = *cookie
+			}
+		}
+	}
+	return cookieResponse, err
+}
+
+func (ca *CookieAuth) getSPToken() *SuccessResponse {
+	reqData := map[string]interface{}{
+		"Username": ca.user,
+		"Password": ca.pass,
+		"Address":  ca.endpoint,
+	}
+
+	t := template.Must(template.New("authXML").Parse(reqString))
+
+	buf := &bytes.Buffer{}
+	if err := t.Execute(buf, reqData); err != nil {
+		panic(err)
+	}
+
+	// Execute the first request which gives us an auth token for the sharepoint service
+	// With this token we can authenticate on the login page and save the returned cookies
+	req, err := http.NewRequest("POST", "https://login.microsoftonline.com/extSTS.srf", buf)
+	if err != nil {
+		panic(err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err.Error())
+	}
+	defer resp.Body.Close()
+
+	respBuf := bytes.Buffer{}
+	respBuf.ReadFrom(resp.Body)
+	s := respBuf.Bytes()
+
+	var conf SuccessResponse
+	err = xml.Unmarshal(s, &conf)
+	if err != nil {
+		panic(err)
+	}
+
+	return &conf
+}

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -28,9 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hensur/onedrive-cookie-test/odrvcookie"
-
 	"github.com/ncw/rclone/backend/webdav/api"
+	"github.com/ncw/rclone/backend/webdav/odrvcookie"
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fs/config"
 	"github.com/ncw/rclone/fs/config/obscure"

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hensur/onedrive-cookie-test/odrvcookie"
+
 	"github.com/ncw/rclone/backend/webdav/api"
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fs/config"
@@ -327,6 +329,16 @@ func (f *Fs) setQuirks(vendor string) {
 	case "nextcloud":
 		f.precision = time.Second
 		f.useOCMtime = true
+	case "sharepoint":
+		// To mount sharepoint, two Cookies are required
+		// They have to be set instead of BasicAuth
+		f.srv.RemoveHeader("Authorization") // We don't need this Header if using cookies
+		spCk := odrvcookie.New(f.user, f.pass, f.endpointURL)
+		spCookies, err := spCk.Cookies()
+		if err != nil {
+			fmt.Println("Error occured fetching cookies")
+		}
+		f.srv.SetCookie(&spCookies.FedAuth, &spCookies.RtFa)
 	case "other":
 	default:
 		fs.Debugf(f, "Unknown vendor %q", vendor)

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -237,6 +237,11 @@ func addSlash(s string) string {
 	return s
 }
 
+// removeLeadingSlash makes sure no path begins with a slash
+func removeLeadingSlash(s string) string {
+	return strings.TrimLeft(s, "/")
+}
+
 // filePath returns a file path (f.root, file)
 func (f *Fs) filePath(file string) string {
 	return rest.URLPathEscape(path.Join(f.root, file))
@@ -244,7 +249,7 @@ func (f *Fs) filePath(file string) string {
 
 // dirPath returns a directory path (f.root, dir)
 func (f *Fs) dirPath(dir string) string {
-	return addSlash(f.filePath(dir))
+	return addSlash(removeLeadingSlash(f.filePath(dir)))
 }
 
 // filePath returns a file path (f.root, remote)
@@ -391,7 +396,7 @@ type listAllFn func(string, bool, *api.Prop) bool
 func (f *Fs) listAll(dir string, directoriesOnly bool, filesOnly bool, fn listAllFn) (found bool, err error) {
 	opts := rest.Opts{
 		Method: "PROPFIND",
-		Path:   f.dirPath(dir), // FIXME Should not start with /
+		Path:   f.dirPath(dir),
 		ExtraHeaders: map[string]string{
 			"Depth": "1",
 		},

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -73,6 +73,9 @@ func init() {
 				Value: "owncloud",
 				Help:  "Owncloud",
 			}, {
+				Value: "sharepoint",
+				Help:  "Sharepoint",
+			}, {
 				Value: "other",
 				Help:  "Other site/service or software",
 			}},

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -341,10 +341,7 @@ func (f *Fs) setQuirks(vendor string) {
 		// They have to be set instead of BasicAuth
 		f.srv.RemoveHeader("Authorization") // We don't need this Header if using cookies
 		spCk := odrvcookie.New(f.user, f.pass, f.endpointURL)
-		spCookies, err := spCk.Cookies()
-		if err != nil {
-			fmt.Println("Error occured fetching cookies")
-		}
+		spCookies := spCk.Cookies()
 		f.srv.SetCookie(&spCookies.FedAuth, &spCookies.RtFa)
 	case "other":
 	default:

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -298,7 +298,11 @@ func NewFs(name, root string) (fs.Fs, error) {
 		CanHaveEmptyDirectories: true,
 	}).Fill(f)
 	f.srv.SetErrorHandler(errorHandler)
-	f.setQuirks(vendor)
+	err = f.setQuirks(vendor)
+	if err != nil {
+		return nil, err
+	}
+
 
 	if root != "" {
 		// Check to see if the root actually an existing file
@@ -323,7 +327,7 @@ func NewFs(name, root string) (fs.Fs, error) {
 }
 
 // setQuirks adjusts the Fs for the vendor passed in
-func (f *Fs) setQuirks(vendor string) {
+func (f *Fs) setQuirks(vendor string) error {
 	if vendor == "" {
 		vendor = "other"
 	}
@@ -341,7 +345,10 @@ func (f *Fs) setQuirks(vendor string) {
 		// They have to be set instead of BasicAuth
 		f.srv.RemoveHeader("Authorization") // We don't need this Header if using cookies
 		spCk := odrvcookie.New(f.user, f.pass, f.endpointURL)
-		spCookies := spCk.Cookies()
+		spCookies, err := spCk.Cookies()
+		if err != nil {
+			return err
+		}
 		f.srv.SetCookie(&spCookies.FedAuth, &spCookies.RtFa)
 	case "other":
 	default:
@@ -352,6 +359,7 @@ func (f *Fs) setQuirks(vendor string) {
 	if !f.canStream {
 		f.features.PutStream = nil
 	}
+	return nil
 }
 
 // Return an Object from a path

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -303,7 +303,6 @@ func NewFs(name, root string) (fs.Fs, error) {
 		return nil, err
 	}
 
-
 	if root != "" {
 		// Check to see if the root actually an existing file
 		remote := path.Base(root)

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -82,7 +82,9 @@ Choose a number from below, or type in your own value
    \ "nextcloud"
  2 / Owncloud
    \ "owncloud"
- 3 / Other site/service or software
+ 3 / Sharepoint
+   \ "sharepoint"
+ 4 / Other site/service or software
    \ "other"
 vendor> 1
 User name
@@ -171,3 +173,44 @@ If you are using `put.io` with `rclone mount` then use the
 mount.
 
 For more help see [the put.io webdav docs](http://help.put.io/apps-and-integrations/ftp-and-webdav).
+
+## Sharepoint ##
+
+Can be used with Sharepoint provided by OneDrive for Business
+or Office365 Education Accounts.
+This feature is only needed for a few of these Accounts,
+mostly Office365 Education ones. These accounts are sometimes not
+verified by the domain owner [github#1975](https://github.com/ncw/rclone/issues/1975)
+
+This means that these accounts can't be added using the official
+API (other Accounts should work with the "onedrive" option). However,
+it is possible to access them using webdav.
+
+To use a sharepoint remote with rclone, add it like this:
+First, you need to get your remote's URL:
+
+- Go [here](https://onedrive.live.com/about/en-us/signin/)
+  to open your OneDrive or to sign in
+- Now take a look a your address bar, the URL should look like this:
+  `https://[YOUR-DOMAIN]-my.sharepoint.com/personal/[YOUR-EMAIL]/_layouts/15/onedrive.aspx`
+
+You'll only need this URL upto the email address. After that, you'll
+most likely want to add "/Documents". That subdirectory contains
+the actual data stored on your OneDrive.
+
+Add the remote to rclone like this:
+Configure the `url` as `https://[YOUR-DOMAIN]-my.sharepoint.com/personal/[YOUR-EMAIL]/Documents`
+and use your normal account email and password for `user` and `pass`.
+If you have 2FA enabled, you have to generate an app password.
+Set the `vendor` to `sharepoint`.
+
+Your config file should look like this:
+
+```
+[sharepoint]
+type = webdav
+url = https://[YOUR-DOMAIN]-my.sharepoint.com/personal/[YOUR-EMAIL]/Documents
+vendor = other
+user = YourEmailAddress
+pass = encryptedpassword
+```

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -191,7 +191,7 @@ First, you need to get your remote's URL:
 
 - Go [here](https://onedrive.live.com/about/en-us/signin/)
   to open your OneDrive or to sign in
-- Now take a look a your address bar, the URL should look like this:
+- Now take a look at your address bar, the URL should look like this:
   `https://[YOUR-DOMAIN]-my.sharepoint.com/personal/[YOUR-EMAIL]/_layouts/15/onedrive.aspx`
 
 You'll only need this URL upto the email address. After that, you'll

--- a/lib/rest/rest.go
+++ b/lib/rest/rest.go
@@ -80,6 +80,14 @@ func (api *Client) SetHeader(key, value string) *Client {
 	return api
 }
 
+// RemoveHeader unsets a header for all requests
+func (api *Client) RemoveHeader(key string) *Client {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	delete(api.headers, key)
+	return api
+}
+
 // SignerFn is used to sign an outgoing request
 type SignerFn func(*http.Request) error
 
@@ -97,6 +105,19 @@ func (api *Client) SetUserPass(UserName, Password string) *Client {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	req.SetBasicAuth(UserName, Password)
 	api.SetHeader("Authorization", req.Header.Get("Authorization"))
+	return api
+}
+
+// SetCookie creates an Cookies Header for all requests with the supplied
+// cookies passed in.
+// All cookies have to be supplied at once, all cookies will be overwritten
+// on a new call to the method
+func (api *Client) SetCookie(cks ...*http.Cookie) *Client {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	for _, ck := range cks {
+		req.AddCookie(ck)
+	}
+	api.SetHeader("Cookie", req.Header.Get("Cookie"))
 	return api
 }
 


### PR DESCRIPTION
Hi,
here it is, my first pull request :) This should fix #1975 

I added the missing documentation. I also added a method to strip the slash from the beginning of a path since it caused some errors. I tested this change against my nextcloud as well and it didn't break anything.
go test -v returns some errors if the TestWebdav remote is a sharepoint account. These errors don't appear if I test with nextcloud as TestWebdav.

I guess it creates some folders with characters not supported by onedrive. Log can be found here:
https://gist.github.com/hensur/d69144467ddf3dab20f410eeec82d9f9