### PR TITLE
B2 Docs: use 'create' instead of 'make' for easier access

### DIFF
--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -80,7 +80,7 @@ See all buckets
 
     rclone lsd remote:
 
-Make a new bucket
+Create a new bucket
 
     rclone mkdir remote:bucket
 


### PR DESCRIPTION
Instead of using 'make' the word 'create' is much easier to find, when you want to create a new bucket ;) Took me some minutes, so I am suggesting this tiny fix.