### PR TITLE
drive: improve directory notifications in ChangeNotify

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -2061,15 +2061,16 @@ func (f *Fs) changeNotifyRunner(notifyFunc func(string, fs.EntryType), startPage
 		}
 		var pathsToClear []entryType
 		for _, change := range changeList.Changes {
+			// find the previous path
 			if path, ok := f.dirCache.GetInv(change.FileId); ok {
 				if change.File != nil && change.File.MimeType != driveFolderType {
 					pathsToClear = append(pathsToClear, entryType{path: path, entryType: fs.EntryObject})
 				} else {
 					pathsToClear = append(pathsToClear, entryType{path: path, entryType: fs.EntryDirectory})
 				}
-				continue
 			}
 
+			// find the new path
 			if change.File != nil {
 				changeType := fs.EntryDirectory
 				if change.File.MimeType != driveFolderType {


### PR DESCRIPTION
#### What is the purpose of this change?

When moving a directory in drive, most of the time only a notification for the directory itself is created, not the old or new parents.

This tires to find the old path for the changed directoy in the `dirCache` and the new path with the `dirCache` of the new parent, which can result in two notifications for a moved directory.

#### Was the change discussed in an issue or in the forum before?

It is somewhat related to #2006, but affects directories instead of files.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
