### PR TITLE
jottacloud: fix bug in --fast-list related to empty folders (#2650)

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -464,12 +464,12 @@ func (f *Fs) listFileDir(remoteStartPath string, startFolder *api.JottaFolder, f
 		if folder.Deleted {
 			return nil
 		}
-		folderPath := path.Join(folder.Path, folder.Name)
-		remoteDirLength := len(folderPath) - pathPrefixLength
+		folderPath := restoreReservedChars(path.Join(folder.Path, folder.Name))
+		folderPathLength := len(folderPath)
 		var remoteDir string
-		if remoteDirLength > 0 {
-			remoteDir = restoreReservedChars(folderPath[pathPrefixLength+1:])
-			if remoteDirLength > startPathLength {
+		if folderPathLength > pathPrefixLength {
+			remoteDir = folderPath[pathPrefixLength+1:]
+			if folderPathLength > startPathLength {
 				d := fs.NewDir(remoteDir, time.Time(folder.ModifiedAt))
 				err := fn(d)
 				if err != nil {


### PR DESCRIPTION
Failing integration tests described in #2650 should be fixed now. Seems the problem was with the empty folders in the test case. It was caused by some incorrect logic in my previous integration test fix (#2558) - which I struggled a bit with, so hopefully all tests works now.