### PR TITLE
sftp: improve private key handling

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -124,11 +124,15 @@ The SFTP remote supports three authentication methods:
   * Key file
   * ssh-agent
 
-Key files should be unencrypted PEM-encoded private key files.  For
-instance `/home/$USER/.ssh/id_rsa`.
+Key files should be PEM-encoded private key files. For instance `/home/$USER/.ssh/id_rsa`.
+Only unencrypted OpenSSH or PEM encrypted files are supported.
 
-If you don't specify `pass` or `key_file` then rclone will attempt to
-contact an ssh-agent.
+If you don't specify `pass` or `key_file` then rclone will attempt to contact an ssh-agent.
+
+You can also specify `key_use_agent` to force the usage of an ssh-agent. In this case
+`key_file` can also be specified to force the usage of a specific key in the ssh-agent.
+
+Using an ssh-agent is the only way to load encrypted OpenSSH keys at the moment.
 
 If you set the `--sftp-ask-password` option, rclone will prompt for a
 password when needed and no password has been configured.
@@ -204,7 +208,7 @@ SSH password, leave blank to use ssh-agent.
 
 #### --sftp-key-file
 
-Path to PEM-encoded private key file, leave blank to use ssh-agent.
+Path to PEM-encoded private key file, leave blank or set key-use-agent to use ssh-agent.
 
 - Config:      key_file
 - Env Var:     RCLONE_SFTP_KEY_FILE
@@ -222,6 +226,19 @@ in the new OpenSSH format can't be used.
 - Env Var:     RCLONE_SFTP_KEY_FILE_PASS
 - Type:        string
 - Default:     ""
+
+#### --sftp-key-use-agent
+
+When set forces the usage of the ssh-agent.
+
+When key-file is also set, the ".pub" file of the specified key-file is read and only the associated key is
+requested from the ssh-agent. This allows to avoid `Too many authentication failures for *username*` errors
+when the ssh-agent contains many keys.
+
+- Config:      key_use_agent
+- Env Var:     RCLONE_SFTP_KEY_USE_AGENT
+- Type:        bool
+- Default:     false
 
 #### --sftp-use-insecure-cipher
 

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -204,10 +204,22 @@ SSH password, leave blank to use ssh-agent.
 
 #### --sftp-key-file
 
-Path to unencrypted PEM-encoded private key file, leave blank to use ssh-agent.
+Path to PEM-encoded private key file, leave blank to use ssh-agent.
 
 - Config:      key_file
 - Env Var:     RCLONE_SFTP_KEY_FILE
+- Type:        string
+- Default:     ""
+
+#### --sftp-key-file-pass
+
+The passphrase to decrypt the PEM-encoded private key file.
+
+Only PEM encrypted key files (old OpenSSH format) are supported. Encrypted keys
+in the new OpenSSH format can't be used.
+
+- Config:      key_file_pass
+- Env Var:     RCLONE_SFTP_KEY_FILE_PASS
 - Type:        string
 - Default:     ""
 


### PR DESCRIPTION
#### What is the purpose of this change?

This PR improves the usage of SSH private keys in the sftp backend.

It adds shell expansion for environment variables and the leading `~` syntax. It also provides two new options to the backend. 

The `key_file_pass` option can be used to configure a password for the provided key file. Due to library limitations the current OpenSSH key file format, identified by a `-----BEGIN OPENSSH PRIVATE KEY-----` header, can't be decrypted with this option.
The `key_use_agent` flag can be used to force `ssh-agent` based authentication. When this option is set, the backend also respects the `key_file` option and only uses the specified key when authenticating with the `ssh-agent`.

#### Was the change discussed in an issue or in the forum before?

#2843

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
