### PR TITLE
Jottacloud resume / de-duplication support

### DIFF
--- a/backend/jottacloud/api/types.go
+++ b/backend/jottacloud/api/types.go
@@ -64,6 +64,15 @@ func (f *Flag) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
 	return attr, errors.New("unimplemented")
 }
 
+// TokenJSON is the struct representing the HTTP response from OAuth2
+// providers returning a token in JSON form.
+type TokenJSON struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int32  `json:"expires_in"` // at least PayPal returns string, while most return number
+}
+
 /*
 GET http://www.jottacloud.com/JFS/<account>
 

--- a/backend/jottacloud/api/types.go
+++ b/backend/jottacloud/api/types.go
@@ -9,7 +9,10 @@ import (
 )
 
 const (
+	// default time format for almost all request and responses
 	timeFormat = "2006-01-02-T15:04:05Z0700"
+	// the API server seems to use a different format
+	apiTimeFormat = "2006-01-02T15:04:05Z07:00"
 )
 
 // Time represents time values in the Jottacloud API. It uses a custom RFC3339 like format.
@@ -39,6 +42,9 @@ func (t *Time) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Return Time string in Jottacloud format
 func (t Time) String() string { return time.Time(t).Format(timeFormat) }
+
+// APIString returns Time string in Jottacloud API format
+func (t Time) APIString() string { return time.Time(t).Format(apiTimeFormat) }
 
 // Flag is a hacky type for checking if an attribute is present
 type Flag bool
@@ -264,4 +270,38 @@ func (e *Error) Error() string {
 		out += fmt.Sprintf(" (%+v)", e.Reason)
 	}
 	return out
+}
+
+// AllocateFileRequest to prepare an upload to Jottacloud
+type AllocateFileRequest struct {
+	Bytes    int64  `json:"bytes"`
+	Created  string `json:"created"`
+	Md5      string `json:"md5"`
+	Modified string `json:"modified"`
+	Path     string `json:"path"`
+}
+
+// AllocateFileResponse for upload requests
+type AllocateFileResponse struct {
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	State     string `json:"state"`
+	UploadID  string `json:"upload_id"`
+	UploadURL string `json:"upload_url"`
+	Bytes     int64  `json:"bytes"`
+	ResumePos int64  `json:"resume_pos"`
+}
+
+// UploadResponse after an upload
+type UploadResponse struct {
+	Name      string      `json:"name"`
+	Path      string      `json:"path"`
+	Kind      string      `json:"kind"`
+	ContentID string      `json:"content_id"`
+	Bytes     int64       `json:"bytes"`
+	Md5       string      `json:"md5"`
+	Created   int64       `json:"created"`
+	Modified  int64       `json:"modified"`
+	Deleted   interface{} `json:"deleted"`
+	Mime      string      `json:"mime"`
 }


### PR DESCRIPTION
Since we have to calculate the MD5 before uploading a file I added support for talking to the new API from Jottacloud to pre-allocate a file and get some information back before uploading.
The allocate method returns http status code 201 when the file is already uploaded and we can skip uploading it altogether (de-duplictation). A copy is still created at the desired location.
Additionally it also returns a "resume" position for the file if the upload was interrupted before. That way rclone can resume uploads to Jottacloud now with this PR.

@ncw I am having some trouble with the oauth for the api server from Jottacloud. They require the string for the `grant_type` to be uppercase. In the code https://github.com/ncw/rclone/blob/7194c358ad7b0287cdc44081a98879349d819288/vendor/golang.org/x/oauth2/oauth2.go#L244 for the oauth2 library it's lowercase. And using lowercase results in the API returning a 400 Bad Request.
Any idea how I could fix that? Do I need to write my very own ouath2.Client which would basically be a 1:1 copy of the existing one, just with the strings for `grant_type` changed to uppercase?