### PR TITLE
sftp: Ensure file hash checking is really disabled

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -769,6 +769,10 @@ func (o *Object) Hash(r hash.Type) (string, error) {
 		return "", hash.ErrUnsupported
 	}
 
+	if o.fs.opt.DisableHashCheck {
+		return "", nil
+	}
+
 	c, err := o.fs.getSftpConnection()
 	if err != nil {
 		return "", errors.Wrap(err, "Hash get SFTP connection")


### PR DESCRIPTION
#### What is the purpose of this change?

The Hash() function still attempts to run a remote SSH command to check the SHA/MD5 checksum of a file, even if the `disable_hashcheck` option is set in the configuration file. This change fixes that behaviour and makes `disable_hashcheck` work as expected again.

- [X] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
