### PR TITLE
Fix ChangeNotify for folders

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1323,7 +1323,12 @@ func (f *Fs) changeNotifyRunner(notifyFunc func(string, fs.EntryType), pollInter
 				continue
 			}
 
-			if change.File != nil && change.File.MimeType != driveFolderType {
+			if change.File != nil {
+				changeType := fs.EntryDirectory
+				if change.File.MimeType != driveFolderType {
+					changeType = fs.EntryObject
+				}
+
 				// translate the parent dir of this object
 				if len(change.File.Parents) > 0 {
 					if path, ok := f.dirCache.GetInv(change.File.Parents[0]); ok {
@@ -1334,10 +1339,10 @@ func (f *Fs) changeNotifyRunner(notifyFunc func(string, fs.EntryType), pollInter
 							path = change.File.Name
 						}
 						// this will now clear the actual file too
-						pathsToClear = append(pathsToClear, entryType{path: path, entryType: fs.EntryObject})
+						pathsToClear = append(pathsToClear, entryType{path: path, entryType: changeType})
 					}
 				} else { // a true root object that is changed
-					pathsToClear = append(pathsToClear, entryType{path: change.File.Name, entryType: fs.EntryObject})
+					pathsToClear = append(pathsToClear, entryType{path: change.File.Name, entryType: changeType})
 				}
 			}
 		}


### PR DESCRIPTION
This fixes 2 bugs in the `ChangeNotify` handling of drive and vfs wich were reported in #2251.

The `ChangeNotify` implementation in `drive` excluded all directories not found in the `dirCache`, which meant new directories would never trigger any notification. 

The `vfs` package assumed that only files can invalidate their parent, but directories should also do this if they are renamed or new. It is currently not possible to get the cause of a directory event, so the parent of a directory needs to be invalidated also.
Sadly this meas that when using the `amazonclouddrive` backend there are now unnecessary invalidation's, as the parent will get its own notification, leading to another parent cache invalidation.