### PR TITLE
golangci: enable lints excluded by default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,9 @@ linters:
   disable-all: true
 
 issues:
+  # Enable some lints excluded by default
+  exclude-use-default: false
+
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-per-linter: 0
 


### PR DESCRIPTION
#### What is the purpose of this change?

Since the switch to `golangci` some lints enabled before are now skipped.
I especially noticed the following two:
```
Error return value of `dirEntries.Close` is not checked (errcheck)
```
and
```
exported method Fs.List should have comment or be unexported (golint)
```

`golangci` has in integrated list of lints skipped by default for all linters.
This behavior is documented in the [command line help](https://github.com/golangci/golangci-lint#command-line-options) under `--exclude-use-default`.

If the lints are intended to be skipped, feel free to close this, but I think they are useful to rclone, especially the `errcheck` ones.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
