### PR TITLE
vfs: "Seek" in the --buffer-size data

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -96,6 +96,16 @@ func (acc *Account) GetReader() io.ReadCloser {
 	return acc.origIn
 }
 
+// GetAsyncReader returns the current AsyncReader or nil if Account is unbuffered
+func (acc *Account) GetAsyncReader() *asyncreader.AsyncReader {
+	acc.mu.Lock()
+	defer acc.mu.Unlock()
+	if asyncIn, ok := acc.in.(*asyncreader.AsyncReader); ok {
+		return asyncIn
+	}
+	return nil
+}
+
 // StopBuffering stops the async buffer doing any more buffering
 func (acc *Account) StopBuffering() {
 	if asyncIn, ok := acc.in.(*asyncreader.AsyncReader); ok {


### PR DESCRIPTION
Try to fulfill `Seek` calls on read only files by discarding bytes in the current buffer data.

Previously all `Seek` calls would discard the whole buffer and open a new connection every time.
Now they will consume the buffer until the right position is reached and only open a new connection if the position is outside the buffer data.

It is also possible to `Seek` backwards, but only inside the current buffer block.