### PR TITLE
enable vfs-read-chunk-size by default

### DIFF
--- a/fs/sizesuffix.go
+++ b/fs/sizesuffix.go
@@ -13,6 +13,17 @@ import (
 // SizeSuffix is an int64 with a friendly way of printing setting
 type SizeSuffix int64
 
+// Common multipliers for SizeSuffix
+const (
+	Byte SizeSuffix = 1 << (iota * 10)
+	KibiByte
+	MebiByte
+	GibiByte
+	TebiByte
+	PebiByte
+	ExbiByte
+)
+
 // Turn SizeSuffix into a string and a suffix
 func (x SizeSuffix) string() (string, string) {
 	scaled := float64(0)

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -48,6 +48,8 @@ var DefaultOpt = Options{
 	CacheMode:         CacheModeOff,
 	CacheMaxAge:       3600 * time.Second,
 	CachePollInterval: 60 * time.Second,
+	ChunkSize:         128 * fs.MebiByte,
+	ChunkSizeLimit:    -1,
 }
 
 // Node represents either a directory (*Dir) or a file (*File)

--- a/vfs/vfsflags/vfsflags.go
+++ b/vfs/vfsflags/vfsflags.go
@@ -24,6 +24,6 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.DurationVarP(flagSet, &Opt.CachePollInterval, "vfs-cache-poll-interval", "", Opt.CachePollInterval, "Interval to poll the cache for stale objects.")
 	flags.DurationVarP(flagSet, &Opt.CacheMaxAge, "vfs-cache-max-age", "", Opt.CacheMaxAge, "Max age of objects in the cache.")
 	flags.FVarP(flagSet, &Opt.ChunkSize, "vfs-read-chunk-size", "", "Read the source objects in chunks.")
-	flags.FVarP(flagSet, &Opt.ChunkSizeLimit, "vfs-read-chunk-size-limit", "", "If greater than --vfs-read-chunk-size, double the chunk size after each chunk read, until the limit is reached. -1 is unlimited.")
+	flags.FVarP(flagSet, &Opt.ChunkSizeLimit, "vfs-read-chunk-size-limit", "", "If greater than --vfs-read-chunk-size, double the chunk size after each chunk read, until the limit is reached. 'off' is unlimited.")
 	platformFlags(flagSet)
 }


### PR DESCRIPTION
`--vfs-read-chunk-size` has been in beta for some time now and seems to work well for many users.

There are a few posts in the forum discussing the general usage of this feature and settings users have tried.
Here are a the ones I think are the most interesting:
https://forum.rclone.org/t/new-feature-vfs-read-chunk-size/5683
https://forum.rclone.org/t/slow-media-start-times-with-mount-cache/5895
https://forum.rclone.org/t/my-vfs-sweetspot-updated-21-jul-2018/6132

This is the outline of these discussions:
- Any value for `vfs-read-chunk-size` will reduce the chance of hitting download limits, since the current default will always request the whole file.
- `vfs-read-chunk-size-limit` can be set to `off` to allow the chunk size to grow infinitely. This only affects consecutive reads and reduces the number of requests for large files.
- `vfs-read-chunk-size` should be greater than `buffer-size` to prevent too many requests from being sent when opening a file.
- Values less then `32M` should only be used if the usage pattern allows it. For fast connections this can cause many requests and may result in rate limiting.

From my own testing and the values seen being used by other users I suggest using `--vfs-read-chunk-size 128M` and `--vfs-read-chunk-size-limit off` as the new defaults. They should not affect any user negatively.