### PR TITLE
Fixed the docs generation to use `$HOME` instead of specific user directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ MANUAL.txt:	MANUAL.md
 	pandoc -s --from markdown --to plain MANUAL.md -o MANUAL.txt
 
 commanddocs: rclone
-	rclone gendocs docs/content/commands/
+	XDG_CACHE_HOME="" XDG_CONFIG_HOME="" HOME="\$$HOME" USER="\$$USER" rclone gendocs docs/content/commands/
 
 backenddocs: rclone bin/make_backend_docs.py
 	./bin/make_backend_docs.py

--- a/docs/content/cache.md
+++ b/docs/content/cache.md
@@ -420,7 +420,7 @@ The remote name is used as the DB file name.
 - Config:      db_path
 - Env Var:     RCLONE_CACHE_DB_PATH
 - Type:        string
-- Default:     "/home/ncw/.cache/rclone/cache-backend"
+- Default:     "$HOME/.cache/rclone/cache-backend"
 
 #### --cache-chunk-path
 
@@ -436,7 +436,7 @@ then "--cache-chunk-path" will use the same path as "--cache-db-path".
 - Config:      chunk_path
 - Env Var:     RCLONE_CACHE_CHUNK_PATH
 - Type:        string
-- Default:     "/home/ncw/.cache/rclone/cache-backend"
+- Default:     "$HOME/.cache/rclone/cache-backend"
 
 #### --cache-db-purge
 


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes the docs generation to use the generic `$HOME` & `$USER` variables instead of specific values for reference.

#### Was the change discussed in an issue or in the forum before?

Fixes #2687 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)

---

Some observations:

* Doesn't work properly when built on Mac.
* User is still set statically in some places where the internal go function is called first.
