### PR TITLE
moveto: fix case-insensitive same remote move

### DIFF
--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -739,6 +739,41 @@ func TestMoveFile(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2)
 }
 
+func TestCaseInsensitiveMoveFile(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+	if !r.Fremote.Features().CaseInsensitive {
+		return
+	}
+
+	file1 := r.WriteFile("file1", "file1 contents", t1)
+	fstest.CheckItems(t, r.Flocal, file1)
+
+	file2 := file1
+	file2.Path = "sub/file2"
+
+	err := operations.MoveFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.Flocal)
+	fstest.CheckItems(t, r.Fremote, file2)
+
+	r.WriteFile("file1", "file1 contents", t1)
+	fstest.CheckItems(t, r.Flocal, file1)
+
+	err = operations.MoveFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.Flocal)
+	fstest.CheckItems(t, r.Fremote, file2)
+
+	file2Capitalized := file2
+	file2Capitalized.Path = "sub/File2"
+
+	err = operations.MoveFile(r.Fremote, r.Fremote, file2Capitalized.Path, file2.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.Flocal)
+	fstest.CheckItems(t, r.Fremote, file2Capitalized)
+}
+
 func TestMoveFileBackupDir(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()


### PR DESCRIPTION
Fixes #3104

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix a bug where moveto would delete a file when trying to change the case of a name on a remote that is case insensitive.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
#3104 
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
