### PR TITLE
crypt/cache: preserve leading / in the wrapped remote path 

### DIFF
--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -263,10 +263,15 @@ func NewFs(name, rootPath string, m configmap.Mapper) (fs.Fs, error) {
 		return nil, errors.Wrapf(err, "failed to clean root path %q", rootPath)
 	}
 
-	remotePath := path.Join(opt.Remote, rpath)
-	wrappedFs, wrapErr := fs.NewFs(remotePath)
+	wInfo, wName, wPath, wConfig, err := fs.ConfigFs(opt.Remote)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse remote %q to wrap", opt.Remote)
+	}
+
+	remotePath := path.Join(wPath, rootPath)
+	wrappedFs, wrapErr := wInfo.NewFs(wName, remotePath, wConfig)
 	if wrapErr != nil && wrapErr != fs.ErrorIsFile {
-		return nil, errors.Wrapf(wrapErr, "failed to make remote %q to wrap", remotePath)
+		return nil, errors.Wrapf(wrapErr, "failed to make remote %s:%s to wrap", wName, remotePath)
 	}
 	var fsErr error
 	fs.Debugf(name, "wrapped %v:%v at root %v", wrappedFs.Name(), wrappedFs.Root(), rpath)

--- a/docs/content/cache.md
+++ b/docs/content/cache.md
@@ -243,6 +243,19 @@ which makes it think we're downloading the full file instead of small chunks.
 Organizing the remotes in this order yelds better results:
 <span style="color:green">**cloud remote** -> **cache** -> **crypt**</span>
 
+#### absolute remote paths ####
+
+`cache` can not differentiate between relative and absolute paths for the wrapped remote.
+Any path given in the `remote` config setting and on the command line will be passed to
+the wrapped remote as is, but for storing the chunks on disk the path will be made
+relative by removing any leading `/` character.
+
+This behavior is irrelevant for most backend types, but there are backends where a leading `/`
+changes the effective directory, e.g. in the `sftp` backend paths starting with a `/` are
+relative to the root of the SSH server and paths without are relative to the user home directory.
+As a result `sftp:bin` and `sftp:/bin` will share the same cache folder, even if they represent
+a different directory on the SSH server.
+
 ### Cache and Remote Control (--rc) ###
 Cache supports the new `--rc` mode in rclone and can be remote controlled through the following end points:
 By default, the listener is disabled if you do not add the flag.


### PR DESCRIPTION
This fixes reports that arose lately, where using a plain `remote` setting like `cloud:` in `cache` or `crypt` would brake some backends.

The way the `remote` value and the root path from the command line where joined together introduced a additional `/` in the wrapped remote path. A `remote` value `cloud:` and the root path `dir` became `cloud:/dir` instead of the desired `cloud:dir`.

This difference could break remotes like `sftp` and `googlecloudstorage`.

I also added a section to the `cache`docs, that `sftp:dir` and `sftp:/dir` will share the same cache folder, which can have unintended side effects.

Fixes #2553
Fixes https://forum.rclone.org/t/rclone-is-not-working-outside-of-the-root-of-crypt-remote/6697