### PR TITLE
crypt: ObjectInfo should return NotSupported instead of empty string …

### DIFF
--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -751,8 +751,8 @@ func (o *ObjectInfo) Size() int64 {
 
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
-func (o *ObjectInfo) Hash(hash hash.Type) (string, error) {
-	return "", nil
+func (o *ObjectInfo) Hash(ht hash.Type) (string, error) {
+	return "", hash.ErrUnsupported
 }
 
 // Check the interfaces are satisfied


### PR DESCRIPTION
@ncw I am not sure if that makes sense at all but returning a empty string as hash and NO error seems a bit dnagerous. I would assume the crypt backend should return the hash.ErrUnsupported for hash values