### PR TITLE
Add disclaimer about generated passwords being stored in an obscured format

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -770,7 +770,9 @@ func ChooseOption(o *fs.Option, name string) string {
 				}
 				password = base64.RawURLEncoding.EncodeToString(pw)
 				fmt.Printf("Your password is: %s\n", password)
-				fmt.Printf("Use this password?\n")
+				fmt.Printf("Use this password? Please note that an obscured version of this \npassword (and not the " +
+					"password itself) will be stored under your \nconfiguration file, so keep this generated password " +
+					"in a safe place.\n")
 				if Confirm() {
 					break
 				}


### PR DESCRIPTION
This PR adds an extra message when creating a new crypt remote and choosing to auto-generate a password for encyption. It warns the user that the "plaintext" version of the password won't be stored so that he remembers to keep it safe somewhere.

@ncw Feel free to comment about the sentence, I am open to any change to make it as clear as possible or if you think the sentence needs to be introduced at some other stage. I have kept line length to 120, not sure what is the convention.