### PR TITLE
dedupe: check for existing filename before renaming a dupe file

### DIFF
--- a/fs/operations/dedupe_test.go
+++ b/fs/operations/dedupe_test.go
@@ -155,7 +155,8 @@ func TestDeduplicateRename(t *testing.T) {
 	file1 := r.WriteUncheckedObject("one.txt", "This is one", t1)
 	file2 := r.WriteUncheckedObject("one.txt", "This is one too", t2)
 	file3 := r.WriteUncheckedObject("one.txt", "This is another one", t3)
-	r.CheckWithDuplicates(t, file1, file2, file3)
+	file4 := r.WriteUncheckedObject("one-1.txt", "This is not a duplicate", t1)
+	r.CheckWithDuplicates(t, file1, file2, file3, file4)
 
 	err := operations.Deduplicate(r.Fremote, operations.DeduplicateRename)
 	require.NoError(t, err)
@@ -168,12 +169,19 @@ func TestDeduplicateRename(t *testing.T) {
 			remote := o.Remote()
 			if remote != "one-1.txt" &&
 				remote != "one-2.txt" &&
-				remote != "one-3.txt" {
+				remote != "one-3.txt" &&
+				remote != "one-4.txt" {
 				t.Errorf("Bad file name after rename %q", remote)
 			}
 			size := o.Size()
-			if size != file1.Size && size != file2.Size && size != file3.Size {
+			if size != file1.Size &&
+				size != file2.Size &&
+				size != file3.Size &&
+				size != file4.Size {
 				t.Errorf("Size not one of the object sizes %d", size)
+			}
+			if remote == "one-1.txt" && size != file4.Size {
+				t.Errorf("Existing non-duplicate file modified %q", remote)
 			}
 		})
 		return nil


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixes dedupe with rename strategy choosing names of files that already exist on the remote as described in #2512. Wasn't sure about adding tests since the existing test case doesn't seem to cover this scenario. 

With files in a remote folder as:
```
file
file
file-1
file-2
```

the first two should be renamed to file-3 and file-4


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
