### PR TITLE
support --no-check-certificate on copyurl command

### DIFF
--- a/fs/fshttp/http.go
+++ b/fs/fshttp/http.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	transport    http.RoundTripper
-	noTransport  sync.Once
+	noTransport  = new(sync.Once)
 	tpsBucket    *rate.Limiter // for limiting number of http transactions per second
 	cookieJar, _ = cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 )
@@ -121,9 +121,15 @@ func dialContextTimeout(ctx context.Context, network, address string, ci *fs.Con
 	return newTimeoutConn(c, ci.Timeout)
 }
 
+// ResetTransport resets the existing transport, allowing it to take new settings.
+// Should only be used for testing.
+func ResetTransport() {
+	noTransport = new(sync.Once)
+}
+
 // NewTransport returns an http.RoundTripper with the correct timeouts
 func NewTransport(ci *fs.ConfigInfo) http.RoundTripper {
-	noTransport.Do(func() {
+	(*noTransport).Do(func() {
 		// Start with a sensible set of defaults then override.
 		// This also means we get new stuff when it gets added to go
 		t := new(http.Transport)

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"path"
 	"path/filepath"
 	"sort"
@@ -21,6 +20,7 @@ import (
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fs/accounting"
 	"github.com/ncw/rclone/fs/fserrors"
+	"github.com/ncw/rclone/fs/fshttp"
 	"github.com/ncw/rclone/fs/hash"
 	"github.com/ncw/rclone/fs/march"
 	"github.com/ncw/rclone/fs/object"
@@ -1399,7 +1399,9 @@ func RcatSize(fdst fs.Fs, dstFileName string, in io.ReadCloser, size int64, modT
 
 // CopyURL copies the data from the url to (fdst, dstFileName)
 func CopyURL(fdst fs.Fs, dstFileName string, url string) (dst fs.Object, err error) {
-	resp, err := http.Get(url)
+	client := fshttp.NewClient(fs.Config)
+	resp, err := client.Get(url)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

rclone will currently always fail when copying a file via `rclone copyurl <url> <remote>`. `--no-check-certificate` exists, but is only used for http fs as far as I can tell. This patch extends the usage to `copyurl` as well, so that `rclone copyurl --no-check-certificate <url> <remote>` will allow to copy from broken servers. 

#### Was the change discussed in an issue or in the forum before?

Not that I am aware.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
