### PR TITLE
fs: add --ignore-case-sync for forced case insensitivity - fixes #2773

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -500,6 +500,12 @@ Do a trial run with no permanent changes.  Use this to see what rclone
 would do without actually doing it.  Useful when setting up the `sync`
 command which deletes files in the destination.
 
+### --ignore-case-sync ###
+
+Using this option will cause rclone to ignore the case of the files 
+when synchronizing so files will not be copied/synced when the
+existing filenames are the same, even if the casing is different.
+
 ### --ignore-checksum ###
 
 Normally rclone will check that the checksums of transferred files

--- a/fs/config.go
+++ b/fs/config.go
@@ -62,6 +62,7 @@ type ConfigInfo struct {
 	MaxDepth               int
 	IgnoreSize             bool
 	IgnoreChecksum         bool
+	IgnoreCaseSync         bool
 	NoTraverse             bool
 	NoUpdateModTime        bool
 	DataRateUnit           string

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -64,6 +64,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.IntVarP(flagSet, &fs.Config.MaxDepth, "max-depth", "", fs.Config.MaxDepth, "If set limits the recursion depth to this.")
 	flags.BoolVarP(flagSet, &fs.Config.IgnoreSize, "ignore-size", "", false, "Ignore size when skipping use mod-time or checksum.")
 	flags.BoolVarP(flagSet, &fs.Config.IgnoreChecksum, "ignore-checksum", "", fs.Config.IgnoreChecksum, "Skip post copy check of checksums.")
+	flags.BoolVarP(flagSet, &fs.Config.IgnoreCaseSync, "ignore-case-sync", "", fs.Config.IgnoreCaseSync, "Ignore case when synchronizing")
 	flags.BoolVarP(flagSet, &fs.Config.NoTraverse, "no-traverse", "", fs.Config.NoTraverse, "Don't traverse destination file system on copy.")
 	flags.BoolVarP(flagSet, &fs.Config.NoUpdateModTime, "no-update-modtime", "", fs.Config.NoUpdateModTime, "Don't update destination mod-time if files identical.")
 	flags.StringVarP(flagSet, &fs.Config.BackupDir, "backup-dir", "", fs.Config.BackupDir, "Make backups into hierarchy based in DIR.")

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -58,7 +58,7 @@ func (m *March) init() {
 	//                  | Yes | No  | No                 |
 	//                  | No  | Yes | Yes                |
 	//                  | Yes | Yes | Yes                |
-	if m.Fdst.Features().CaseInsensitive {
+	if m.Fdst.Features().CaseInsensitive || fs.Config.IgnoreCaseSync {
 		m.transforms = append(m.transforms, strings.ToLower)
 	}
 }


### PR DESCRIPTION
#### What is the purpose of this change?
This change adds the ability to prevent the clone/sync of duplicate files for which only the casings differs, regardless if the source/target file-systems have case-sensitive filesystems (e.g. most/all linux systems)

e.g. files "Application A.doc" and "application a.doc" are now treated as the same file if the flag is set.

#### Was the change discussed in an issue or in the forum before?
Issue link: https://github.com/ncw/rclone/issues/2773
Forum link: https://forum.rclone.org/t/copy-sync-how-to-ignore-casing-when-checking-for-duplicates/7715

#### Checklist

- [X ] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X ] I have added tests for all changes in this PR if appropriate.
- [X ] I have added documentation for the changes if appropriate.
- [X ] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X ] I'm done, this Pull Request is ready for review :-)
