### PR TITLE
check: Add one-way argument

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -9,11 +9,13 @@ import (
 // Globals
 var (
 	download = false
+	oneway   = false
 )
 
 func init() {
 	cmd.Root.AddCommand(commandDefintion)
 	commandDefintion.Flags().BoolVarP(&download, "download", "", download, "Check by downloading rather than with hash.")
+	commandDefintion.Flags().BoolVarP(&oneway, "one-way", "", oneway, "Check one way only, source files must exist on remote")
 }
 
 var commandDefintion = &cobra.Command{
@@ -31,15 +33,19 @@ If you supply the --download flag, it will download the data from
 both remotes and check them against each other on the fly.  This can
 be useful for remotes that don't support hashes or if you really want
 to check all the data.
+
+If you supply the --one-way flag, it will only check that files in source
+match the files in destination, not the other way around. Meaning extra files in
+destination that are not in the source will not trigger an error.
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)
 		fsrc, fdst := cmd.NewFsSrcDst(args)
 		cmd.Run(false, false, command, func() error {
 			if download {
-				return operations.CheckDownload(fdst, fsrc)
+				return operations.CheckDownload(fdst, fsrc, oneway)
 			}
-			return operations.Check(fdst, fsrc)
+			return operations.Check(fdst, fsrc, oneway)
 		})
 	},
 }

--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -10,8 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Globals
+var (
+	oneway = false
+)
+
 func init() {
 	cmd.Root.AddCommand(commandDefintion)
+	commandDefintion.Flags().BoolVarP(&oneway, "one-way", "", oneway, "Check one way only, source files must exist on destination")
 }
 
 var commandDefintion = &cobra.Command{
@@ -40,6 +46,10 @@ the files in remote:path.
     rclone cryptcheck remote:path encryptedremote:path
 
 After it has run it will log the status of the encryptedremote:.
+
+If you supply the --one-way flag, it will only check that files in source
+match the files in destination, not the other way around. Meaning extra files in
+destination that are not in the source will not trigger an error.
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)
@@ -100,5 +110,5 @@ func cryptCheck(fdst, fsrc fs.Fs) error {
 		return false, false
 	}
 
-	return operations.CheckFn(fcrypt, fsrc, checkIdentical)
+	return operations.CheckFn(fcrypt, fsrc, checkIdentical, oneway)
 }


### PR DESCRIPTION
--one-way argument will check that all files on source matches the files on detination,
but not the other way. For example files present on destination but not on source will not
trigger an error.

Fixes: #1526