### PR TITLE
test: Add a matrix run for 0.11.x to run in a single cpu mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ addons:
       - libfuse-dev
       - rpm
       - pkg-config
+      - util-linux  # for taskset
 cache:
   directories:
     - $HOME/.cache/go-build
@@ -61,6 +62,9 @@ matrix:
     - go: 1.11.x
       script:
         - make quicktest
+    - go: 1.11.x
+      script:
+        - taskset -c 0 make quicktest  # 1 CPU machine
     - go: 1.12.x
       env:
         - GOTAGS=cmount

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
         - make quicktest
     - go: 1.11.x
       script:
-        - taskset -c 0 make quicktest  # 1 CPU machine
+        - taskset -c 0 make test  # 1 CPU machine
     - go: 1.12.x
       env:
         - GOTAGS=cmount


### PR DESCRIPTION
We are troubleshooting the rclone build failing on Debian machines because
a test (TestMount/CacheMode=off/TestTouchAndDelete) getting stuck.  This commit
is primarily to check if similar failure gets triggered "upstream"

<details>
<summary>May be of some utility -- here is a tracebacks I saw when (I think, sorry -- too much is going on in parallel) I tried to interrupt that build (Ctrl-C)</summary>

```
=== RUN   TestMount/CacheMode=off/TestTouchAndDelete

SIGQUIT: quit
PC=0x45ff31 m=0 sigcode=0

goroutine 5 [syscall]:
runtime.notetsleepg(0x1a0d0a0, 0xffffffffffffffff, 0x4012f0)
	/usr/lib/go-1.11/src/runtime/lock_futex.go:227 +0x37 fp=0xc00005c788 sp=0xc00005c758 pc=0x40cb27
os/signal.signal_recv(0x0)
	/usr/lib/go-1.11/src/runtime/sigqueue.go:139 +0x9c fp=0xc00005c7b0 sp=0xc00005c788 pc=0x444c5c
os/signal.loop()
	/usr/lib/go-1.11/src/os/signal/signal_unix.go:23 +0x22 fp=0xc00005c7e0 sp=0xc00005c7b0 pc=0x5e8dc2
runtime.goexit()
	/usr/lib/go-1.11/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc00005c7e8 sp=0xc00005c7e0 pc=0x45e0e1
created by os/signal.init.0
	/usr/lib/go-1.11/src/os/signal/signal_unix.go:29 +0x41

goroutine 1 [chan receive]:
testing.(*T).Run(0xc00011ad00, 0x1091e1f, 0x9, 0x10e54b0, 0x4838a6)
	/usr/lib/go-1.11/src/testing/testing.go:879 +0x383
testing.runTests.func1(0xc00011ac00)
	/usr/lib/go-1.11/src/testing/testing.go:1119 +0x78
testing.tRunner(0xc00011ac00, 0xc0002a9e08)
	/usr/lib/go-1.11/src/testing/testing.go:827 +0xbf
testing.runTests(0xc000284c60, 0x19db6f0, 0x1, 0x1, 0x40daff)
	/usr/lib/go-1.11/src/testing/testing.go:1117 +0x2aa
testing.(*M).Run(0xc000110f80, 0x0)
	/usr/lib/go-1.11/src/testing/testing.go:1034 +0x165
main.main()
	_testmain.go:42 +0x13d

goroutine 14 [running]:
	goroutine running on other thread; stack unavailable
created by testing.(*T).Run
	/usr/lib/go-1.11/src/testing/testing.go:878 +0x35c

goroutine 13 [chan receive]:
testing.(*T).Run(0xc00011b000, 0x109be29, 0x12, 0x10e5568, 0x757f14)
	/usr/lib/go-1.11/src/testing/testing.go:879 +0x383
github.com/ncw/rclone/cmd/mountlib/mounttest.RunTests.func1(0xc00011af00)
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/github.com/ncw/rclone/cmd/mountlib/mounttest/fs.go:55 +0x50
testing.tRunner(0xc00011af00, 0x10e54d0)
	/usr/lib/go-1.11/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/lib/go-1.11/src/testing/testing.go:878 +0x35c

goroutine 8 [chan receive]:
testing.(*T).Run(0xc00011af00, 0xc0002b0dd0, 0xd, 0x10e54d0, 0x1)
	/usr/lib/go-1.11/src/testing/testing.go:879 +0x383
github.com/ncw/rclone/cmd/mountlib/mounttest.RunTests(0xc00011ad00, 0x10e54c0)
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/github.com/ncw/rclone/cmd/mountlib/mounttest/fs.go:54 +0x199
github.com/ncw/rclone/cmd/mount.TestMount(0xc00011ad00)
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/github.com/ncw/rclone/cmd/mount/mount_test.go:12 +0x37
testing.tRunner(0xc00011ad00, 0x10e54b0)
	/usr/lib/go-1.11/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/lib/go-1.11/src/testing/testing.go:878 +0x35c

goroutine 11 [runnable]:
syscall.Syscall(0x0, 0x8, 0xc00034e000, 0x21000, 0x40, 0x21000, 0x0)
	/usr/lib/go-1.11/src/syscall/asm_linux_amd64.s:18 +0x5
syscall.read(0x8, 0xc00034e000, 0x21000, 0x21000, 0x5c76cf, 0xc0001a97d8, 0x8)
	/usr/lib/go-1.11/src/syscall/zsyscall_linux_amd64.go:732 +0x5a
syscall.Read(0x8, 0xc00034e000, 0x21000, 0x21000, 0xc0002b0f50, 0x7, 0x0)
	/usr/lib/go-1.11/src/syscall/syscall_unix.go:172 +0x49
bazil.org/fuse.(*Conn).ReadRequest(0xc000226b40, 0x10e46f8, 0xc0001183c0, 0x11ebe20, 0xc0000b5bd0)
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/bazil.org/fuse/fuse.go:552 +0xb1
bazil.org/fuse/fs.(*Server).Serve(0xc0001183c0, 0x11e3360, 0xc0002850e0, 0x0, 0x0)
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/bazil.org/fuse/fs/serve.go:414 +0x332
github.com/ncw/rclone/cmd/mount.mount.func1(0xc0001183c0, 0xc0002850e0, 0xc000226b40, 0xc000226f60)
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/github.com/ncw/rclone/cmd/mount/mount.go:98 +0x45
created by github.com/ncw/rclone/cmd/mount.mount
	/home/yoh/deb/gits/pkg-exppsy/rclone/obj-x86_64-linux-gnu/src/github.com/ncw/rclone/cmd/mount/mount.go:97 +0x2e2

rax    0xca
rbx    0x19efce0
rcx    0x45ff33
rdx    0x0
rdi    0x1a0d0a0
rsi    0x80
rbp    0xc00005c710
rsp    0xc00005c6c8
r8     0x0
r9     0x0
r10    0x0
r11    0x286
r12    0xffffffffffffffff
r13    0x2
r14    0x1
r15    0x2
rip    0x45ff31
rflags 0x286
cs     0x33
fs     0x0
gs     0x0

^Cmake: *** [debian/rules:16: binary] Error 1
```
</details>