### PR TITLE
lsjson: add option to display the original object id

### DIFF
--- a/backend/cache/object.go
+++ b/backend/cache/object.go
@@ -353,6 +353,13 @@ func (o *Object) tempFileStartedUpload() bool {
 	return started
 }
 
+// UnWrap returns the Object that this Object is wrapping or
+// nil if it isn't wrapping anything
+func (o *Object) UnWrap() fs.Object {
+	return o.Object
+}
+
 var (
-	_ fs.Object = (*Object)(nil)
+	_ fs.Object          = (*Object)(nil)
+	_ fs.ObjectUnWrapper = (*Object)(nil)
 )


### PR DESCRIPTION
This adds the `--original` flag to the lsjson command, which enables the output of the ID from the underlying remote object.

This is useful when wrapped backends like `crypt` or `cache` are used and you want find real ID of a file.

It currently only works for `fs.Object`, not for `fs.Directory`.