### PR TITLE
fix typo in rcd docs

### DIFF
--- a/cmd/rcd/rcd.go
+++ b/cmd/rcd/rcd.go
@@ -17,7 +17,7 @@ var commandDefintion = &cobra.Command{
 	Use:   "rcd <path to files to serve>*",
 	Short: `Run rclone listening to remote control commands only.`,
 	Long: `
-This runs rclone so that it only listents to remote control commands.
+This runs rclone so that it only listens to remote control commands.
 
 This is useful if you are controlling rclone via the rc API.
 


### PR DESCRIPTION
#### What is the purpose of this change?
I was reading the docs and found a typo.

#### Was the change discussed in an issue or in the forum before?
I didn't look for this problem in issues or the forum.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
