### PR TITLE
note on minimum version with support for b2 multi application keys

### DIFF
--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -98,7 +98,8 @@ excess files in the bucket.
 B2 supports multiple [Application Keys for different access permission
 to B2 Buckets](https://www.backblaze.com/b2/docs/application_keys.html).
 
-You can use these with rclone too.
+You can use these with rclone too; you will need to use rclone version 1.43
+or later.
 
 Follow Backblaze's docs to create an Application Key with the required
 permission and add the `Application Key ID` as the `account` and the


### PR DESCRIPTION
This trivial patch adds a note about the minimum version of rclone
needed in order to be able to use multiple application keys with the b2
backend.

For reference: https://github.com/ncw/rclone/issues/2513

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

As Debian stable (amongst other distros) is shipping an older version,
users running rclone < 1.43 and reading about this feature in the online
docs may struggle to realise why they are not able to sync to b2 when
configured to use an application key other than the master one.

#### Was the change discussed in an issue or in the forum before?

No. It is a trivial patch meant to clarify minimum version of rclone needed to use b2 multi application keys.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
