### PR TITLE
cache: use secure websockets for HTTPS Plex addresses

### DIFF
--- a/backend/cache/plex.go
+++ b/backend/cache/plex.go
@@ -108,7 +108,7 @@ func (p *plexConnector) closeWebsocket() {
 
 func (p *plexConnector) listenWebsocket() {
 	u := strings.Replace(p.url.String(), "http://", "ws://", 1)
-	u = strings.Replace(u, "https://", "ws://", 1)
+	u = strings.Replace(u, "https://", "wss://", 1)
 	conn, err := websocket.Dial(fmt.Sprintf(defPlexNotificationURL, strings.TrimRight(u, "/"), p.token),
 		"", "http://localhost")
 	if err != nil {


### PR DESCRIPTION
When using a PMS that requires HTTPS I get the following in the logs, where `https://fooflix.com` is the configured Plex URL and it is only available via that address.

```
ERROR : plex: websocket.Dial ws://fooflix.com/:/websockets/notifications?X-Plex-Token={redacted_token}: bad status
```

Inspecting Plex Web all the sockets connect via `wss://`. In the rclone code `https://` was being replaced with `ws://`, not the secure version.