### PR TITLE
install: linux skip man pages if no mandb - fixes #3175

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -152,9 +152,13 @@ case $OS in
     chown root:root /usr/bin/rclone.new
     mv /usr/bin/rclone.new /usr/bin/rclone
     #manuals
-    mkdir -p /usr/local/share/man/man1
-    cp rclone.1 /usr/local/share/man/man1/
-    mandb
+    if ! [ -x "$(command -v mandb)" ]; then
+        echo 'mandb not found. The rclone man docs will not be installed.'
+    else 
+        mkdir -p /usr/local/share/man/man1
+        cp rclone.1 /usr/local/share/man/man1/
+        mandb
+    fi
     ;;
   'freebsd'|'openbsd'|'netbsd')
     #bin


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Skip man docs during install if linux mandb is not installed
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
https://github.com/ncw/rclone/issues/3175
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
