### PR TITLE
Add Scaleway to rclone documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Rclone *("rsync for cloud storage")* is a command line program to sync files and
   * put.io [:page_facing_up:](https://rclone.org/webdav/#put-io)
   * QingStor [:page_facing_up:](https://rclone.org/qingstor/)
   * Rackspace Cloud Files [:page_facing_up:](https://rclone.org/swift/)
+  * Scaleway [:page_facing_up:](https://rclone.org/s3/#scaleway)
   * SFTP [:page_facing_up:](https://rclone.org/sftp/)
   * Wasabi [:page_facing_up:](https://rclone.org/s3/#wasabi)
   * WebDAV [:page_facing_up:](https://rclone.org/webdav/)

--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -44,6 +44,7 @@ Rclone is a command line program to sync files and directories to and from:
 * {{< provider name="put.io" home="https://put.io/" config="/webdav/#put-io" >}}
 * {{< provider name="QingStor" home="https://www.qingcloud.com/products/storage" config="/qingstor/" >}}
 * {{< provider name="Rackspace Cloud Files" home="https://www.rackspace.com/cloud/files" config="/swift/" >}}
+* {{< provider name="Scaleway" home="https://www.scaleway.com/object-storage/" config="/s3/#scaleway" >}}
 * {{< provider name="SFTP" home="https://en.wikipedia.org/wiki/SFTP" config="/sftp/" >}}
 * {{< provider name="Wasabi" home="https://wasabi.com/" config="/s3/#wasabi" >}}
 * {{< provider name="WebDAV" home="https://en.wikipedia.org/wiki/WebDAV" config="/webdav/" >}}

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -1413,6 +1413,28 @@ So once set up, for example to copy files into a bucket
 rclone copy /path/to/files minio:bucket
 ```
 
+### Scaleway {#scaleway}
+
+[Scaleway](https://www.scaleway.com/object-storage/) The Object Storage platform allows you to store anything from backups, logs and web assets to documents and photos.
+Files can be dropped from the Scaleway console or transferred through our API and CLI or using any S3-compatible tool.
+
+Scaleway provides an S3 interface which can be configured for use with rclone like this:
+
+```
+[scaleway]
+type = s3
+env_auth = false
+endpoint = s3.nl-ams.scw.cloud
+access_key_id = SCWXXXXXXXXXXXXXX
+secret_access_key = 1111111-2222-3333-44444-55555555555555
+region = nl-ams
+location_constraint =
+acl = private
+force_path_style = false
+server_side_encryption =
+storage_class =
+```
+
 ### Wasabi ###
 
 [Wasabi](https://wasabi.com) is a cloud-based object storage service for a


### PR DESCRIPTION
#### What is the purpose of this change?

Scaleway is offering a S3 compatible product. The goal of this PR is to inform rclone users that they can use Scaleway object storage with rclone.