### PR TITLE
s3: Add support for Glacier Deep Archive and Intelligent-Tiering

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -653,6 +653,9 @@ isn't set then "acl" is used instead.`,
 			}, {
 				Value: "DEEP_ARCHIVE",
 				Help:  "Glacier Deep Archive storage class",
+			}, {
+				Value: "INTELLIGENT_TIERING",
+				Help:  "Intelligent-Tiering storage class",
 			}},
 		}, {
 			// Mapping from here: https://www.alibabacloud.com/help/doc-detail/64919.htm

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -222,6 +222,8 @@ Choose a number from below, or type in your own value
    \ "GLACIER"
  7 / Glacier Deep Archive storage class
    \ "DEEP_ARCHIVE"
+ 8 / Intelligent-Tiering storage class
+   \ "INTELLIGENT_TIERING"
 storage_class> 1
 Remote config
 --------------------
@@ -930,6 +932,8 @@ The storage class to use when storing new objects in S3.
         - Glacier storage class
     - "DEEP_ARCHIVE"
         - Glacier Deep Archive storage class
+    - "INTELLIGENT_TIERING"
+        - Intelligent-Tiering storage class
 
 #### --s3-storage-class
 


### PR DESCRIPTION
#### What is the purpose of this change?

Support for AWS S3 storage classes that currently aren't supported.

#### Was the change discussed in an issue or in the forum before?

#3088 mentions Glacier Deep Archive. Intelligent-Tiering hasn't been discussed as far as I can tell, but it seems like a no-brainer to support all possible storage classes.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate. (`GLACIER` didn't come with tests so I figured this doesn't need any either, but I tested `DEEP_ARCHIVE` manually since I actually wanted to use it, and it works with these changes.)
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)