### PR TITLE
b2: cleanup unfinished large files

### DIFF
--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -181,8 +181,8 @@ versions of files, leaving the current ones intact.  You can also
 supply a path and only old versions under that path will be deleted,
 eg `rclone cleanup remote:bucket/path/to/stuff`.
 
-Note that `cleanup` does not remove partially uploaded files
-from the bucket.
+Note that `cleanup` will remove partially uploaded files from the bucket
+if they are more than a day old.
 
 When you `purge` a bucket, the current and the old versions will be
 deleted then the bucket will be deleted.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

The `cleanup` command will delete unfinished large file uploads that
were started more than a day ago (to avoid deleting uploads that are
potentially still in progress).

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Fixes #2617

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
