### PR TITLE
Docs: Fix Cache Docs Typo

### DIFF
--- a/docs/content/cache.md
+++ b/docs/content/cache.md
@@ -1,4 +1,4 @@
------
+---
 title: "Cache"
 description: "Rclone docs for cache remote"
 date: "2017-09-03"


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Fixes a typo in the cache docs page that causes Hugo not to find the title and description.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
No
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
