### PR TITLE
drive: improve handling of items with multiple parents

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -2199,11 +2199,13 @@ func (f *Fs) changeNotifyRunner(notifyFunc func(string, fs.EntryType), startPage
 
 				// translate the parent dir of this object
 				if len(change.File.Parents) > 0 {
-					if parentPath, ok := f.dirCache.GetInv(change.File.Parents[0]); ok {
-						// and append the drive file name to compute the full file name
-						newPath := path.Join(parentPath, change.File.Name)
-						// this will now clear the actual file too
-						pathsToClear = append(pathsToClear, entryType{path: newPath, entryType: changeType})
+					for _, parent := range change.File.Parents {
+						if parentPath, ok := f.dirCache.GetInv(parent); ok {
+							// and append the drive file name to compute the full file name
+							newPath := path.Join(parentPath, change.File.Name)
+							// this will now clear the actual file too
+							pathsToClear = append(pathsToClear, entryType{path: newPath, entryType: changeType})
+						}
 					}
 				} else { // a true root object that is changed
 					pathsToClear = append(pathsToClear, entryType{path: change.File.Name, entryType: changeType})


### PR DESCRIPTION
#### What is the purpose of this change?

This change fixes the issue discovered in [#2946](https://github.com/ncw/rclone/issues/2946#issuecomment-461435150).
It has the drawback, that folders with multiple parents will be scanned multiple times (once per parent) during `ListR`.

This also improves `ChangeNotify` for items with multiple parents.

#### Was the change discussed in an issue or in the forum before?

#2946

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
