### PR TITLE
fstests: add TestFsPutChunked

### DIFF
--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -2,12 +2,12 @@
 
 // +build !freebsd,!netbsd,!openbsd,!plan9,!solaris,go1.8
 
-package azureblob_test
+package azureblob
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/azureblob"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -15,7 +15,16 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName:  "TestAzureBlob:",
-		NilObject:   (*azureblob.Object)(nil),
+		NilObject:   (*Object)(nil),
 		TiersToTest: []string{"Hot", "Cool"},
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			MaxChunkSize: maxChunkSize,
+		},
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/backend/b2/b2_test.go
+++ b/backend/b2/b2_test.go
@@ -1,10 +1,10 @@
 // Test B2 filesystem interface
-package b2_test
+package b2
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/b2"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -12,6 +12,15 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestB2:",
-		NilObject:  (*b2.Object)(nil),
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			MinChunkSize: minChunkSize,
+		},
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/backend/drive/drive_test.go
+++ b/backend/drive/drive_test.go
@@ -1,10 +1,10 @@
 // Test Drive filesystem interface
-package drive_test
+package drive
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/drive"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -12,6 +12,16 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestDrive:",
-		NilObject:  (*drive.Object)(nil),
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			MinChunkSize:  minChunkSize,
+			CeilChunkSize: fstests.NextPowerOfTwo,
+		},
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/backend/dropbox/dropbox_test.go
+++ b/backend/dropbox/dropbox_test.go
@@ -1,10 +1,10 @@
 // Test Dropbox filesystem interface
-package dropbox_test
+package dropbox
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/dropbox"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -12,6 +12,15 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestDropbox:",
-		NilObject:  (*dropbox.Object)(nil),
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			MaxChunkSize: maxChunkSize,
+		},
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/backend/jottacloud/jottacloud_internal_test.go
+++ b/backend/jottacloud/jottacloud_internal_test.go
@@ -4,50 +4,25 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
+	"github.com/ncw/rclone/lib/readers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// A test reader to return a test pattern of size
-type testReader struct {
-	size int64
-	c    byte
-}
-
-// Reader is the interface that wraps the basic Read method.
-func (r *testReader) Read(p []byte) (n int, err error) {
-	for i := range p {
-		if r.size <= 0 {
-			return n, io.EOF
-		}
-		p[i] = r.c
-		r.c = (r.c + 1) % 253
-		r.size--
-		n++
-	}
-	return
-}
-
 func TestReadMD5(t *testing.T) {
-	// smoke test the reader
-	b, err := ioutil.ReadAll(&testReader{size: 10})
-	require.NoError(t, err)
-	assert.Equal(t, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, b)
-
 	// Check readMD5 for different size and threshold
 	for _, size := range []int64{0, 1024, 10 * 1024, 100 * 1024} {
 		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
 			hasher := md5.New()
-			n, err := io.Copy(hasher, &testReader{size: size})
+			n, err := io.Copy(hasher, readers.NewPatternReader(size))
 			require.NoError(t, err)
 			assert.Equal(t, n, size)
 			wantMD5 := fmt.Sprintf("%x", hasher.Sum(nil))
 			for _, threshold := range []int64{512, 1024, 10 * 1024, 20 * 1024} {
 				t.Run(fmt.Sprintf("%d", threshold), func(t *testing.T) {
-					in := &testReader{size: size}
+					in := readers.NewPatternReader(size)
 					gotMD5, out, cleanup, err := readMD5(in, size, threshold)
 					defer cleanup()
 					require.NoError(t, err)

--- a/backend/onedrive/onedrive_test.go
+++ b/backend/onedrive/onedrive_test.go
@@ -1,10 +1,10 @@
 // Test OneDrive filesystem interface
-package onedrive_test
+package onedrive
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/onedrive"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -12,6 +12,15 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestOneDrive:",
-		NilObject:  (*onedrive.Object)(nil),
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			CeilChunkSize: fstests.NextMultipleOf(chunkSizeMultiple),
+		},
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -1,10 +1,10 @@
 // Test S3 filesystem interface
-package s3_test
+package s3
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/s3"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -12,6 +12,15 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestS3:",
-		NilObject:  (*s3.Object)(nil),
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			MinChunkSize: minChunkSize,
+		},
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -1,10 +1,10 @@
 // Test Swift filesystem interface
-package swift_test
+package swift
 
 import (
 	"testing"
 
-	"github.com/ncw/rclone/backend/swift"
+	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fstest/fstests"
 )
 
@@ -12,6 +12,12 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestSwift:",
-		NilObject:  (*swift.Object)(nil),
+		NilObject:  (*Object)(nil),
 	})
 }
