### PR TITLE
Add reveal command

### DIFF
--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/ncw/rclone/cmd/purge"
 	_ "github.com/ncw/rclone/cmd/rc"
 	_ "github.com/ncw/rclone/cmd/rcat"
+	_ "github.com/ncw/rclone/cmd/reveal"
 	_ "github.com/ncw/rclone/cmd/rmdir"
 	_ "github.com/ncw/rclone/cmd/rmdirs"
 	_ "github.com/ncw/rclone/cmd/serve"

--- a/cmd/reveal/reveal.go
+++ b/cmd/reveal/reveal.go
@@ -1,0 +1,30 @@
+package reveal
+
+import (
+	"fmt"
+
+	"github.com/ncw/rclone/cmd"
+	"github.com/ncw/rclone/fs/config/obscure"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd.Root.AddCommand(commandDefintion)
+}
+
+var commandDefintion = &cobra.Command{
+	Use:   "reveal password",
+	Short: `Reveal obscured password from rclone.conf`,
+	Run: func(command *cobra.Command, args []string) {
+		cmd.CheckArgs(1, 1, command, args)
+		cmd.Run(false, false, command, func() error {
+			revealed, err := obscure.Reveal(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Println(revealed)
+			return nil
+		})
+	},
+	Hidden: true,
+}

--- a/fs/config/obscure/obscure_test.go
+++ b/fs/config/obscure/obscure_test.go
@@ -36,3 +36,25 @@ func TestObscure(t *testing.T) {
 
 	}
 }
+
+func TestReveal(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+		iv   string
+	}{
+		{"YWFhYWFhYWFhYWFhYWFhYQ", "", "aaaaaaaaaaaaaaaa"},
+		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato", "aaaaaaaaaaaaaaaa"},
+		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato", "bbbbbbbbbbbbbbbb"},
+	} {
+		cryptRand = bytes.NewBufferString(test.iv)
+		got, err := Reveal(test.in)
+		assert.NoError(t, err)
+		assert.Equal(t, test.want, got)
+		// Now the Must variants
+		cryptRand = bytes.NewBufferString(test.iv)
+		got = MustReveal(test.in)
+		assert.Equal(t, test.want, got)
+
+	}
+}


### PR DESCRIPTION
This PR adds the `reveal` command, which is the opposite of the existing `obscure` command.

It will take as an argument an obscured password (that is, a password as stored in rclone.config) and will return the actual password value. 

I'm taking for granted this command doesn't exist just because it was not implemented, and not because we don't want it to be easily available. In the end, my understanding is that obscurity is just an extra step for avoiding visual eavesdropping.

Lot of global flags are available for this command and are useless, but since obscure command also has them I didn't go further in removing them.