### PR TITLE
mount: ensure atexit and unmount get run on interrupt

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -470,6 +470,7 @@ func initConfig() {
 }
 
 func resolveExitCode(err error) {
+	atexit.Run()
 	if err == nil {
 		os.Exit(exitCodeSuccess)
 	}

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -13,6 +13,7 @@ import (
 	fusefs "bazil.org/fuse/fs"
 	"github.com/ncw/rclone/cmd/mountlib"
 	"github.com/ncw/rclone/fs"
+	"github.com/ncw/rclone/lib/atexit"
 	"github.com/ncw/rclone/vfs"
 	"github.com/ncw/rclone/vfs/vfsflags"
 	"github.com/okzk/sdnotify"
@@ -133,6 +134,7 @@ func Mount(f fs.Fs, mountpoint string) error {
 	signal.Notify(sigInt, syscall.SIGINT, syscall.SIGTERM)
 	sigHup := make(chan os.Signal, 1)
 	signal.Notify(sigHup, syscall.SIGHUP)
+	atexit.IgnoreSignals()
 
 	if err := sdnotify.SdNotifyReady(); err != nil && err != sdnotify.SdNotifyNoSocket {
 		return errors.Wrap(err, "failed to notify systemd")


### PR DESCRIPTION
When running `rclone mount`, there where 2 signal handlers for `os.Interrupt`.

Those handlers would run concurrently and in some cases cause either unmount or `atexit.Run()` being skipped.

In addition `atexit.Run()` will get called in `resolveExitCode` to ensure cleanup on errors.