### PR TITLE
Add aws endpoint eu-north-1

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -132,6 +132,9 @@ func init() {
 				Value: "eu-west-2",
 				Help:  "EU (London) Region\nNeeds location constraint eu-west-2.",
 			}, {
+				Value: "eu-north-1",
+				Help:  "EU (Stockholm) Region\nNeeds location constraint eu-north-1.",
+			}, {
 				Value: "eu-central-1",
 				Help:  "EU (Frankfurt) Region\nNeeds location constraint eu-central-1.",
 			}, {
@@ -392,6 +395,9 @@ func init() {
 			}, {
 				Value: "eu-west-2",
 				Help:  "EU (London) Region.",
+			}, {
+				Value: "eu-north-1",
+				Help:  "EU (Stockholm) Region.",
 			}, {
 				Value: "EU",
 				Help:  "EU Region.",

--- a/cmd/listremotes/listremotes.go
+++ b/cmd/listremotes/listremotes.go
@@ -16,7 +16,7 @@ var (
 
 func init() {
 	cmd.Root.AddCommand(commandDefintion)
-	commandDefintion.Flags().BoolVarP(&listLong, "long", "l", listLong, "Show the type as well as names.")
+	commandDefintion.Flags().BoolVarP(&listLong, "long", "", listLong, "Show the type as well as names.")
 }
 
 var commandDefintion = &cobra.Command{

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -22,6 +22,7 @@ const (
 	ApSoutheast2RegionID = "ap-southeast-2" // Asia Pacific (Sydney).
 	CaCentral1RegionID   = "ca-central-1"   // Canada (Central).
 	EuCentral1RegionID   = "eu-central-1"   // EU (Frankfurt).
+	EuNorth1RegionID     = "eu-north-1"     // EU (Stockholm).
 	EuWest1RegionID      = "eu-west-1"      // EU (Ireland).
 	EuWest2RegionID      = "eu-west-2"      // EU (London).
 	EuWest3RegionID      = "eu-west-3"      // EU (Paris).

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -22670,6 +22670,9 @@ const (
 
 	// BucketLocationConstraintEuCentral1 is a BucketLocationConstraint enum value
 	BucketLocationConstraintEuCentral1 = "eu-central-1"
+
+	// BucketLocationConstraintEuNorth1 is a BucketLocationConstraint enum value
+	BucketLocationConstraintEuNorth1 = "eu-north-1"
 )
 
 const (


### PR DESCRIPTION
#### What is the purpose of this change?

Add the new eu-north-1 endpoint for aws.

#### Was the change discussed in an issue or in the forum before?

ncw requested a pull request.
https://forum.rclone.org/t/support-aws-s3-eu-north-1-by-updating-aws-sdk-go/8060

#### Question

Apparently the listremotes command does not work in the latest version of rclone.
I dropped the "l" shortcut that apparent conflicted with another shortcut.
I do not know if this is the right solution.