### PR TITLE
fstests: fix TestFsName fails when using remote:with/path

### DIFF
--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -385,7 +385,7 @@ func Run(t *testing.T, opt *Opt) {
 	t.Run("FsName", func(t *testing.T) {
 		skipIfNotOk(t)
 		got := remote.Name()
-		want := remoteName
+		want := remoteName[:strings.IndexRune(remoteName, ':')+1]
 		if isLocalRemote {
 			want = "local:"
 		}


### PR DESCRIPTION
This PR makes it possible to specify a subfolder to run the tests in.

Before this, the command `go test -v -remote remote:some/path` causes the `FsName` test to fail because `remote.Name() == "remote:"` is not equal to `remoteName == "remote:some/path"`