### PR TITLE
change too long names cutting mechanism - fixes #2490

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -256,11 +256,14 @@ func (acc *Account) String() string {
 			etas = "0s"
 		}
 	}
+
 	name := []rune(acc.name)
 	if fs.Config.StatsFileNameLength > 0 {
 		if len(name) > fs.Config.StatsFileNameLength {
-			where := len(name) - fs.Config.StatsFileNameLength
-			name = append([]rune{'.', '.', '.'}, name[where:]...)
+			suffixLength := fs.Config.StatsFileNameLength / 2
+			prefixLength := fs.Config.StatsFileNameLength - suffixLength
+			suffixStart := len(name) - suffixLength
+			name = append(append(name[:prefixLength], '…'), name[suffixStart:]...)
 		}
 	}
 


### PR DESCRIPTION
Fix for the https://github.com/ncw/rclone/issues/2490 issue
I wasn't sure how I should split the visible characters ( quoting the issue description `This ticket is to change the UI to <...> like ThisisATestFile...EndOfFilesName.xxx`) so I implemented the version where a visible prefix is equal or  one character longer than a visible suffix.