### PR TITLE
- install using 'busybox' if available, when no other unzip tools present

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -10,7 +10,7 @@
 set -e
 
 #when adding a tool to the list make sure to also add it's corresponding command further in the script
-unzip_tools_list=('unzip' '7z')
+unzip_tools_list=('unzip' '7z', 'busybox')
 
 usage() { echo "Usage: curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
 
@@ -132,6 +132,10 @@ case $unzip_tool in
     ;;
   '7z')
     7z x $rclone_zip -o$unzip_dir
+    ;;
+  'busybox')
+    mkdir -p $unzip_dir
+    busybox unzip $rclone_zip -d $unzip_dir
     ;;
 esac
     


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
The purpose is to allow install on modern Linux distribution (Debian, Ubuntu) where busybox is available initially, without prior installing additional software (unzip, 7z).
No product code changes done, only installer script located in documentation folder changed - so no tests and documentation updates are required.
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
