### PR TITLE
fs/operations: optimize choosing the main folder in dedup - fixes #2568

### DIFF
--- a/fs/operations/dedupe.go
+++ b/fs/operations/dedupe.go
@@ -209,6 +209,20 @@ func dedupeMergeDuplicateDirs(f fs.Fs, duplicateDirs [][]fs.Directory) error {
 	}
 	for _, dirs := range duplicateDirs {
 		if !fs.Config.DryRun {
+
+			//Find the largest directory and merge duplicates into it
+			largestDir := dirs[0]
+			largestDirId := 0
+			counter := 0
+			for _, dir := range dirs {
+				if dir.Size() > largestDir.Size() {
+					largestDir = dir
+					largestDirId = counter
+				}
+				counter++
+			}
+			dirs[0], dirs[largestDirId] = dirs[largestDirId], dirs[0]
+
 			fs.Infof(dirs[0], "Merging contents of duplicate directories")
 			err := mergeDirs(dirs)
 			if err != nil {


### PR DESCRIPTION
Fix to  #2568 issue.

I used a different function ('Size()') than @ncw suggested in the issue comments, but if I understand the code correctly, it should give us exactly the information we need.