### PR TITLE
The small workaround fixes the missing MD5 for Jottacloud by using a …

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -79,7 +79,7 @@ type Options struct {
 	User               string        `config:"user"`
 	Pass               string        `config:"pass"`
 	Mountpoint         string        `config:"mountpoint"`
-	MD5MemoryThreshold fs.SizeSuffix `config:"chunk_size"`
+	MD5MemoryThreshold fs.SizeSuffix `config:"md5_memory_limit"`
 }
 
 // Fs represents a remote jottacloud

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -767,7 +767,7 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 // The new object may have been created if an error is returned
 func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
 	md5String, err := src.Hash(hash.MD5)
-	if err != nil {
+	if err != nil || md5String == "" {
 		// if the source can't provide a MD5 hash we are screwed and need to calculate it ourselfs
 		// we read the entire file and cache it in the localdir and send it AFTERwards
 

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -1,13 +1,18 @@
 package jottacloud
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/ncw/rclone/backend/jottacloud/api"
@@ -32,7 +37,7 @@ const (
 	defaultDevice     = "Jotta"
 	defaultMountpoint = "Sync"
 	rootURL           = "https://www.jottacloud.com/jfs/"
-	//newApiRootUrl   = "https://api.jottacloud.com"
+	apiURL            = "https://api.jottacloud.com"
 	//newUploadUrl	  = "https://up-no-001.jottacloud.com"
 )
 
@@ -49,6 +54,9 @@ func init() {
 			Name:       "pass",
 			Help:       "Password.",
 			IsPassword: true,
+		}, {
+			Name: "localdir",
+			Help: "Local cache directory for MD5 calculations",
 		}, {
 			Name:     "mountpoint",
 			Help:     "The mountpoint to use.",
@@ -68,18 +76,21 @@ func init() {
 type Options struct {
 	User       string `config:"user"`
 	Pass       string `config:"pass"`
+	LocalDir   string `config:"localdir"`
 	Mountpoint string `config:"mountpoint"`
 }
 
 // Fs represents a remote jottacloud
 type Fs struct {
-	name        string
-	root        string
-	opt         Options
-	features    *fs.Features
-	endpointURL string
-	srv         *rest.Client
-	pacer       *pacer.Pacer
+	name            string
+	root            string
+	localdir        string
+	localdirCounter uint64
+	opt             Options
+	features        *fs.Features
+	endpointURL     string
+	srv             *rest.Client
+	pacer           *pacer.Pacer
 }
 
 // Object describes a jottacloud object
@@ -255,6 +266,13 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 		return nil, errors.New("jottacloud needs user and password")
 	}
 
+	f.localdir = config.FileGet(name, "localdir")
+	if err = os.RemoveAll(f.localdir); err != nil {
+		return nil, fmt.Errorf("Cleaning local MD5 directory '%s' for Jottacloud failed, error: %s", f.localdir, err)
+	}
+	if err = os.MkdirAll(f.localdir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("Creating local MD5 directory '%s' for Jottacloud failed, error: %s", f.localdir, err)
+	}
 	f.srv.SetUserPass(opt.User, opt.Pass)
 	f.srv.SetErrorHandler(errorHandler)
 
@@ -748,6 +766,52 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 //
 // The new object may have been created if an error is returned
 func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
+	md5String, err := src.Hash(hash.MD5)
+	if err != nil {
+		// if the source can't provide a MD5 hash we are screwed and need to calculate it ourselfs
+		// we read the entire file and cache it in the localdir and send it AFTERwards
+
+		// increase a counter to get unique ids for the cache files
+		atomic.AddUint64(&o.fs.localdirCounter, 1)
+
+		// we need a MD5
+		md5Hasher := md5.New()
+		// this is our cache file
+		localFilename := filepath.Join(o.fs.localdir, strconv.FormatUint(atomic.LoadUint64(&o.fs.localdirCounter), 16))
+		// use the teeReader to write to the local file AND caclulate the MD5 while doing so
+		teeReader := io.TeeReader(in, md5Hasher)
+		// create the cache file
+		localFile, err := os.Create(localFilename)
+		if err != nil {
+			return err
+		}
+
+		// reade the ENTIRE file to disc and calculate the MD5 in the process
+		if _, err = io.Copy(localFile, teeReader); err != nil {
+			return err
+		}
+		// jump to the start of the local file so we can pass it along
+		localFile.Seek(0, 0)
+
+		// YEAH, the thing we need the MD5 string
+		md5String = hex.EncodeToString(md5Hasher.Sum(nil))
+
+		// clean up the file after we are done downloading
+		defer func() {
+			// the file should normally already be close, but just to make sure
+			localFile.Close()
+			// delete the cache file after we are done
+			err = os.Remove(localFilename)
+			if err != nil {
+				fs.Errorf(nil, "Failed to remove '%s', error: %s", localFilename, err)
+			}
+			fs.Infof(nil, "Removed '%s'", localFilename)
+		}()
+
+		// replace the already read source with a reader of our cached file
+		in = localFile
+	}
+
 	size := src.Size()
 
 	var resp *http.Response
@@ -762,14 +826,10 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 		Parameters:    url.Values{},
 	}
 
-	md5, err := src.Hash(hash.MD5)
-	if err != nil {
-		opts.ExtraHeaders["JMd5"] = md5
-		opts.Parameters.Set("cphash", md5)
-	}
-
+	opts.ExtraHeaders["JMd5"] = md5String
+	opts.Parameters.Set("cphash", md5String)
 	opts.ExtraHeaders["JSize"] = strconv.FormatInt(size, 10)
-	//opts.ExtraHeaders["JCreated"] =
+	// opts.ExtraHeaders["JCreated"] = api.Time(src.ModTime()).String()
 	opts.ExtraHeaders["JModified"] = api.Time(src.ModTime()).String()
 
 	// Parameters observed in other implementations

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -782,7 +782,9 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 				return err
 			}
 			// jump to the start of the local file so we can pass it along
-			tempFile.Seek(0, 0)
+			if _, err = tempFile.Seek(0, 0); err != nil {
+				return err
+			}
 
 			// clean up the file after we are done downloading
 			defer func() {


### PR DESCRIPTION
…local cache directory

This is a fix for the required MD5 before upload to Jottacloud.
If a source can't provide a MD5 (like the crypt backend for example) the entire source file is read into a file in a local cache directory and the uploaded after the full file is read including MD5 calculation.
The local cache directory needs to be define during `config` of the Jottacloud remote