### PR TITLE
OneDrive-SharePoint

### DIFF
--- a/backend/onedrive/api/types.go
+++ b/backend/onedrive/api/types.go
@@ -88,9 +88,10 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 // ItemReference groups data needed to reference a OneDrive item
 // across the service into a single structure.
 type ItemReference struct {
-	DriveID string `json:"driveId"` // Unique identifier for the Drive that contains the item.	Read-only.
-	ID      string `json:"id"`      // Unique identifier for the item.	Read/Write.
-	Path    string `json:"path"`    // Path that used to navigate to the item.	Read/Write.
+	DriveID   string `json:"driveId"`   // Unique identifier for the Drive that contains the item.	Read-only.
+	ID        string `json:"id"`        // Unique identifier for the item.	Read/Write.
+	Path      string `json:"path"`      // Path that used to navigate to the item.	Read/Write.
+	DriveType string `json:"driveType"` // Type of the drive,	Read-Only
 }
 
 // FolderFacet groups folder-related data on OneDrive into a single structure

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1470,14 +1470,14 @@ func (o *Object) uploadFragment(url string, start int64, totalSize int64, chunk 
 
 				bodyBytes, err2 := ioutil.ReadAll(resp.Body)
 				if err2 != nil {
-					fs.Debugf(o, "Stream Read Error", err)
+					fs.Debugf(o, "Stream Read Error : %v", err)
 				}
 				info = &api.Item{}
 
 				m := &api.Item{}
 				err := json.Unmarshal(bodyBytes, &m)
 				if err != nil {
-					fs.Debugf(o, "Stream Read Error", err)
+					fs.Debugf(o, "Stream Read Error : %v", err)
 				}
 				if m.Size != totalSize {
 					var possibleOfficeMatchingProblem = false


### PR DESCRIPTION
SharePoint Modifications to OneDrive.

The SharePoint OneDrive runs on a different MS Graph section, to the Personal and Business OneDrive also utilising the quickxorhash.  Hashes are changed to some types of Microsoft files when  loaded to SharePoint,  this does not effect files created in SharePoint, so synchronisation is difficult the first time.