### PR TITLE
sftp: Add --ssh-path-override flag #1474

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -41,6 +41,7 @@ var (
 
 	// Flags
 	sftpAskPassword = flags.BoolP("sftp-ask-password", "", false, "Allow asking for SFTP password when needed.")
+	sshPathOverride = flags.StringP("ssh-path-override", "", "", "Override path used by SSH connection.")
 )
 
 func init() {
@@ -763,6 +764,9 @@ func (o *Object) Hash(r hash.Type) (string, error) {
 	session.Stdout = &stdout
 	session.Stderr = &stderr
 	escapedPath := shellEscape(o.path())
+	if *sshPathOverride != "" {
+		escapedPath = shellEscape(path.Join(*sshPathOverride, o.remote))
+	}
 	err = session.Run(hashCmd + " " + escapedPath)
 	if err != nil {
 		_ = session.Close()

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -155,6 +155,11 @@ Here are the command line options specific to this remote.
 
 Ask for the SFTP password if needed when no password has been configured.
 
+#### --ssh-path-override ####
+
+Override path used by SSH connection. Allows checksum calculation when
+SFTP and SSH paths are different.
+
 ### Modified time ###
 
 Modified times are stored on the server to 1 second precision.

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -158,7 +158,16 @@ Ask for the SFTP password if needed when no password has been configured.
 #### --ssh-path-override ####
 
 Override path used by SSH connection. Allows checksum calculation when
-SFTP and SSH paths are different.
+SFTP and SSH paths are different. This issue affects among others Synology
+NAS boxes.
+
+Shared folders can be found in directories representing volumes
+
+    rclone sync /home/local/directory remote:/directory --ssh-path-override /volume2/directory
+
+Home directory can be found in a shared folder called `homes`
+
+    rclone sync /home/local/directory remote:/home/directory --ssh-path-override /volume1/homes/USER/directory
 
 ### Modified time ###
 


### PR DESCRIPTION
The flag allows calculation of checksums on systems using different paths for SSH and SFTP, like synology NAS boxes.

Tested on synology NAS – checksums are finally calculated. Added a mention in the documentation.