### PR TITLE
stats: handle FatalError and NoRetryError when reported to stats

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -311,11 +311,11 @@ func Run(Retry bool, showStats bool, cmd *cobra.Command, f func() error) {
 			}
 			break
 		}
-		if fserrors.IsFatalError(err) {
+		if fserrors.IsFatalError(err) || accounting.Stats.HadFatalError() {
 			fs.Errorf(nil, "Fatal error received - not attempting retries")
 			break
 		}
-		if fserrors.IsNoRetryError(err) {
+		if fserrors.IsNoRetryError(err) || (accounting.Stats.Errored() && !accounting.Stats.HadRetryError()) {
 			fs.Errorf(nil, "Can't retry this error - not attempting retries")
 			break
 		}


### PR DESCRIPTION
This is a proposal to properly handle `FatalError` and `NoRetryError` when they are not directly returned by the command, but just reported to stats.

See https://github.com/ncw/rclone/pull/2488#issuecomment-416675577 for the addressed use-case. 