### PR TITLE
added files-only and dirs-only to lsjson

### DIFF
--- a/cmd/lsf/lsf.go
+++ b/cmd/lsf/lsf.go
@@ -164,6 +164,8 @@ func Lsf(fsrc fs.Fs, out io.Writer) error {
 	list.SetAbsolute(absolute)
 	var opt = operations.ListJSONOpt{
 		NoModTime: true,
+		DirsOnly:  dirsOnly,
+		FilesOnly: filesOnly,
 		Recurse:   recurse,
 	}
 
@@ -195,15 +197,6 @@ func Lsf(fsrc fs.Fs, out io.Writer) error {
 	}
 
 	return operations.ListJSON(fsrc, "", &opt, func(item *operations.ListJSONItem) error {
-		if item.IsDir {
-			if filesOnly {
-				return nil
-			}
-		} else {
-			if dirsOnly {
-				return nil
-			}
-		}
 		_, _ = fmt.Fprintln(out, list.Format(item))
 		return nil
 	})

--- a/cmd/lsjson/lsjson.go
+++ b/cmd/lsjson/lsjson.go
@@ -23,6 +23,8 @@ func init() {
 	commandDefintion.Flags().BoolVarP(&opt.NoModTime, "no-modtime", "", false, "Don't read the modification time (can speed things up).")
 	commandDefintion.Flags().BoolVarP(&opt.ShowEncrypted, "encrypted", "M", false, "Show the encrypted names.")
 	commandDefintion.Flags().BoolVarP(&opt.ShowOrigIDs, "original", "", false, "Show the ID of the underlying Object.")
+	commandDefintion.Flags().BoolVarP(&opt.FilesOnly, "files-only", "", false, "Show only files in the listing.")
+	commandDefintion.Flags().BoolVarP(&opt.DirsOnly, "dirs-only", "", false, "Show only directories in the listing.")
 }
 
 var commandDefintion = &cobra.Command{
@@ -54,6 +56,10 @@ If --hash is not specified the Hashes property won't be emitted.
 If --no-modtime is specified then ModTime will be blank.
 
 If --encrypted is not specified the Encrypted won't be emitted.
+
+If --dirs-only is not specified files in addition to directories are returned
+
+If --files-only is not specified directories in addition to the files will be returned.
 
 The Path field will only show folders below the remote path being listed.
 If "remote:path" contains the file "subfolder/file.txt", the Path for "file.txt"


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
This:
-  change adds a dirs-only and files-only option to lsjson. 
- updates lsf to use the new options.

Fixes #3090
-->

#### Was the change discussed in an issue or in the forum before?

<!--
https://github.com/ncw/rclone/issues/3090
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
