### PR TITLE
 Add ServerSideAcrossConfig Flag and check for it

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -902,6 +902,7 @@ func NewFs(name, path string, m configmap.Mapper) (fs.Fs, error) {
 		ReadMimeType:            true,
 		WriteMimeType:           true,
 		CanHaveEmptyDirectories: true,
+		ServerSideAcrossConfigs: true,
 	}).Fill(f)
 
 	// Create a new authorized Drive client.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -409,6 +409,7 @@ type Features struct {
 	BucketBased             bool // is bucket based (like s3, swift etc)
 	SetTier                 bool // allows set tier functionality on objects
 	GetTier                 bool // allows to retrieve storage tier of objects
+	ServerSideAcrossConfigs bool // can server side copy between different remotes of the same type
 
 	// Purge all files in the root and the root directory
 	//


### PR DESCRIPTION
#### What is the purpose of this change?
Add a fs.Feature to display that the remote can copy between configs and add a check for this


#### Was the change discussed in an issue or in the forum before?
https://github.com/ncw/rclone/issues/2728

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)