### PR TITLE
Make CIs available for forks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,4 +46,4 @@ artifacts:
 - path: build/*-v*.zip
 
 deploy_script:
-- IF "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" make appveyor_upload
+- IF "%APPVEYOR_REPO_NAME%" == "ncw/rclone" IF "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" make appveyor_upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ go:
 - 1.10.x
 - 1.11.x
 - tip
+go_import_path: github.com/ncw/rclone
 before_install:
 - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo modprobe fuse ; sudo chmod 666 /dev/fuse ; sudo chown root:$USER /etc/fuse.conf ; fi
 - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update && brew tap caskroom/cask && brew cask install osxfuse ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ deploy:
   script: make travis_beta
   skip_cleanup: true
   on:
+    repo: ncw/rclone
     all_branches: true
     go: 1.11.x
     condition: $TRAVIS_PULL_REQUEST == false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,14 @@ You patch will get reviewed and you might get asked to fix some stuff.
 If so, then make the changes in the same branch, squash the commits,
 rebase it to master then push it to Github with `--force`.
 
+## Enabling CI for your fork ##
+
+The CI config files for rclone have taken care of forks of the project, so you can enable CI for your fork repo easily.
+
+rclone currently uses [Travis CI](https://travis-ci.org/), [AppVeyor](https://ci.appveyor.com/), and
+[Circle CI](https://circleci.com/) to build the project. To enable them for your fork, simply go into their
+websites, find your fork of rclone, and enable building there.
+
 ## Testing ##
 
 rclone's tests are run from the go testing framework, so at the top


### PR DESCRIPTION
This PR makes a few changes to the config files for Travis CI and AppVeyor CI so that they work for forks of the repo.

P.S. Circle CI already works for forks and needs no change.