### PR TITLE
Adds a public IP flag for ftp.  Closes #3158

### DIFF
--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -78,6 +78,7 @@ func newServer(f fs.Fs, opt *ftpopt.Options) (*server, error) {
 		},
 		Hostname:     host,
 		Port:         portNum,
+		PublicIp:     opt.PublicIP,
 		PassivePorts: opt.PassivePorts,
 		Auth: &Auth{
 			BasicUser: opt.BasicUser,

--- a/cmd/serve/ftp/ftpflags/ftpflags.go
+++ b/cmd/serve/ftp/ftpflags/ftpflags.go
@@ -16,6 +16,7 @@ var (
 func AddFlagsPrefix(flagSet *pflag.FlagSet, prefix string, Opt *ftpopt.Options) {
 	rc.AddOption("ftp", &Opt)
 	flags.StringVarP(flagSet, &Opt.ListenAddr, prefix+"addr", "", Opt.ListenAddr, "IPaddress:Port or :Port to bind server to.")
+	flags.StringVarP(flagSet, &Opt.PublicIP, prefix+"public-ip", "", Opt.PublicIP, "Public IP address to advertise for passive connections.")
 	flags.StringVarP(flagSet, &Opt.PassivePorts, prefix+"passive-port", "", Opt.PassivePorts, "Passive port range to use.")
 	flags.StringVarP(flagSet, &Opt.BasicUser, prefix+"user", "", Opt.BasicUser, "User name for authentication.")
 	flags.StringVarP(flagSet, &Opt.BasicPass, prefix+"pass", "", Opt.BasicPass, "Password for authentication. (empty value allow every password)")

--- a/cmd/serve/ftp/ftpopt/ftp_options.go
+++ b/cmd/serve/ftp/ftpopt/ftp_options.go
@@ -24,6 +24,7 @@ You can set a single username and password with the --user and --pass flags.
 type Options struct {
 	//TODO add more options
 	ListenAddr   string // Port to listen on
+	PublicIP     string // Passive ports range
 	PassivePorts string // Passive ports range
 	BasicUser    string // single username for basic auth if not using Htpasswd
 	BasicPass    string // password for BasicUser
@@ -32,6 +33,7 @@ type Options struct {
 // DefaultOpt is the default values used for Options
 var DefaultOpt = Options{
 	ListenAddr:   "localhost:2121",
+	PublicIP:     "",
 	PassivePorts: "30000-32000",
 	BasicUser:    "anonymous",
 	BasicPass:    "",


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
This commit adds a public IP option so is passive mode behind a device, one can specify the public IP.
-->

#### Was the change discussed in an issue or in the forum before?

<!--
https://github.com/ncw/rclone/issues/3158
-->

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ x] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
