### PR TITLE
feat: add --md-only flag

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -14,6 +14,7 @@ What happens if you CTRL-C a multipart upload
 */
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -600,6 +601,7 @@ Use this only if v4 signatures don't work, eg pre Jewel/v10 CEPH.`,
 const (
 	metaMtime      = "Mtime"                       // the meta key to store mtime in - eg X-Amz-Meta-Mtime
 	metaMD5Hash    = "Md5chksum"                   // the meta key to store md5hash in
+	metaMdOnly     = "Mdonly"                      // the meta key to specify that a request is metadata-only
 	listChunkSize  = 1000                          // number of items to read at once
 	maxRetries     = 10                            // number of retries to make of operations
 	maxSizeForCopy = 5 * 1024 * 1024 * 1024        // The maximum size of object we can COPY
@@ -1573,30 +1575,55 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	mimeType := fs.MimeType(src)
 
 	key := o.fs.root + o.remote
-	req := s3manager.UploadInput{
-		Bucket:      &o.fs.bucket,
-		ACL:         &o.fs.opt.ACL,
-		Key:         &key,
-		Body:        in,
-		ContentType: &mimeType,
-		Metadata:    metadata,
-		//ContentLength: &size,
-	}
-	if o.fs.opt.ServerSideEncryption != "" {
-		req.ServerSideEncryption = &o.fs.opt.ServerSideEncryption
-	}
-	if o.fs.opt.SSEKMSKeyID != "" {
-		req.SSEKMSKeyId = &o.fs.opt.SSEKMSKeyID
-	}
-	if o.fs.opt.StorageClass != "" {
-		req.StorageClass = &o.fs.opt.StorageClass
-	}
-	err = o.fs.pacer.CallNoRetry(func() (bool, error) {
-		_, err = uploader.Upload(&req)
-		return shouldRetry(err)
-	})
-	if err != nil {
-		return err
+	if fs.Config.MdOnly {
+		metadata[metaMdOnly] = aws.String("true")
+		req := s3.PutObjectInput{
+			Bucket:        &o.fs.bucket,
+			ACL:           &o.fs.opt.ACL,
+			Key:           &key,
+			Body:          bytes.NewReader([]byte("")),
+			Metadata:      metadata,
+			ContentLength: aws.Int64(0),
+		}
+		if o.fs.opt.ServerSideEncryption != "" {
+			req.ServerSideEncryption = &o.fs.opt.ServerSideEncryption
+		}
+		if o.fs.opt.SSEKMSKeyID != "" {
+			req.SSEKMSKeyId = &o.fs.opt.SSEKMSKeyID
+		}
+		if o.fs.opt.StorageClass != "" {
+			req.StorageClass = &o.fs.opt.StorageClass
+		}
+		_, err := o.fs.c.PutObject(&req)
+		if err != nil {
+			return err
+		}
+	} else {
+		req := s3manager.UploadInput{
+			Bucket:      &o.fs.bucket,
+			ACL:         &o.fs.opt.ACL,
+			Key:         &key,
+			Body:        in,
+			ContentType: &mimeType,
+			Metadata:    metadata,
+			//ContentLength: &size,
+		}
+		if o.fs.opt.ServerSideEncryption != "" {
+			req.ServerSideEncryption = &o.fs.opt.ServerSideEncryption
+		}
+		if o.fs.opt.SSEKMSKeyID != "" {
+			req.SSEKMSKeyId = &o.fs.opt.SSEKMSKeyID
+		}
+		if o.fs.opt.StorageClass != "" {
+			req.StorageClass = &o.fs.opt.StorageClass
+		}
+		err = o.fs.pacer.CallNoRetry(func() (bool, error) {
+			_, err = uploader.Upload(&req)
+			return shouldRetry(err)
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	// Read the metadata from the newly created object

--- a/fs/config.go
+++ b/fs/config.go
@@ -84,6 +84,7 @@ type ConfigInfo struct {
 	MaxBacklog            int
 	StatsOneLine          bool
 	Progress              bool
+	MdOnly                bool
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -86,6 +86,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.IntVarP(flagSet, &fs.Config.MaxBacklog, "max-backlog", "", fs.Config.MaxBacklog, "Maximum number of objects in sync or check backlog.")
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLine, "stats-one-line", "", fs.Config.StatsOneLine, "Make the stats fit on one line.")
 	flags.BoolVarP(flagSet, &fs.Config.Progress, "progress", "P", fs.Config.Progress, "Show progress during transfer.")
+	flags.BoolVarP(flagSet, &fs.Config.MdOnly, "md-only", "", fs.Config.MdOnly, "Upload metadata only.")
 }
 
 // SetFlags converts any flags into config which weren't straight foward

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -318,6 +318,11 @@ func Copy(f fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Objec
 		return newDst, err
 	}
 
+	if fs.Config.MdOnly {
+		fs.Infof(src, actionTaken)
+		return newDst, err
+	}
+
 	// Verify sizes are the same after transfer
 	if sizeDiffers(src, dst) {
 		err = errors.Errorf("corrupted on transfer: sizes differ %d vs %d", src.Size(), dst.Size())


### PR DESCRIPTION
Signed-off-by: Giacomo Guiulfo <giacomoguiulfo@gmail.com>

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add support for a global flag, "md-only". If enabled, only metadata of the files will be uploaded to the cloud backends. Also, a metadata header "Mdonly" will be included so that a cloud backend is aware that metadata-only put(s) were intended.

#### Was the change discussed in an issue or in the forum before?

Partially. This PR represent a subset of the changes discussed in https://forum.rclone.org/t/min-age-and-max-age-support-for-atime-and-ctime/2122/2.

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
