### PR TITLE
s3: add support for "Glacier Deep Archive" storage class - fixes #3088

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -645,6 +645,9 @@ isn't set then "acl" is used instead.`,
 			}, {
 				Value: "GLACIER",
 				Help:  "Glacier storage class",
+			}, {
+				Value: "DEEP_ARCHIVE",
+				Help:  "Glacier Deep Archive storage class",
 			}},
 		}, {
 			// Mapping from here: https://www.alibabacloud.com/help/doc-detail/64919.htm

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -220,6 +220,8 @@ Choose a number from below, or type in your own value
    \ "ONEZONE_IA"
  6 / Glacier storage class
    \ "GLACIER"
+ 7 / Glacier Deep Archive storage class
+   \ "DEEP_ARCHIVE"
 storage_class> 1
 Remote config
 --------------------
@@ -387,7 +389,7 @@ you can't transfer small objects.  As a work-around you can use the
 
 A proper fix is being worked on in [issue #1824](https://github.com/ncw/rclone/issues/1824).
 
-### Glacier ###
+### Glacier and Glacier Deep Archive ###
 
 You can upload objects using the glacier storage class or transition them to glacier using a [lifecycle policy](http://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-lifecycle.html).
 The bucket can still be synced or copied into normally, but if rclone


### PR DESCRIPTION
#### What is the purpose of this change?
Add new AWS S3 storage class `DEEP_ARCHIVE`.

#### Was the change discussed in an issue or in the forum before?
Issue #3088 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
