### PR TITLE
list: change debug logs for excluded items

### DIFF
--- a/fs/list/list.go
+++ b/fs/list/list.go
@@ -28,7 +28,7 @@ func DirSorted(f fs.Fs, includeAll bool, dir string) (entries fs.DirEntries, err
 	// starting directory, otherwise ListDirSorted should not be
 	// called.
 	if !includeAll && filter.Active.ListContainsExcludeFile(entries) {
-		fs.Debugf(dir, "Excluded from sync (and deletion)")
+		fs.Debugf(dir, "Excluded")
 		return nil, nil
 	}
 	return filterAndSortDir(entries, includeAll, dir, filter.Active.IncludeObject, filter.Active.IncludeDirectory(f))
@@ -51,7 +51,7 @@ func filterAndSortDir(entries fs.DirEntries, includeAll bool, dir string,
 			// Make sure we don't delete excluded files if not required
 			if !includeAll && !IncludeObject(x) {
 				ok = false
-				fs.Debugf(x, "Excluded from sync (and deletion)")
+				fs.Debugf(x, "Excluded")
 			}
 		case fs.Directory:
 			if !includeAll {
@@ -61,7 +61,7 @@ func filterAndSortDir(entries fs.DirEntries, includeAll bool, dir string,
 				}
 				if !include {
 					ok = false
-					fs.Debugf(x, "Excluded from sync (and deletion)")
+					fs.Debugf(x, "Excluded")
 				}
 			}
 		default:


### PR DESCRIPTION
Addresses discussion started in #878.

I thought it might be better to drop "from sync (and deletion)" altogether since listing is not just restricted to the sync command (`rclone -vv --exclude a tree remote:dir` would output the "Excluded from sync (and deletion)" line for example).

With files setup as:

```
dir/a
dir/b

remote/dir/a
remote/dir/b
```

The output from a `rclone -vv --exclude a --delete-excluded sync dir remote:dir` seems clear enough:

```
2018/09/20 23:17:33 DEBUG : a: Excluded
2018/09/20 23:17:33 INFO : Google drive root 'dir': Waiting for checks to finish
2018/09/20 23:17:33 DEBUG : b: Size and modification time the same (differ by -852.223µs, within tolerance 1ms)
2018/09/20 23:17:33 DEBUG : b: Unchanged skipping
2018/09/20 23:17:33 INFO : Google drive root 'dir': Waiting for transfers to finish
2018/09/20 23:17:33 INFO : Waiting for deletions to finish
2018/09/20 23:17:34 INFO : a: Deleted
```