### PR TITLE
docs: fix cache default path

### DIFF
--- a/docs/content/cache.md
+++ b/docs/content/cache.md
@@ -420,7 +420,7 @@ The remote name is used as the DB file name.
 - Config:      db_path
 - Env Var:     RCLONE_CACHE_DB_PATH
 - Type:        string
-- Default:     "/home/ncw/.cache/rclone/cache-backend"
+- Default:     "/tmp/rclone/cache-backend"
 
 #### --cache-chunk-path
 
@@ -436,7 +436,7 @@ then "--cache-chunk-path" will use the same path as "--cache-db-path".
 - Config:      chunk_path
 - Env Var:     RCLONE_CACHE_CHUNK_PATH
 - Type:        string
-- Default:     "/home/ncw/.cache/rclone/cache-backend"
+- Default:     "/tmp/rclone/cache-backend"
 
 #### --cache-db-purge
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixing the documentation for cache to specify the current default cache directory.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
