### PR TITLE
cmd: Fix tab-completion for remotes with underscores in their names

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -45,7 +45,7 @@ __rclone_custom_func() {
         else
             __rclone_init_completion -n : || return
         fi
-        if [[ $cur =~ ^[[:alnum:]]*$ ]]; then
+        if [[ $cur =~ ^[[:alnum:]_]*$ ]]; then
             local remote
             while IFS= read -r remote; do
                 [[ $remote != $cur* ]] || COMPREPLY+=("$remote")
@@ -54,7 +54,7 @@ __rclone_custom_func() {
                 local paths=("$cur"*)
                 [[ ! -f ${paths[0]} ]] || COMPREPLY+=("${paths[@]}")
             fi
-        elif [[ $cur =~ ^[[:alnum:]]+: ]]; then
+        elif [[ $cur =~ ^[[:alnum:]_]+: ]]; then
             local path=${cur#*:}
             if [[ $path == */* ]]; then
                 local prefix=${path%/*}


### PR DESCRIPTION
#### What is the purpose of this change?

Rclone's Bash completion script is currently unable to tab-complete remotes that have underscores in their names (e.g. `Dropbox_Alternate1:`). This change is intended to fix that issue.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
