### PR TITLE
Implemented PublicLink support for Jottacloud

### DIFF
--- a/backend/jottacloud/api/types.go
+++ b/backend/jottacloud/api/types.go
@@ -233,16 +233,17 @@ GET http://www.jottacloud.com/JFS/<account>/<device>/<mountpoint>/.../<file>
 
 // JottaFile represents a Jottacloud file
 type JottaFile struct {
-	XMLName    xml.Name
-	Name       string `xml:"name,attr"`
-	Deleted    Flag   `xml:"deleted,attr"`
-	State      string `xml:"currentRevision>state"`
-	CreatedAt  Time   `xml:"currentRevision>created"`
-	ModifiedAt Time   `xml:"currentRevision>modified"`
-	Updated    Time   `xml:"currentRevision>updated"`
-	Size       int64  `xml:"currentRevision>size"`
-	MimeType   string `xml:"currentRevision>mime"`
-	MD5        string `xml:"currentRevision>md5"`
+	XMLName         xml.Name
+	Name            string `xml:"name,attr"`
+	Deleted         Flag   `xml:"deleted,attr"`
+	PublicSharePath string `xml:"publicSharePath"`
+	State           string `xml:"currentRevision>state"`
+	CreatedAt       Time   `xml:"currentRevision>created"`
+	ModifiedAt      Time   `xml:"currentRevision>modified"`
+	Updated         Time   `xml:"currentRevision>updated"`
+	Size            int64  `xml:"currentRevision>size"`
+	MimeType        string `xml:"currentRevision>mime"`
+	MD5             string `xml:"currentRevision>md5"`
 }
 
 // Error is a custom Error for wrapping Jottacloud error responses

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -34,7 +34,9 @@ without account.
 			if err != nil {
 				return err
 			}
-			fmt.Println(link)
+			if link != "" {
+				fmt.Println(link)
+			}
 			return nil
 		})
 	},

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -149,6 +149,11 @@ Controls whether files are sent to the trash or deleted
 permanently. Defaults to false, namely sending files to the trash.
 Use `--jottacloud-hard-delete=true` to delete files permanently instead.
 
+#### --jottacloud-unlink ####
+
+Set to true to make the link command remove existing public link to file/folder.
+Default is false, meaning link command will create or retrieve public link.
+
 ### Troubleshooting ###
 
 Jottacloud exhibits some inconsistent behaviours regarding deleted files and folders which may cause Copy, Move and DirMove operations to previously deleted paths to fail. Emptying the trash should help in such cases.

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -138,7 +138,7 @@ operations more efficient.
 | Google Drive                 | Yes   | Yes  | Yes  | Yes     | Yes     | Yes   | Yes          | Yes         | Yes |
 | HTTP                         | No    | No   | No   | No      | No      | No    | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) | No  |
 | Hubic                        | Yes † | Yes  | No   | No      | No      | Yes   | Yes          | No [#2178](https://github.com/ncw/rclone/issues/2178) | Yes |
-| Jottacloud                   | Yes   | Yes  | Yes  | Yes     | No      | Yes   | No           | No                                                    | No  |
+| Jottacloud                   | Yes   | Yes  | Yes  | Yes     | No      | Yes   | No           | Yes                                                   | No  |
 | Mega                         | Yes   | No   | Yes  | Yes     | No      | No    | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) | Yes |
 | Microsoft Azure Blob Storage | Yes   | Yes  | No   | No      | No      | Yes   | No           | No [#2178](https://github.com/ncw/rclone/issues/2178) | No  |
 | Microsoft OneDrive           | Yes   | Yes  | Yes  | Yes     | No [#575](https://github.com/ncw/rclone/issues/575) | No | No | No [#2178](https://github.com/ncw/rclone/issues/2178) | Yes |


### PR DESCRIPTION
Title basically says it all..
Did not see any functionality in rclone for removing the public link again? That would be simple to implement for Jottacloud (just set mode "disableShare" instead of "enableShare")..