### PR TITLE
vfs: add the vfs/refresh rc command

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -256,6 +256,7 @@ func (d *Dir) _readDirFromEntries(entries fs.DirEntries, dirTree walk.DirTree, w
 	return nil
 }
 
+// readDirTree forces a refresh of the complete directory tree
 func (d *Dir) readDirTree() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -273,6 +274,14 @@ func (d *Dir) readDirTree() error {
 	fs.Debugf(d.path, "Reading directory tree done in %s", time.Since(when))
 	d.read = when
 	return nil
+}
+
+// readDir forces a refresh of the directory
+func (d *Dir) readDir() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.read = time.Time{}
+	return d._readDir()
 }
 
 // stat a single item in the directory

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -197,10 +197,14 @@ func (d *Dir) _readDir() error {
 	return nil
 }
 
+// update d.items for each dir in the DirTree below this one and
+// set the last read time - must be called with the lock held
 func (d *Dir) _readDirFromDirTree(dirTree walk.DirTree, when time.Time) error {
 	return d._readDirFromEntries(dirTree[d.path], dirTree, when)
 }
 
+// update d.items and if dirTree is not nil update each dir in the DirTree below this one and
+// set the last read time - must be called with the lock held
 func (d *Dir) _readDirFromEntries(entries fs.DirEntries, dirTree walk.DirTree, when time.Time) error {
 	var err error
 	// Cache the items by name

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -61,4 +61,84 @@ starting with dir will forget that dir, eg
 
 `,
 	})
+	rc.Add(rc.Call{
+		Path: "vfs/refresh",
+		Fn: func(in rc.Params) (out rc.Params, err error) {
+			root, err := vfs.Root()
+			if err != nil {
+				return nil, err
+			}
+			getDir := func(path string) (*Dir, error) {
+				path = strings.Trim(path, "/")
+				segments := strings.Split(path, "/")
+				var node Node = root
+				for _, s := range segments {
+					if dir, ok := node.(*Dir); ok {
+						node, err = dir.stat(s)
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+				if dir, ok := node.(*Dir); ok {
+					return dir, nil
+				}
+				return nil, EINVAL
+			}
+
+			result := map[string]string{}
+			if len(in) == 0 {
+				err = root.readDirTree()
+				if err != nil {
+					result[""] = err.Error()
+				} else {
+					result[""] = "OK"
+				}
+			} else {
+				for k, v := range in {
+					path, ok := v.(string)
+					if !ok {
+						return out, errors.Errorf("value must be string %q=%v", k, v)
+					}
+					if strings.HasPrefix(k, "dir") {
+						dir, err := getDir(path)
+						if err != nil {
+							result[path] = err.Error()
+						} else {
+							err = dir.readDirTree()
+							if err != nil {
+								result[path] = err.Error()
+							} else {
+								result[path] = "OK"
+							}
+
+						}
+					} else {
+						return out, errors.Errorf("unknown key %q", k)
+					}
+				}
+			}
+			out = rc.Params{
+				"result": result,
+			}
+			return out, nil
+		},
+		Title: "Refresh the directory cache tree.",
+		Help: `
+This reads the full directory tree for the paths and freshens the
+directory cache.
+
+If no paths are passed in then it will refresh the root directory.
+
+    rclone rc vfs/refresh
+
+Otherwise pass directories in as dir=path. Any parameter key
+starting with dir will refresh that directory, eg
+
+    rclone rc vfs/refresh dir=home/junk dir2=data/misc
+
+This refresh will use --fast-list if enabled.
+
+`,
+	})
 }

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/ncw/rclone/fs"
@@ -95,11 +96,8 @@ starting with dir will forget that dir, eg
 					if !ok {
 						return out, errors.Errorf("value must be string %q=%v", k, v)
 					}
-					switch strings.ToLower(s) {
-					case "true", "1":
-						recursive = true
-					case "false", "0":
-					default:
+					recursive, err = strconv.ParseBool(s)
+					if err != nil {
 						return out, errors.Errorf("invalid value %q=%v", k, v)
 					}
 					delete(in, k)
@@ -151,9 +149,9 @@ starting with dir will forget that dir, eg
 			}
 			return out, nil
 		},
-		Title: "Refresh the directory cache tree.",
+		Title: "Refresh the directory cache.",
 		Help: `
-This reads the full directory tree for the paths and freshens the
+This reads the directories for the specified paths and freshens the
 directory cache.
 
 If no paths are passed in then it will refresh the root directory.
@@ -165,7 +163,8 @@ starting with dir will refresh that directory, eg
 
     rclone rc vfs/refresh dir=home/junk dir2=data/misc
 
-This refresh will use --fast-list if enabled.
+If the parameter recursive=true is given the whole directory tree
+will get refreshed. This refresh will use --fast-list if enabled.
 
 `,
 	})


### PR DESCRIPTION
The `vfs/refresh` command will walk the directory tree (using `walk.NewDirTree`) for the given paths and freshen the directory cache for the full tree.
It will use the fast-list capability of the remote when enabled.

When a mount is setup like this
```
rclone mount --checkers=6 --dir-cache-time 240h --rc --fast-list remote: /mnt/remote
```
you can now precache a large directory tree with 
```
rclone rc vfs/refresh dir=hugedir
```
before running a script that would read each directory in the tree one by one to speed up the process.

The `vfs/refresh` command will always walk the full directory tree, regardless of its directory cache state.