### PR TITLE
errorHandler function for failed oauth requests

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -97,7 +97,15 @@ func init() {
 					log.Fatalf("Failed to configure token: %v", err)
 				}
 			} else {
-				err := oauthutil.Config("onedrive", name, oauthBusinessConfig, oauthBusinessResource)
+				err := oauthutil.ConfigErrorCheck("onedrive", name, func(req *http.Request) oauthutil.AuthError {
+					var resp oauthutil.AuthError
+
+					resp.Name = req.URL.Query().Get("error")
+					resp.Code = strings.Split(req.URL.Query().Get("error_description"), ":")[0] // error_description begins with XXXXXXXXXXXX:
+					resp.Description = strings.Join(strings.Split(req.URL.Query().Get("error_description"), ":")[1:], ":")
+					resp.HelpURL = "https://rclone.org/onedrive/#troubleshooting"
+					return resp
+				}, oauthBusinessConfig, oauthBusinessResource)
 				if err != nil {
 					log.Fatalf("Failed to configure token: %v", err)
 					return


### PR DESCRIPTION
More details on the single commits can be found in their messages.
This addresses #1975 

I thought of a way to handle errors returned by the authentication providers in a generic way.
This is what I came up with, every backend can provide its own handler and gets the failed oauth request with all parameters. This handler then returns a struct with some data about the error. This struct can be formatted for the web and cli interface.

What do you think of the concept? I think the code can be improved, but I just wanted to share the "Proof-of-Concept" before I add anything else to it.