### PR TITLE
Fix install for Synology

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -10,7 +10,7 @@
 set -e
 
 #when adding a tool to the list make sure to also add it's corresponding command further in the script
-unzip_tools_list=('unzip' '7z', 'busybox')
+unzip_tools_list=('unzip' '7z' 'busybox')
 
 usage() { echo "Usage: curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
 


### PR DESCRIPTION
7z check doesn't work due to misplaced comma, so installation fails on Synology.

As discussed here: https://forum.rclone.org/t/rclone-install-broken-for-synology-again/7863/5