### PR TITLE
docs: clearify buffer-size is per transfer/filehandle

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -341,6 +341,10 @@ change the bwlimit dynamically:
 Use this sized buffer to speed up file transfers.  Each `--transfer`
 will use this much memory for buffering.
 
+When using `mount` or `cmount` each open file descriptor will use this much
+memory for buffering.
+See the [mount](/commands/rclone_mount/#file-buffering) documentation for more details.
+
 Set to 0 to disable the buffering for the minimum memory usage.
 
 ### --checkers=N ###

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -79,7 +79,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.FVarP(flagSet, &fs.Config.LogLevel, "log-level", "", "Log level DEBUG|INFO|NOTICE|ERROR")
 	flags.FVarP(flagSet, &fs.Config.StatsLogLevel, "stats-log-level", "", "Log level to show --stats output DEBUG|INFO|NOTICE|ERROR")
 	flags.FVarP(flagSet, &fs.Config.BwLimit, "bwlimit", "", "Bandwidth limit in kBytes/s, or use suffix b|k|M|G or a full timetable.")
-	flags.FVarP(flagSet, &fs.Config.BufferSize, "buffer-size", "", "Buffer size when copying files.")
+	flags.FVarP(flagSet, &fs.Config.BufferSize, "buffer-size", "", "In memory buffer size when reading files for each --transfer.")
 	flags.FVarP(flagSet, &fs.Config.StreamingUploadCutoff, "streaming-upload-cutoff", "", "Cutoff for switching to chunked upload if file size is unknown. Upload starts after reaching cutoff or when file ends.")
 	flags.FVarP(flagSet, &fs.Config.Dump, "dump", "", "List of items to dump from: "+fs.DumpFlagsList)
 	flags.FVarP(flagSet, &fs.Config.MaxTransfer, "max-transfer", "", "Maximum size of data to transfer.")

--- a/vfs/help.go
+++ b/vfs/help.go
@@ -27,6 +27,23 @@ Or individual files or directories:
 
     rclone rc vfs/forget file=path/to/file dir=path/to/dir
 
+### File Buffering
+
+The ` + "`--buffer-size`" + ` flag determines the amount of memory,
+that will be used to buffer data in advance.
+
+Each open file descriptor will try to keep the specified amount of
+data in memory at all times. The buffered data is bound to one file
+descriptor and won't be shared between multiple open file descriptors
+of the same file.
+
+This flag is a upper limit for the used memory per file descriptor.
+The buffer will only use memory for data that is downloaded but not
+not yet read. If the buffer is empty, only a small amount of memory
+will be used.
+The maximum memory used by rclone for buffering can be up to
+` + "`--buffer-size * open files`" + `.
+
 ### File Caching
 
 **NB** File caching is **EXPERIMENTAL** - use with care!


### PR DESCRIPTION
Since there seems be some confusion how much memory `--buffer-size` uses, I suggest we change the command line help, to make it clearer it's per `--transfer`.

The full documentation already makes this clear, but the CLI help is probably the first place people will read and should express the same.

I also added a paragraph for `mount` and `cmount` to the documentation that they behave somewhat differently.

Should the CLI help also include this difference?
Is it possible change the help text for `mount` and `cmount` only?