### PR TITLE
Implement optional permanent deletion in Jottacloud (not using trash)

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -71,6 +71,11 @@ func init() {
 			Help:     "Files bigger than this will be cached on disk to calculate the MD5 if required.",
 			Default:  fs.SizeSuffix(10 * 1024 * 1024),
 			Advanced: true,
+		}, {
+			Name:     "hard_delete",
+			Help:     "Delete files permanently rather than putting them into the trash.",
+			Default:  false,
+			Advanced: true,
 		}},
 	})
 }
@@ -81,6 +86,7 @@ type Options struct {
 	Pass               string        `config:"pass"`
 	Mountpoint         string        `config:"mountpoint"`
 	MD5MemoryThreshold fs.SizeSuffix `config:"md5_memory_limit"`
+	HardDelete         bool          `config:"hard_delete"`
 }
 
 // Fs represents a remote jottacloud
@@ -498,7 +504,11 @@ func (f *Fs) purgeCheck(dir string, check bool) (err error) {
 		NoResponse: true,
 	}
 
-	opts.Parameters.Set("dlDir", "true")
+	if f.opt.HardDelete {
+		opts.Parameters.Set("rmDir", "true")
+	} else {
+		opts.Parameters.Set("dlDir", "true")
+	}
 
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
@@ -914,7 +924,11 @@ func (o *Object) Remove() error {
 		Parameters: url.Values{},
 	}
 
-	opts.Parameters.Set("dl", "true")
+	if o.fs.opt.HardDelete {
+		opts.Parameters.Set("rm", "true")
+	} else {
+		opts.Parameters.Set("dl", "true")
+	}
 
 	return o.fs.pacer.Call(func() (bool, error) {
 		resp, err := o.fs.srv.CallXML(&opts, nil, nil)

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -99,7 +99,11 @@ the `--jottacloud-md5-memory-limit` flag.
 
 ### Deleting files ###
 
-Any files you delete with rclone will end up in the trash. Due to a lack of API documentation emptying the trash is currently only possible via the Jottacloud website.
+By default rclone will send all files to the trash when deleting files.
+Due to a lack of API documentation emptying the trash is currently
+only possible via the Jottacloud website. If deleting permanently
+is required then use the `--jottacloud-hard-delete` flag,
+or set the equivalent environment variable.
 
 ### Versions ###
 
@@ -123,6 +127,12 @@ system.
 
 Files bigger than this will be cached on disk to calculate the MD5 if
 required. (default 10M)
+
+#### --jottacloud-hard-delete ####
+
+Controls whether files are sent to the trash or deleted
+permanently. Defaults to false, namely sending files to the trash.
+Use `--jottacloud-hard-delete=true` to delete files permanently instead.
 
 ### Troubleshooting ###
 


### PR DESCRIPTION
When deleting, the item will be moved to trash by default, as before, but now you can specify option `--jottacloud-use-trash=false` to permanently delete it instead.

PS: I used the same naming of the option as in Drive (`--drive-use-trash=false`), but it is kind of annoying to have such boolean arguments where the default is true so you must always set the `=false` value instead of just the `--option` , if you know what I mean. Mega has such a negated option `--mega-hard-delete`, but then that name wasn't 100% fit..