+
+func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
+	return f.setUploadChunkSize(cs)
+}
+
+var _ fstests.SetUploadChunkSizer = (*Fs)(nil)

--- a/fs/sizesuffix.go
+++ b/fs/sizesuffix.go
@@ -4,6 +4,7 @@ package fs
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -129,4 +130,16 @@ func (x *SizeSuffix) Scan(s fmt.ScanState, ch rune) error {
 		return err
 	}
 	return x.Set(string(token))
+}
+
+// SizeSuffixList is a sclice SizeSuffix values
+type SizeSuffixList []SizeSuffix
+
+func (l SizeSuffixList) Len() int           { return len(l) }
+func (l SizeSuffixList) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l SizeSuffixList) Less(i, j int) bool { return l[i] < l[j] }
+
+// Sort sorts the list
+func (l SizeSuffixList) Sort() {
+	sort.Sort(l)
 }

--- a/fstest/fstests/bits.go
+++ b/fstest/fstests/bits.go
@@ -1,0 +1,33 @@
+//+build !go1.9
+
+package fstests
+
+func leadingZeros64(x uint64) int {
+	var n uint64 = 64
+
+	if y := x >> 32; y != 0 {
+		n = n - 32
+		x = y
+	}
+	if y := x >> 16; y != 0 {
+		n = n - 16
+		x = y
+	}
+	if y := x >> 8; y != 0 {
+		n = n - 8
+		x = y
+	}
+	if y := x >> 4; y != 0 {
+		n = n - 4
+		x = y
+	}
+	if y := x >> 2; y != 0 {
+		n = n - 2
+		x = y
+	}
+	if y := x >> 1; y != 0 {
+		return int(n - 2)
+	}
+
+	return int(n - x)
+}

--- a/fstest/fstests/bits_go1_9.go
+++ b/fstest/fstests/bits_go1_9.go
@@ -1,0 +1,11 @@
+//+build go1.9
+
+package fstests
+
+import (
+	"math/bits"
+)
+
+func leadingZeros64(x uint64) int {
+	return bits.LeadingZeros64(x)
+}

--- a/lib/readers/pattern_reader.go
+++ b/lib/readers/pattern_reader.go
@@ -1,0 +1,29 @@
+package readers
+
+import "io"
+
+// NewPatternReader creates a reader, that returns a deterministic byte pattern.
+// After length bytes are read
+func NewPatternReader(length int64) io.Reader {
+	return &patternReader{
+		length: length,
+	}
+}
+
+type patternReader struct {
+	length int64
+	c      byte
+}
+
+func (r *patternReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		if r.length <= 0 {
+			return n, io.EOF
+		}
+		p[i] = r.c
+		r.c = (r.c + 1) % 253
+		r.length--
+		n++
+	}
+	return
+}

--- a/lib/readers/pattern_reader_test.go
+++ b/lib/readers/pattern_reader_test.go
@@ -1,0 +1,30 @@
+package readers
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatternReader(t *testing.T) {
+	b2 := make([]byte, 1)
+
+	r := NewPatternReader(0)
+	b, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{}, b)
+	n, err := r.Read(b2)
+	require.Equal(t, io.EOF, err)
+	require.Equal(t, 0, n)
+
+	r = NewPatternReader(10)
+	b, err = ioutil.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, b)
+	n, err = r.Read(b2)
+	require.Equal(t, io.EOF, err)
+	require.Equal(t, 0, n)
+}


### PR DESCRIPTION
#### What is the purpose of this change?

This adds a test for chunked uploads to the integration tests.
Each remote now has a `ChunkedUploadConfig` field in the `fstests.Opt` struct, to specify the required settings for the test. In addition, each remote that supports chunked uploads has to implement the `fstest.SetUploadChunkSizer` interface, which allows to change the value at runtime. Remotes that do not implement the `fstest.SetUploadChunkSizer` interface will not be tested, since the test would be the same as `TestFsPut` with bigger files.

These are the currently minimum chunk sizes and the total number of bytes uploaded to the remote during the test:

remote | min chunk size | test upload size
------ | -------------- | ----------------
b2 | 5M | 190M
s3 | 5M | 190M
drive | 256K | 13M
onedrive | 320K | 25M
\* | 1 | 28M

These numbers could probably be reduced a bit by removing some similar test cases. There should be no file download involved, as `file.Check` only compares the hash and modtime.

The output of the following tests can be viewed here: [chunked.log](https://github.com/ncw/rclone/files/2456792/chunked.log)

`go test -v ./backend/drive ./backend/onedrive ./backend/s3 ./backend/local -test.run '^TestIntegration/((Setup|Init|Purge|Finalise)|FsPutChunked)$' | tee chunked.log`

#### Was the change discussed in an issue or in the forum before?

#2549

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
