### PR TITLE
Refine handling of unknown-sized uploads - #2832

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -227,6 +227,10 @@ type Fs interface {
 
 	// Put in to the remote path with the modTime given of the given size
 	//
+	// When called from outside a Fs by rclone, src.Size() will always be >= 0.
+	// But for unknown-sized objects (indicated by src.Size() == -1), Put should either
+	// return an error or upload it properly (rather than e.g. calling panic).
+	//
 	// May create the object even if it returns an error - if so
 	// will return the object and the error, otherwise will return
 	// nil and the error
@@ -275,6 +279,10 @@ type Object interface {
 	Open(options ...OpenOption) (io.ReadCloser, error)
 
 	// Update in to the object with the modTime given of the given size
+	//
+	// When called from outside a Fs by rclone, src.Size() will always be >= 0.
+	// But for unknown-sized objects (indicated by src.Size() == -1), Upload should either
+	// return an error or update the object properly (rather than e.g. calling panic).
 	Update(in io.Reader, src ObjectInfo, options ...OpenOption) error
 
 	// Removes this object

--- a/fs/rc/config.go
+++ b/fs/rc/config.go
@@ -74,6 +74,20 @@ Repeated as often as required.
 Only supply the options you wish to change.  If an option is unknown
 it will be silently ignored.  Not all options will have an effect when
 changed like this.
+
+For example:
+
+This sets DEBUG level logs (-vv)
+
+    rclone rc options/set --json '{"main": {"LogLevel": 8}}'
+
+And this sets INFO level logs (-v)
+
+    rclone rc options/set --json '{"main": {"LogLevel": 7}}'
+
+And this sets NOTICE level logs (normal without -v)
+
+    rclone rc options/set --json '{"main": {"LogLevel": 6}}'
 `,
 	})
 }

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -1407,6 +1407,53 @@ func Run(t *testing.T, opt *Opt) {
 
 		})
 
+		// TestFsUploadUnknownSize ensures Fs.Put() and Object.Update() don't panic when
+		// src.Size() == -1
+		t.Run("FsUploadUnknownSize", func(t *testing.T) {
+			skipIfNotOk(t)
+
+			t.Run("FsPutUnknownSize", func(t *testing.T) {
+				defer func() {
+					assert.Nil(t, recover(), "Fs.Put() should not panic when src.Size() == -1")
+				}()
+
+				contents := fstest.RandomString(100)
+				in := bytes.NewBufferString(contents)
+
+				obji := object.NewStaticObjectInfo("unknown-size-put.txt", fstest.Time("2002-02-03T04:05:06.499999999Z"), -1, true, nil, nil)
+				obj, err := remote.Put(in, obji)
+				if err == nil {
+					require.NoError(t, obj.Remove(), "successfully uploaded unknown-sized file but failed to remove")
+				}
+				// if err != nil: it's okay as long as no panic
+			})
+
+			t.Run("FsUpdateUnknownSize", func(t *testing.T) {
+				unknownSizeUpdateFile := fstest.Item{
+					ModTime: fstest.Time("2002-02-03T04:05:06.499999999Z"),
+					Path:    "unknown-size-update.txt",
+				}
+
+				testPut(t, remote, &unknownSizeUpdateFile)
+
+				defer func() {
+					assert.Nil(t, recover(), "Object.Update() should not panic when src.Size() == -1")
+				}()
+
+				newContents := fstest.RandomString(200)
+				in := bytes.NewBufferString(newContents)
+
+				obj := findObject(t, remote, unknownSizeUpdateFile.Path)
+				obji := object.NewStaticObjectInfo(unknownSizeUpdateFile.Path, unknownSizeUpdateFile.ModTime, -1, true, nil, obj.Fs())
+				err := obj.Update(in, obji)
+				if err == nil {
+					require.NoError(t, obj.Remove(), "successfully updated object with unknown-sized source but failed to remove")
+				}
+				// if err != nil: it's okay as long as no panic
+			})
+
+		})
+
 		// Purge the folder
 		err = operations.Purge(remote, "")
 		require.NoError(t, err)


### PR DESCRIPTION
This PR implements the changes disscussed in https://github.com/ncw/rclone/issues/2832#issuecomment-451862366. It:
- Makes clear in docs that `Put` and `Update` won't be called from outside a backend with a size < 0
- Makes `operations.Copy` call `operations.Rcat` if the input size is -1 which will buffer it on disk if necessary or use PutStream if available
- Ensures in the tests that `Fs.Put()` and `Object.Update()` don't panic when `src.Size() == -1`.