### PR TITLE
webdav: add workaround for missing mtime - fixes #2420

### DIFF
--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -151,6 +151,12 @@ func (t *Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 
+	// If time is missing then return the epoch
+	if v == "" {
+		*t = Time(time.Unix(0, 0))
+		return nil
+	}
+
 	// Parse the time format in multiple possible ways
 	var newT time.Time
 	for _, timeFormat := range timeFormats {


### PR DESCRIPTION
Workaround for #2420, maybe there is a better fix, but this will do for the moment.
I replaced the proposed Now() with unix time 0, as I think this is less arbitrary and prevents possible files without an mtime from constant overwriting during sync.