### PR TITLE
Fix Multipart upload check

### DIFF
--- a/lib/rest/rest.go
+++ b/lib/rest/rest.go
@@ -393,7 +393,7 @@ func (api *Client) callCodec(opts *Opts, request interface{}, response interface
 			opts.Body = bytes.NewBuffer(requestBody)
 		}
 	}
-	isMultipart := (opts.MultipartParams != nil || opts.MultipartMetadataName != "") && opts.Body != nil
+	isMultipart := (opts.MultipartParams != nil || opts.MultipartContentName != "") && opts.Body != nil
 	if isMultipart {
 		params := opts.MultipartParams
 		if params == nil {


### PR DESCRIPTION

#### What is the purpose of this change?
In the Documentation it states:
// If (opts.MultipartParams or opts.MultipartContentName) and
// opts.Body are set then CallJSON will do a multipart upload with a
// file attached.

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
