### PR TITLE
all: fix go-critic linter suggestions

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -831,7 +831,7 @@ func (o *Object) decodeMetaDataFromPropertiesResponse(info *azblob.BlobGetProper
 }
 
 func (o *Object) decodeMetaDataFromBlob(info *azblob.BlobItem) (err error) {
-	o.md5 = string(info.Properties.ContentMD5[:])
+	o.md5 = string(info.Properties.ContentMD5)
 	o.mimeType = *info.Properties.ContentType
 	o.size = *info.Properties.ContentLength
 	o.modTime = info.Properties.LastModified

--- a/backend/b2/api/types.go
+++ b/backend/b2/api/types.go
@@ -74,7 +74,7 @@ const versionFormat = "-v2006-01-02-150405.000"
 func (t Timestamp) AddVersion(remote string) string {
 	ext := path.Ext(remote)
 	base := remote[:len(remote)-len(ext)]
-	s := (time.Time)(t).Format(versionFormat)
+	s := time.Time(t).Format(versionFormat)
 	// Replace the '.' with a '-'
 	s = strings.Replace(s, ".", "-", -1)
 	return base + s + ext
@@ -107,20 +107,20 @@ func RemoveVersion(remote string) (t Timestamp, newRemote string) {
 
 // IsZero returns true if the timestamp is unitialised
 func (t Timestamp) IsZero() bool {
-	return (time.Time)(t).IsZero()
+	return time.Time(t).IsZero()
 }
 
 // Equal compares two timestamps
 //
 // If either are !IsZero then it returns false
 func (t Timestamp) Equal(s Timestamp) bool {
-	if (time.Time)(t).IsZero() {
+	if time.Time(t).IsZero() {
 		return false
 	}
-	if (time.Time)(s).IsZero() {
+	if time.Time(s).IsZero() {
 		return false
 	}
-	return (time.Time)(t).Equal((time.Time)(s))
+	return time.Time(t).Equal(time.Time(s))
 }
 
 // File is info about a file

--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -668,7 +668,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 		Parameters: fieldsValue(),
 	}
 	replacedLeaf := replaceReservedChars(leaf)
-	copy := api.CopyFile{
+	copyFile := api.CopyFile{
 		Name: replacedLeaf,
 		Parent: api.Parent{
 			ID: directoryID,
@@ -677,7 +677,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	var resp *http.Response
 	var info *api.Item
 	err = f.pacer.Call(func() (bool, error) {
-		resp, err = f.srv.CallJSON(&opts, &copy, &info)
+		resp, err = f.srv.CallJSON(&opts, &copyFile, &info)
 		return shouldRetry(resp, err)
 	})
 	if err != nil {

--- a/backend/crypt/cipher_test.go
+++ b/backend/crypt/cipher_test.go
@@ -24,7 +24,7 @@ func TestNewNameEncryptionMode(t *testing.T) {
 		{"off", NameEncryptionOff, ""},
 		{"standard", NameEncryptionStandard, ""},
 		{"obfuscate", NameEncryptionObfuscated, ""},
-		{"potato", NameEncryptionMode(0), "Unknown file name encryption mode \"potato\""},
+		{"potato", NameEncryptionOff, "Unknown file name encryption mode \"potato\""},
 	} {
 		actual, actualErr := NewNameEncryptionMode(test.in)
 		assert.Equal(t, actual, test.expected)

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -704,15 +704,15 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 
 // newDir returns a dir with the Name decrypted
 func (f *Fs) newDir(dir fs.Directory) fs.Directory {
-	new := fs.NewDirCopy(dir)
+	newDir := fs.NewDirCopy(dir)
 	remote := dir.Remote()
 	decryptedRemote, err := f.cipher.DecryptDirName(remote)
 	if err != nil {
 		fs.Debugf(remote, "Undecryptable dir name: %v", err)
 	} else {
-		new.SetRemote(decryptedRemote)
+		newDir.SetRemote(decryptedRemote)
 	}
-	return new
+	return newDir
 }
 
 // ObjectInfo describes a wrapped fs.ObjectInfo for being the source

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -838,7 +838,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	id, _, _ := parseDirID(directoryID)
 
 	replacedLeaf := replaceReservedChars(leaf)
-	copy := api.CopyItemRequest{
+	copyReq := api.CopyItemRequest{
 		Name: &replacedLeaf,
 		ParentReference: api.ItemReference{
 			ID: id,
@@ -846,7 +846,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	}
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
-		resp, err = f.srv.CallJSON(&opts, &copy, nil)
+		resp, err = f.srv.CallJSON(&opts, &copyReq, nil)
 		return shouldRetry(resp, err)
 	})
 	if err != nil {

--- a/backend/onedrive/quickxorhash/quickxorhash_test.go
+++ b/backend/onedrive/quickxorhash/quickxorhash_test.go
@@ -140,7 +140,7 @@ func TestQuickXorHashByBlock(t *testing.T) {
 			got := h.Sum(nil)
 			want, err := base64.StdEncoding.DecodeString(test.out)
 			require.NoError(t, err, what)
-			assert.Equal(t, want, got[:], test.size, what)
+			assert.Equal(t, want, got, test.size, what)
 		}
 	}
 }

--- a/backend/yandex/api/performdelete.go
+++ b/backend/yandex/api/performdelete.go
@@ -29,7 +29,7 @@ func (c *Client) PerformDelete(url string) error {
 		if err != nil {
 			return err
 		}
-		return errors.Errorf("delete error [%d]: %s", resp.StatusCode, string(body[:]))
+		return errors.Errorf("delete error [%d]: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/backend/yandex/api/performdownload.go
+++ b/backend/yandex/api/performdownload.go
@@ -34,7 +34,7 @@ func (c *Client) PerformDownload(url string, headers map[string]string) (out io.
 		if err != nil {
 			return nil, err
 		}
-		return nil, errors.Errorf("download error [%d]: %s", resp.StatusCode, string(body[:]))
+		return nil, errors.Errorf("download error [%d]: %s", resp.StatusCode, string(body))
 	}
 	return resp.Body, err
 }

--- a/backend/yandex/api/performmkdir.go
+++ b/backend/yandex/api/performmkdir.go
@@ -28,7 +28,7 @@ func (c *Client) PerformMkdir(url string) (int, string, error) {
 			return 0, "", err
 		}
 		//third parameter is the json error response body
-		return resp.StatusCode, string(body[:]), errors.Errorf("create folder error [%d]: %s", resp.StatusCode, string(body[:]))
+		return resp.StatusCode, string(body), errors.Errorf("create folder error [%d]: %s", resp.StatusCode, string(body))
 	}
 	return resp.StatusCode, "", nil
 }

--- a/backend/yandex/api/performupload.go
+++ b/backend/yandex/api/performupload.go
@@ -32,7 +32,7 @@ func (c *Client) PerformUpload(url string, data io.Reader, contentType string) (
 			return err
 		}
 
-		return errors.Errorf("upload error [%d]: %s", resp.StatusCode, string(body[:]))
+		return errors.Errorf("upload error [%d]: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -189,7 +189,7 @@ var _ fusefs.NodeLinker = (*Dir)(nil)
 
 // Link creates a new directory entry in the receiver based on an
 // existing Node. Receiver must be a directory.
-func (d *Dir) Link(ctx context.Context, req *fuse.LinkRequest, old fusefs.Node) (new fusefs.Node, err error) {
-	defer log.Trace(d, "req=%v, old=%v", req, old)("new=%v, err=%v", &new, &err)
+func (d *Dir) Link(ctx context.Context, req *fuse.LinkRequest, old fusefs.Node) (newNode fusefs.Node, err error) {
+	defer log.Trace(d, "req=%v, old=%v", req, old)("new=%v, err=%v", &newNode, &err)
 	return nil, fuse.ENOSYS
 }

--- a/cmd/mountlib/mounttest/dir.go
+++ b/cmd/mountlib/mounttest/dir.go
@@ -143,7 +143,7 @@ func TestDirModTime(t *testing.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
-	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	mtime := time.Date(2012, time.November, 18, 17, 32, 31, 0, time.UTC)
 	err := os.Chtimes(run.path("dir"), mtime, mtime)
 	require.NoError(t, err)
 

--- a/cmd/mountlib/mounttest/file.go
+++ b/cmd/mountlib/mounttest/file.go
@@ -16,7 +16,7 @@ func TestFileModTime(t *testing.T) {
 
 	run.createFile(t, "file", "123")
 
-	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	mtime := time.Date(2012, time.November, 18, 17, 32, 31, 0, time.UTC)
 	err := os.Chtimes(run.path("file"), mtime, mtime)
 	require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestFileModTimeWithOpenWriters(t *testing.T) {
 		t.Skip("Skipping test on Windows")
 	}
 
-	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	mtime := time.Date(2012, time.November, 18, 17, 32, 31, 0, time.UTC)
 	filepath := run.path("cp-archive-test")
 
 	f, err := osCreate(filepath)

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -932,7 +932,7 @@ func NewRemoteName() (name string) {
 
 // editOptions edits the options.  If new is true then it just allows
 // entry and doesn't show any old values.
-func editOptions(ri *fs.RegInfo, name string, new bool) {
+func editOptions(ri *fs.RegInfo, name string, isNew bool) {
 	hasAdvanced := false
 	for _, advanced := range []bool{false, true} {
 		if advanced {
@@ -951,7 +951,7 @@ func editOptions(ri *fs.RegInfo, name string, new bool) {
 			}
 			subProvider := getConfigData().MustValue(name, fs.ConfigProvider, "")
 			if matchProvider(option.Provider, subProvider) {
-				if !new {
+				if !isNew {
 					fmt.Printf("Value %q = %q\n", option.Name, FileGet(name, option.Name))
 					fmt.Printf("Edit? (y/n)>\n")
 					if !Confirm() {

--- a/fs/config/configmap/configmap_test.go
+++ b/fs/config/configmap/configmap_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	_ Mapper = (Simple)(nil)
-	_ Getter = (Simple)(nil)
-	_ Setter = (Simple)(nil)
+	_ Mapper = Simple(nil)
+	_ Getter = Simple(nil)
+	_ Setter = Simple(nil)
 )
 
 func TestConfigMapGet(t *testing.T) {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -628,16 +628,16 @@ func (ft *Features) Mask(f Fs) *Features {
 // Wrap makes a Copy of the features passed in, overriding the UnWrap/Wrap
 // method only if available in f.
 func (ft *Features) Wrap(f Fs) *Features {
-	copy := new(Features)
-	*copy = *ft
+	ftCopy := new(Features)
+	*ftCopy = *ft
 	if do, ok := f.(UnWrapper); ok {
-		copy.UnWrap = do.UnWrap
+		ftCopy.UnWrap = do.UnWrap
 	}
 	if do, ok := f.(Wrapper); ok {
-		copy.WrapFs = do.WrapFs
-		copy.SetWrapper = do.SetWrapper
+		ftCopy.WrapFs = do.WrapFs
+		ftCopy.SetWrapper = do.SetWrapper
 	}
-	return copy
+	return ftCopy
 }
 
 // WrapsFs adds extra information between `f` which wraps `w`

--- a/fs/fserrors/error.go
+++ b/fs/fserrors/error.go
@@ -53,7 +53,7 @@ func (err wrappedRetryError) Retry() bool {
 }
 
 // Check interface
-var _ Retrier = wrappedRetryError{(error)(nil)}
+var _ Retrier = wrappedRetryError{error(nil)}
 
 // RetryError makes an error which indicates it would like to be retried
 func RetryError(err error) error {
@@ -97,7 +97,7 @@ func (err wrappedFatalError) Fatal() bool {
 }
 
 // Check interface
-var _ Fataler = wrappedFatalError{(error)(nil)}
+var _ Fataler = wrappedFatalError{error(nil)}
 
 // FatalError makes an error which indicates it is a fatal error and
 // the sync should stop.
@@ -145,7 +145,7 @@ func (err wrappedNoRetryError) NoRetry() bool {
 }
 
 // Check interface
-var _ NoRetrier = wrappedNoRetryError{(error)(nil)}
+var _ NoRetrier = wrappedNoRetryError{error(nil)}
 
 // NoRetryError makes an error which indicates the sync shouldn't be
 // retried.

--- a/fs/fshttp/http_test.go
+++ b/fs/fshttp/http_test.go
@@ -15,26 +15,26 @@ func ptr(p interface{}) string {
 
 func TestSetDefaults(t *testing.T) {
 	old := http.DefaultTransport.(*http.Transport)
-	new := new(http.Transport)
-	setDefaults(new, old)
+	newT := new(http.Transport)
+	setDefaults(newT, old)
 	// Can't use assert.Equal or reflect.DeepEqual for this as it has functions in
 	// Check functions by comparing the "%p" representations of them
-	assert.Equal(t, ptr(old.Proxy), ptr(new.Proxy), "when checking .Proxy")
-	assert.Equal(t, ptr(old.DialContext), ptr(new.DialContext), "when checking .DialContext")
+	assert.Equal(t, ptr(old.Proxy), ptr(newT.Proxy), "when checking .Proxy")
+	assert.Equal(t, ptr(old.DialContext), ptr(newT.DialContext), "when checking .DialContext")
 	// Check the other public fields
-	assert.Equal(t, ptr(old.Dial), ptr(new.Dial), "when checking .Dial")
-	assert.Equal(t, ptr(old.DialTLS), ptr(new.DialTLS), "when checking .DialTLS")
-	assert.Equal(t, old.TLSClientConfig, new.TLSClientConfig, "when checking .TLSClientConfig")
-	assert.Equal(t, old.TLSHandshakeTimeout, new.TLSHandshakeTimeout, "when checking .TLSHandshakeTimeout")
-	assert.Equal(t, old.DisableKeepAlives, new.DisableKeepAlives, "when checking .DisableKeepAlives")
-	assert.Equal(t, old.DisableCompression, new.DisableCompression, "when checking .DisableCompression")
-	assert.Equal(t, old.MaxIdleConns, new.MaxIdleConns, "when checking .MaxIdleConns")
-	assert.Equal(t, old.MaxIdleConnsPerHost, new.MaxIdleConnsPerHost, "when checking .MaxIdleConnsPerHost")
-	assert.Equal(t, old.IdleConnTimeout, new.IdleConnTimeout, "when checking .IdleConnTimeout")
-	assert.Equal(t, old.ResponseHeaderTimeout, new.ResponseHeaderTimeout, "when checking .ResponseHeaderTimeout")
-	assert.Equal(t, old.ExpectContinueTimeout, new.ExpectContinueTimeout, "when checking .ExpectContinueTimeout")
-	assert.Equal(t, old.TLSNextProto, new.TLSNextProto, "when checking .TLSNextProto")
-	assert.Equal(t, old.MaxResponseHeaderBytes, new.MaxResponseHeaderBytes, "when checking .MaxResponseHeaderBytes")
+	assert.Equal(t, ptr(old.Dial), ptr(newT.Dial), "when checking .Dial")
+	assert.Equal(t, ptr(old.DialTLS), ptr(newT.DialTLS), "when checking .DialTLS")
+	assert.Equal(t, old.TLSClientConfig, newT.TLSClientConfig, "when checking .TLSClientConfig")
+	assert.Equal(t, old.TLSHandshakeTimeout, newT.TLSHandshakeTimeout, "when checking .TLSHandshakeTimeout")
+	assert.Equal(t, old.DisableKeepAlives, newT.DisableKeepAlives, "when checking .DisableKeepAlives")
+	assert.Equal(t, old.DisableCompression, newT.DisableCompression, "when checking .DisableCompression")
+	assert.Equal(t, old.MaxIdleConns, newT.MaxIdleConns, "when checking .MaxIdleConns")
+	assert.Equal(t, old.MaxIdleConnsPerHost, newT.MaxIdleConnsPerHost, "when checking .MaxIdleConnsPerHost")
+	assert.Equal(t, old.IdleConnTimeout, newT.IdleConnTimeout, "when checking .IdleConnTimeout")
+	assert.Equal(t, old.ResponseHeaderTimeout, newT.ResponseHeaderTimeout, "when checking .ResponseHeaderTimeout")
+	assert.Equal(t, old.ExpectContinueTimeout, newT.ExpectContinueTimeout, "when checking .ExpectContinueTimeout")
+	assert.Equal(t, old.TLSNextProto, newT.TLSNextProto, "when checking .TLSNextProto")
+	assert.Equal(t, old.MaxResponseHeaderBytes, newT.MaxResponseHeaderBytes, "when checking .MaxResponseHeaderBytes")
 }
 
 func TestCleanAuth(t *testing.T) {

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -982,15 +982,15 @@ func Purge(f fs.Fs, dir string) error {
 // Delete removes all the contents of a container.  Unlike Purge, it
 // obeys includes and excludes.
 func Delete(f fs.Fs) error {
-	delete := make(fs.ObjectsChan, fs.Config.Transfers)
+	delChan := make(fs.ObjectsChan, fs.Config.Transfers)
 	delErr := make(chan error, 1)
 	go func() {
-		delErr <- DeleteFiles(delete)
+		delErr <- DeleteFiles(delChan)
 	}()
 	err := ListFn(f, func(o fs.Object) {
-		delete <- o
+		delChan <- o
 	})
-	close(delete)
+	close(delChan)
 	delError := <-delErr
 	if err == nil {
 		err = delError

--- a/fstest/test_all/test_all.go
+++ b/fstest/test_all/test_all.go
@@ -172,7 +172,7 @@ func newTest(pkg, remote string, subdir bool, fastlist bool) *test {
 		pkg:     pkg,
 		remote:  remote,
 		subdir:  subdir,
-		cmdLine: []string{binary, "-test.timeout", (*timeout).String(), "-remote", remote},
+		cmdLine: []string{binary, "-test.timeout", timeout.String(), "-remote", remote},
 		try:     1,
 	}
 	if *fstest.Verbose {
@@ -226,7 +226,7 @@ func (t *test) findFailures() {
 
 // nextCmdLine returns the next command line
 func (t *test) nextCmdLine() []string {
-	cmdLine := t.cmdLine[:]
+	cmdLine := t.cmdLine
 	if t.runFlag != "" {
 		cmdLine = append(cmdLine, "-test.run", t.runFlag)
 	}

--- a/vfs/read_write.go
+++ b/vfs/read_write.go
@@ -261,9 +261,9 @@ func (fh *RWFileHandle) close() (err error) {
 		return nil
 	}
 
-	copy := false
+	isCopied := false
 	if writer {
-		copy = fh.file.delWriter(fh, fh.modified())
+		isCopied = fh.file.delWriter(fh, fh.modified())
 		defer fh.file.finishWriterClose()
 	}
 
@@ -293,7 +293,7 @@ func (fh *RWFileHandle) close() (err error) {
 		}
 	}
 
-	if copy {
+	if isCopied {
 		// Transfer the temp file to the remote
 		cacheObj, err := fh.d.vfs.cache.f.NewObject(fh.remote)
 		if err != nil {

--- a/vfs/read_write_test.go
+++ b/vfs/read_write_test.go
@@ -576,7 +576,7 @@ func TestRWFileModTimeWithOpenWriters(t *testing.T) {
 	defer r.Finalise()
 	vfs, fh := rwHandleCreateWriteOnly(t, r)
 
-	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	mtime := time.Date(2012, time.November, 18, 17, 32, 31, 0, time.UTC)
 
 	_, err := fh.Write([]byte{104, 105})
 	require.NoError(t, err)

--- a/vfs/write_test.go
+++ b/vfs/write_test.go
@@ -226,7 +226,7 @@ func TestWriteFileModTimeWithOpenWriters(t *testing.T) {
 	defer r.Finalise()
 	vfs, fh := writeHandleCreate(t, r)
 
-	mtime := time.Date(2012, 11, 18, 17, 32, 31, 0, time.UTC)
+	mtime := time.Date(2012, time.November, 18, 17, 32, 31, 0, time.UTC)
 
 	_, err := fh.Write([]byte{104, 105})
 	require.NoError(t, err)


### PR DESCRIPTION
Fix some warning that were found by [go-critic](https://github.com/go-critic/go-critic) like redundant dereference, shadowed builtins, not using named consts, redundant parentheses. 
Log:
```
check-package: github.com/ncw/rclone/fstest/test_all/test_all.go:175:46: underef: could simplify (*timeout).String to timeout.String

check-package: github.com/ncw/rclone/backend/yandex/api/performdelete.go:32:73: unslice: could simplify body[:] to body
check-package: github.com/ncw/rclone/backend/yandex/api/performdownload.go:37:80: unslice: could simplify body[:] to body
check-package: github.com/ncw/rclone/backend/yandex/api/performmkdir.go:31:34: unslice: could simplify body[:] to body
check-package: github.com/ncw/rclone/backend/yandex/api/performmkdir.go:31:114: unslice: could simplify body[:] to body
check-package: github.com/ncw/rclone/backend/yandex/api/performupload.go:35:73: unslice: could simplify body[:] to body
check-package: github.com/ncw/rclone/fstest/test_all/test_all.go:229:13: unslice: could simplify t.cmdLine[:] to t.cmdLine
check-package: github.com/ncw/rclone/backend/azureblob/azureblob.go:834:17: unslice: could simplify info.Properties.ContentMD5[:] to info.Properties.ContentMD5
check-package: github.com/ncw/rclone/backend/onedrive/quickxorhash/quickxorhash_test.go:143:26: unslice: could simplify got[:] to got

check-package: github.com/ncw/rclone/vfs/read_write_test.go:579:27: namedConst: use time.November instead of 11
check-package: github.com/ncw/rclone/vfs/write_test.go:229:27: namedConst: use time.November instead of 11
check-package: github.com/ncw/rclone/cmd/mountlib/mounttest/dir.go:146:27: namedConst: use time.November instead of 11
check-package: github.com/ncw/rclone/cmd/mountlib/mounttest/file.go:19:27: namedConst: use time.November instead of 11
check-package: github.com/ncw/rclone/cmd/mountlib/mounttest/file.go:44:27: namedConst: use time.November instead of 11
check-package: github.com/ncw/rclone/backend/crypt/cipher_test.go:27:33: namedConst: use NameEncryptionOff instead of 0

check-package: github.com/ncw/rclone/fs/fs.go:631:2: builtinShadow: shadowing of predeclared identifier: copy
check-package: github.com/ncw/rclone/backend/box/box.go:671:2: builtinShadow: shadowing of predeclared identifier: copy
check-package: github.com/ncw/rclone/vfs/read_write.go:264:2: builtinShadow: shadowing of predeclared identifier: copy
check-package: github.com/ncw/rclone/fs/operations/operations.go:985:2: builtinShadow: shadowing of predeclared identifier: delete
check-package: github.com/ncw/rclone/cmd/mount/dir.go:192:82: builtinShadow: shadowing of predeclared identifier: new
check-package: github.com/ncw/rclone/fs/fshttp/http_test.go:18:2: builtinShadow: shadowing of predeclared identifier: new
check-package: github.com/ncw/rclone/fs/config/config.go:935:47: builtinShadow: shadowing of predeclared identifier: new
check-package: github.com/ncw/rclone/backend/crypt/crypt.go:707:2: builtinShadow: shadowing of predeclared identifier: new
check-package: github.com/ncw/rclone/backend/onedrive/onedrive.go:841:2: builtinShadow: shadowing of predeclared identifier: copy

check-package: github.com/ncw/rclone/fs/config/configmap/configmap_test.go:10:13: typeUnparen: could simplify (Simple) to Simple
check-package: github.com/ncw/rclone/fs/config/configmap/configmap_test.go:11:13: typeUnparen: could simplify (Simple) to Simple
check-package: github.com/ncw/rclone/fs/config/configmap/configmap_test.go:12:13: typeUnparen: could simplify (Simple) to Simple
check-package: github.com/ncw/rclone/backend/b2/api/types.go:77:7: typeUnparen: could simplify (time.Time) to time.Time
check-package: github.com/ncw/rclone/backend/b2/api/types.go:110:9: typeUnparen: could simplify (time.Time) to time.Time
check-package: github.com/ncw/rclone/backend/b2/api/types.go:117:5: typeUnparen: could simplify (time.Time) to time.Time
check-package: github.com/ncw/rclone/backend/b2/api/types.go:120:5: typeUnparen: could simplify (time.Time) to time.Time
check-package: github.com/ncw/rclone/backend/b2/api/types.go:123:9: typeUnparen: could simplify (time.Time) to time.Time
check-package: github.com/ncw/rclone/backend/b2/api/types.go:123:30: typeUnparen: could simplify (time.Time) to time.Time
check-package: github.com/ncw/rclone/fs/fserrors/error.go:56:35: typeUnparen: could simplify (error) to error
check-package: github.com/ncw/rclone/fs/fserrors/error.go:100:35: typeUnparen: could simplify (error) to error
check-package: github.com/ncw/rclone/fs/fserrors/error.go:148:39: typeUnparen: could simplify (error) to error
```