### PR TITLE
webdav/sharepoint: renew cookies after 12hrs

### DIFF
--- a/backend/webdav/odrvcookie/renew.go
+++ b/backend/webdav/odrvcookie/renew.go
@@ -1,0 +1,32 @@
+package odrvcookie
+
+import (
+	"time"
+
+	"github.com/ncw/rclone/lib/rest"
+)
+
+// CookieRenew holds information for the renew
+type CookieRenew struct {
+	srv     *rest.Client
+	timer   *time.Ticker
+	renewFn func()
+}
+
+// NewRenew returns and starts a CookieRenew
+func NewRenew(interval time.Duration, renewFn func()) *CookieRenew {
+	renew := CookieRenew{
+		timer:   time.NewTicker(interval),
+		renewFn: renewFn,
+	}
+	go renew.Renew()
+	return &renew
+}
+
+// Renew calls the renewFn for every tick
+func (c *CookieRenew) Renew() {
+	for {
+		<-c.timer.C // wait for tick
+		c.renewFn()
+	}
+}

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -372,6 +372,17 @@ func (f *Fs) setQuirks(vendor string) error {
 		if err != nil {
 			return err
 		}
+
+		odrvcookie.NewRenew(12*time.Hour, func() {
+			spCookies, err := spCk.Cookies()
+			if err != nil {
+				fs.Errorf("could not renew cookies: %s", err.Error())
+				return
+			}
+			f.srv.SetCookie(&spCookies.FedAuth, &spCookies.RtFa)
+			fs.Debugf(spCookies, "successfully renewed sharepoint cookies")
+		})
+
 		f.srv.SetCookie(&spCookies.FedAuth, &spCookies.RtFa)
 
 		// sharepoint, unlike the other vendors, only lists files if the depth header is set to 0


### PR DESCRIPTION
#### What is the purpose of this change?
This change will start a go function when the sharepoint vendor is initialized.
The function renews the authentication cookies every 12 hrs. It should prevent sharepoint from blocking requests as 403 FORBIDDEN.

#### Was the change discussed in an issue or in the forum before?
#2562 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
