### PR TITLE
ncdu: return error instead of log.Fatal in Show

### DIFF
--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -6,7 +6,6 @@ package ncdu
 
 import (
 	"fmt"
-	"log"
 	"path"
 	"sort"
 	"strings"
@@ -466,7 +465,7 @@ func NewUI(f fs.Fs) *UI {
 func (u *UI) Show() error {
 	err := termbox.Init()
 	if err != nil {
-		log.Fatal(err)
+		return errors.Wrap(err, "termbox init")
 	}
 	defer termbox.Close()
 


### PR DESCRIPTION
I don't think this `log.Fatal(err)` in ncdu is intentional, but better ask than revert later.

This makes a termbox error much more recognizable.
#2538 could be an error returned by termbox, which is simply a syscall error message.