### PR TITLE
jottacloud: Handle empty time values

### DIFF
--- a/backend/jottacloud/api/types.go
+++ b/backend/jottacloud/api/types.go
@@ -12,41 +12,35 @@ const (
 	timeFormat = "2006-01-02-T15:04:05Z0700"
 )
 
-// Time represents represents date and time information for the
-// Jottacloud API, by using a custom RFC3339 like format
+// Time represents time values in the Jottacloud API. It uses a custom RFC3339 like format.
 type Time time.Time
 
 // UnmarshalXML turns XML into a Time
 func (t *Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var v string
-	err := d.DecodeElement(&v, &start)
-	if err != nil {
+	if err := d.DecodeElement(&v, &start); err != nil {
 		return err
 	}
-	var newT time.Time
-	newT, err = time.Parse(timeFormat, v)
-	if err == nil {
-		*t = Time(newT)
+	if v == "" {
+		*t = Time(time.Time{})
+		return nil
 	}
-	//fmt.Printf("UnmarshalTime (in: %s, out: %s)\n", v, newT.String())
+	newTime, err := time.Parse(timeFormat, v)
+	if err == nil {
+		*t = Time(newTime)
+	}
 	return err
 }
 
 // MarshalXML turns a Time into XML
 func (t *Time) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	timeString := (*time.Time)(t).Format(timeFormat)
-	return e.EncodeElement(timeString, start)
+	return e.EncodeElement(t.String(), start)
 }
 
 // Return Time string in Jottacloud format
-func (t Time) String() string {
-	t1 := (time.Time)(t)
-	s := t1.Format(timeFormat)
-	//fmt.Printf("FormatTime: (in %s, out: %s)\n", t1.String(), s)
-	return s
-}
+func (t Time) String() string { return time.Time(t).Format(timeFormat) }
 
-// Flag is a Hacky type for checking if an attribute is present
+// Flag is a hacky type for checking if an attribute is present
 type Flag bool
 
 // UnmarshalXMLAttr sets Flag to true if the attribute is present
@@ -260,7 +254,7 @@ type Error struct {
 
 // Error returns a string for the error and statistifes the error interface
 func (e *Error) Error() string {
-	out := fmt.Sprintf("Error %d", e.StatusCode)
+	out := fmt.Sprintf("error %d", e.StatusCode)
 	if e.Message != "" {
 		out += ": " + e.Message
 	}

--- a/backend/jottacloud/api/types_test.go
+++ b/backend/jottacloud/api/types_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+)
+
+func TestMountpointEmptyModificationTime(t *testing.T) {
+	mountpoint := `
+<mountPoint time="2018-08-12-T09:58:24Z" host="dn-157">
+  <name xml:space="preserve">Sync</name>
+  <path xml:space="preserve">/foo/Jotta</path>
+  <abspath xml:space="preserve">/foo/Jotta</abspath>
+  <size>0</size>
+  <modified></modified>
+  <device>Jotta</device>
+  <user>foo</user>
+  <metadata first="" max="" total="0" num_folders="0" num_files="0"/>
+</mountPoint>
+`
+	var jf JottaFolder
+	if err := xml.Unmarshal([]byte(mountpoint), &jf); err != nil {
+		t.Fatal(err)
+	}
+	if !time.Time(jf.ModifiedAt).IsZero() {
+		t.Errorf("got non-zero time, want zero")
+	}
+}


### PR DESCRIPTION
I encountered a time parsing bug while testing the new Jottacloud backend. If a
mount point in Jottacloud has never been written to, the `modification` XML
element will be an empty string.

Example from my initial testing. My `jotta` remote was configured to use the
`/Sync` mount point, which I had never used before.

```
$ rclone ls jotta:
2018/08/11 22:48:36 ERROR : : error listing: couldn't list files: parsing time "" as "2006-01-02-T15:04:05Z0700": cannot parse "" as "2006"
2018/08/11 22:48:36 Failed to ls: couldn't list files: parsing time "" as "2006-01-02-T15:04:05Z0700": cannot parse "" as "2006"
```