### PR TITLE
Add service_account_credentials for Google Cloud and Drive

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -468,7 +468,7 @@ func createOAuthClient(name string) (*http.Client, error) {
 		serviceAccountPath := config.FileGet(name, "service_account_file")
 		loadedCreds, err := ioutil.ReadFile(os.ExpandEnv(serviceAccountPath))
 		if err != nil {
-			log.Fatalf("Error opening service account credentials file: %v", err)
+			return nil, errors.Wrap(err, "error opening service account credentials file")
 		}
 		serviceAccountCreds = loadedCreds
 	}

--- a/backend/googlecloudstorage/googlecloudstorage.go
+++ b/backend/googlecloudstorage/googlecloudstorage.go
@@ -297,19 +297,19 @@ func NewFs(name, root string) (fs.Fs, error) {
 		serviceAccountPath := config.FileGet(name, "service_account_file")
 		loadedCreds, err := ioutil.ReadFile(os.ExpandEnv(serviceAccountPath))
 		if err != nil {
-			log.Fatalf("Error opening service account credentials file: %v", err)
+			return nil, errors.Wrap(err, "error opening service account credentials file")
 		}
 		serviceAccountCreds = loadedCreds
 	}
 	if len(serviceAccountCreds) > 0 {
 		oAuthClient, err = getServiceAccountClient(serviceAccountCreds)
 		if err != nil {
-			log.Fatalf("Failed configuring Google Cloud Storage Service Account: %v", err)
+			return nil, errors.Wrap(err, "failed configuring Google Cloud Storage Service Account")
 		}
 	} else {
 		oAuthClient, _, err = oauthutil.NewClient(name, storageConfig)
 		if err != nil {
-			log.Fatalf("Failed to configure Google Cloud Storage: %v", err)
+			return nil, errors.Wrap(err, "failed to configure Google Cloud Storage")
 		}
 	}
 

--- a/backend/googlecloudstorage/googlecloudstorage.go
+++ b/backend/googlecloudstorage/googlecloudstorage.go
@@ -277,12 +277,8 @@ func parsePath(path string) (bucket, directory string, err error) {
 	return
 }
 
-func getServiceAccountClient(keyJsonfilePath string) (*http.Client, error) {
-	data, err := ioutil.ReadFile(os.ExpandEnv(keyJsonfilePath))
-	if err != nil {
-		return nil, errors.Wrap(err, "error opening credentials file")
-	}
-	conf, err := google.JWTConfigFromJSON(data, storageConfig.Scopes...)
+func getServiceAccountClient(credentialsData []byte) (*http.Client, error) {
+	conf, err := google.JWTConfigFromJSON(credentialsData, storageConfig.Scopes...)
 	if err != nil {
 		return nil, errors.Wrap(err, "error processing credentials")
 	}
@@ -295,9 +291,18 @@ func NewFs(name, root string) (fs.Fs, error) {
 	var oAuthClient *http.Client
 	var err error
 
-	serviceAccountPath := config.FileGet(name, "service_account_file")
-	if serviceAccountPath != "" {
-		oAuthClient, err = getServiceAccountClient(serviceAccountPath)
+	// try loading service account credentials from env variable, then from a file
+	serviceAccountCreds := []byte(config.FileGet(name, "service_account_credentials"))
+	if len(serviceAccountCreds) == 0 {
+		serviceAccountPath := config.FileGet(name, "service_account_file")
+		loadedCreds, err := ioutil.ReadFile(os.ExpandEnv(serviceAccountPath))
+		if err != nil {
+			log.Fatalf("Error opening service account credentials file: %v", err)
+		}
+		serviceAccountCreds = loadedCreds
+	}
+	if len(serviceAccountCreds) > 0 {
+		oAuthClient, err = getServiceAccountClient(serviceAccountCreds)
 		if err != nil {
 			log.Fatalf("Failed configuring Google Cloud Storage Service Account: %v", err)
 		}

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -202,7 +202,9 @@ actively logged-in users, for example build machines.
 To use a Service Account instead of OAuth2 token flow, enter the path
 to your Service Account credentials at the `service_account_file`
 prompt during `rclone config` and rclone won't use the browser based
-authentication flow.
+authentication flow. If you'd rather stuff the contents of the file
+into an environment variable, you can set `service_account_credentials`
+with the actual contents of the file instead.
 
 #### Use case - Google Apps/G-suite account and individual Drive ####
 

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -202,9 +202,10 @@ actively logged-in users, for example build machines.
 To use a Service Account instead of OAuth2 token flow, enter the path
 to your Service Account credentials at the `service_account_file`
 prompt during `rclone config` and rclone won't use the browser based
-authentication flow. If you'd rather stuff the contents of the file
-into an environment variable, you can set `service_account_credentials`
-with the actual contents of the file instead.
+authentication flow. If you'd rather stuff the contents of the
+credentials file into the rclone config file, you can set
+`service_account_credentials` with the actual contents of the file
+instead, or set the equivalent environment variable.
 
 #### Use case - Google Apps/G-suite account and individual Drive ####
 

--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -212,7 +212,9 @@ are what rclone will use for authentication.
 To use a Service Account instead of OAuth2 token flow, enter the path
 to your Service Account credentials at the `service_account_file`
 prompt and rclone won't use the browser based authentication
-flow.
+flow. If you'd rather stuff the contents of the file into an
+environment variable, you can set `service_account_credentials` with
+the actual contents of the file instead.
 
 ### --fast-list ###
 

--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -212,9 +212,10 @@ are what rclone will use for authentication.
 To use a Service Account instead of OAuth2 token flow, enter the path
 to your Service Account credentials at the `service_account_file`
 prompt and rclone won't use the browser based authentication
-flow. If you'd rather stuff the contents of the file into an
-environment variable, you can set `service_account_credentials` with
-the actual contents of the file instead.
+flow. If you'd rather stuff the contents of the credentials file into
+the rclone config file, you can set `service_account_credentials` with
+the actual contents of the file instead, or set the equivalent
+environment variable.
 
 ### --fast-list ###
 


### PR DESCRIPTION
Adds the ability to configure a service account without needing a file on disk: `service_account_credentials` (the contents of the service account credentials file) can be put directly into an environment variable. This works for Google Cloud Storage and Google Drive!

As discussed here: https://forum.rclone.org/t/accessing-google-cloud-storage-without-service-account-file/5461/5?u=matt

Includes a mention in the docs.

Thanks again for the pointers. Let me know if there's anything else!