### PR TITLE
azureblob and fstests - Exclude archive tier from SetTier integration tests

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -191,19 +191,6 @@ func validateAccessTier(tier string) bool {
 	}
 }
 
-// validAccessTiers returns list of supported storage tiers on azureblob fs
-func validAccessTiers() []string {
-	validTiers := [...]azblob.AccessTierType{azblob.AccessTierHot, azblob.AccessTierCool,
-		azblob.AccessTierArchive}
-
-	var tiers [len(validTiers)]string
-
-	for i, tier := range validTiers {
-		tiers[i] = string(tier)
-	}
-	return tiers[:]
-}
-
 // retryErrorCodes is a slice of error codes that we will retry
 var retryErrorCodes = []int{
 	401, // Unauthorized (eg "Token has expired")
@@ -321,7 +308,6 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 		BucketBased:   true,
 		SetTier:       true,
 		GetTier:       true,
-		ListTiers:     true,
 	}).Fill(f)
 	if f.root != "" {
 		f.root += "/"
@@ -1335,11 +1321,6 @@ func (o *Object) SetTier(tier string) error {
 // GetTier returns object tier in azure as string
 func (o *Object) GetTier() string {
 	return string(o.accessTier)
-}
-
-// ListTiers returns list of storage tiers supported on this object
-func (o *Object) ListTiers() []string {
-	return validAccessTiers()
 }
 
 // Check the interfaces are satisfied

--- a/backend/azureblob/azureblob_internal_test.go
+++ b/backend/azureblob/azureblob_internal_test.go
@@ -11,9 +11,7 @@ import (
 func (f *Fs) InternalTest(t *testing.T) {
 	// Check first feature flags are set on this
 	// remote
-	enabled := f.Features().ListTiers
-	assert.True(t, enabled)
-	enabled = f.Features().SetTier
+	enabled := f.Features().SetTier
 	assert.True(t, enabled)
 	enabled = f.Features().GetTier
 	assert.True(t, enabled)

--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -14,7 +14,8 @@ import (
 // TestIntegration runs integration tests against the remote
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
-		RemoteName: "TestAzureBlob:",
-		NilObject:  (*azureblob.Object)(nil),
+		RemoteName:  "TestAzureBlob:",
+		NilObject:   (*azureblob.Object)(nil),
+		TiersToTest: []string{"Hot", "Cool"},
 	})
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -341,12 +341,6 @@ type GetTierer interface {
 	GetTier() string
 }
 
-// ListTierer is an optional interface for Object
-type ListTierer interface {
-	// ListTiers returns list of supported storage tiers
-	ListTiers() []string
-}
-
 // ListRCallback defines a callback function for ListR to use
 //
 // It is called for each tranche of entries read from the listing and
@@ -386,7 +380,6 @@ type Features struct {
 	BucketBased             bool // is bucket based (like s3, swift etc)
 	SetTier                 bool // allows set tier functionality on objects
 	GetTier                 bool // allows to retrieve storage tier of objects
-	ListTiers               bool // allows to list supported tiers on objects
 
 	// Purge all files in the root and the root directory
 	//
@@ -607,7 +600,6 @@ func (ft *Features) Mask(f Fs) *Features {
 	ft.BucketBased = ft.BucketBased && mask.BucketBased
 	ft.SetTier = ft.SetTier && mask.SetTier
 	ft.GetTier = ft.GetTier && mask.GetTier
-	ft.ListTiers = ft.ListTiers && mask.ListTiers
 
 	if mask.Purge == nil {
 		ft.Purge = nil


### PR DESCRIPTION
azureblob and fstests - Exclude archive tier from SetTier integration tests, added ExcludedSettings to fstests.Opt, a key-value map to hold various settings, where key is setting name and value is list of settings