### PR TITLE
onedrive: ignore OneNote files by default - fixes #211

### DIFF
--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -165,6 +165,13 @@ system.
 Above this size files will be chunked - must be multiple of 320k. The
 default is 10MB.  Note that the chunks will be buffered into memory.
 
+#### --onedrive-expose-onenote-files ####
+
+By default rclone will hide OneNote files in directory listing because operations like `Open`
+and `Update` won't work on them.  But this behaviour may also prevent you from deleting them.
+If you want to delete OneNote files or otherwise want them to show up in directory listing,
+set this flag.
+
 ### Limitations ###
 
 Note that OneDrive is case insensitive so you can't have a


### PR DESCRIPTION
OneNote files are a kind of files that look like files, but behave like folders. Operations like `Open` and `Update` fail on them. This PR hides them from directory listing, and prevent invalid operations on them, returning more user-friendly error messages. 

Since hiding these files from listing may also prevent them from being deleted, the flag `--onedrive-expose-onenote-files` is also added, which allows OneNote files to show up in directory listing. Illegal operations on them are still rejected even if this flag is set.

This should fix #211.