### PR TITLE
Distinguish between objects and directories when synchronizing filesystems

### DIFF
--- a/fs/direntries.go
+++ b/fs/direntries.go
@@ -17,12 +17,7 @@ func (ds DirEntries) Swap(i, j int) {
 
 // Less is part of sort.Interface.
 func (ds DirEntries) Less(i, j int) bool {
-	if ds[i].Remote() == ds[j].Remote() {
-		_, idir := ds[i].(*Dir)
-		_, jdir := ds[j].(*Dir)
-		return !idir && jdir
-	}
-	return ds[i].Remote() < ds[j].Remote()
+	return CompareDirEntries(ds[i], ds[j]) < 0
 }
 
 // ForObject runs the function supplied on every object in the entries
@@ -83,4 +78,27 @@ func DirEntryType(d DirEntry) string {
 		return "directory"
 	}
 	return fmt.Sprintf("unknown type %T", d)
+}
+
+// CompareDirEntries returns 1 if a > b, 0 if a == b and -1 if a < b
+func CompareDirEntries(a, b DirEntry) int {
+	switch {
+	case a.Remote() > b.Remote():
+		return 1
+	case a.Remote() < b.Remote():
+		return -1
+	default:
+		// same name
+		typeA := DirEntryType(a)
+		typeB := DirEntryType(b)
+		switch {
+		// object before directory
+		case typeA > typeB:
+			return -1
+		case typeA < typeB:
+			return 1
+		default:
+			return 0
+		}
+	}
 }

--- a/fs/direntries.go
+++ b/fs/direntries.go
@@ -17,6 +17,11 @@ func (ds DirEntries) Swap(i, j int) {
 
 // Less is part of sort.Interface.
 func (ds DirEntries) Less(i, j int) bool {
+	if ds[i].Remote() == ds[j].Remote() {
+		_, idir := ds[i].(*Dir)
+		_, jdir := ds[j].(*Dir)
+		return !idir && jdir
+	}
 	return ds[i].Remote() < ds[j].Remote()
 }
 

--- a/fs/direntries.go
+++ b/fs/direntries.go
@@ -81,24 +81,26 @@ func DirEntryType(d DirEntry) string {
 }
 
 // CompareDirEntries returns 1 if a > b, 0 if a == b and -1 if a < b
+// If two dir entries have the same name, compare their types (directories are before objects)
 func CompareDirEntries(a, b DirEntry) int {
-	switch {
-	case a.Remote() > b.Remote():
+	aName := a.Remote()
+	bName := b.Remote()
+
+	if aName > bName {
 		return 1
-	case a.Remote() < b.Remote():
+	} else if aName < bName {
 		return -1
-	default:
-		// same name
-		typeA := DirEntryType(a)
-		typeB := DirEntryType(b)
-		switch {
-		// object before directory
-		case typeA > typeB:
-			return -1
-		case typeA < typeB:
-			return 1
-		default:
-			return 0
-		}
 	}
+
+	typeA := DirEntryType(a)
+	typeB := DirEntryType(b)
+
+	// same name, compare types
+	if typeA > typeB {
+		return 1
+	} else if typeA < typeB {
+		return -1
+	}
+
+	return 0
 }

--- a/fs/direntries_test.go
+++ b/fs/direntries_test.go
@@ -1,0 +1,97 @@
+package fs
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ncw/rclone/fs/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeObject string
+
+func (o FakeObject) ModTime() time.Time {
+	return time.Now()
+}
+
+func (o FakeObject) String() string {
+	return fmt.Sprintf("FakeObject(%s)", string(o))
+}
+
+func (o FakeObject) Remote() string {
+	return string(o)
+}
+
+func (o FakeObject) Size() int64 {
+	return 0
+}
+
+func (o FakeObject) SetModTime(t time.Time) error {
+	return nil
+}
+
+func (o FakeObject) Open(options ...OpenOption) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (o FakeObject) Update(in io.Reader, src ObjectInfo, options ...OpenOption) error {
+	return nil
+}
+
+func (o FakeObject) Remove() error {
+	return nil
+}
+
+func (o FakeObject) Fs() Info {
+	return nil
+}
+
+func (o FakeObject) Hash(typ hash.Type) (string, error) {
+	return string(o), nil
+}
+
+func (o FakeObject) Storable() bool {
+	return false
+}
+
+type FakeDir string
+
+func (d FakeDir) Items() int64 {
+	return 0
+}
+
+func (d FakeDir) ID() string {
+	return string(d)
+}
+
+func (d FakeDir) Remote() string {
+	return string(d)
+}
+
+func (d FakeDir) String() string {
+	return fmt.Sprintf("FakeDir(%s)", string(d))
+}
+
+func (d FakeDir) ModTime() time.Time {
+	return time.Now()
+}
+
+func (d FakeDir) Size() int64 {
+	return 0
+}
+
+var _ Object = FakeObject("")
+var _ Directory = FakeDir("")
+
+func TestDirEntriesSort(t *testing.T) {
+	a := FakeObject("a")
+	aDir := FakeDir("a")
+	b := FakeObject("b")
+	bDir := FakeDir("b")
+	dirEntries := DirEntries{bDir, b, aDir, a}
+	sort.Sort(dirEntries)
+	assert.Equal(t, DirEntries{a, aDir, b, bDir}, dirEntries)
+}

--- a/fs/direntries_test.go
+++ b/fs/direntries_test.go
@@ -1,97 +1,26 @@
-package fs
+package fs_test
 
 import (
-	"fmt"
-	"io"
 	"sort"
 	"testing"
-	"time"
 
-	"github.com/ncw/rclone/fs/hash"
+	"github.com/ncw/rclone/fs"
+	"github.com/ncw/rclone/fstest/mockdir"
+	"github.com/ncw/rclone/fstest/mockobject"
 	"github.com/stretchr/testify/assert"
 )
 
-type FakeObject string
-
-func (o FakeObject) ModTime() time.Time {
-	return time.Now()
-}
-
-func (o FakeObject) String() string {
-	return fmt.Sprintf("FakeObject(%s)", string(o))
-}
-
-func (o FakeObject) Remote() string {
-	return string(o)
-}
-
-func (o FakeObject) Size() int64 {
-	return 0
-}
-
-func (o FakeObject) SetModTime(t time.Time) error {
-	return nil
-}
-
-func (o FakeObject) Open(options ...OpenOption) (io.ReadCloser, error) {
-	return nil, nil
-}
-
-func (o FakeObject) Update(in io.Reader, src ObjectInfo, options ...OpenOption) error {
-	return nil
-}
-
-func (o FakeObject) Remove() error {
-	return nil
-}
-
-func (o FakeObject) Fs() Info {
-	return nil
-}
-
-func (o FakeObject) Hash(typ hash.Type) (string, error) {
-	return string(o), nil
-}
-
-func (o FakeObject) Storable() bool {
-	return false
-}
-
-type FakeDir string
-
-func (d FakeDir) Items() int64 {
-	return 0
-}
-
-func (d FakeDir) ID() string {
-	return string(d)
-}
-
-func (d FakeDir) Remote() string {
-	return string(d)
-}
-
-func (d FakeDir) String() string {
-	return fmt.Sprintf("FakeDir(%s)", string(d))
-}
-
-func (d FakeDir) ModTime() time.Time {
-	return time.Now()
-}
-
-func (d FakeDir) Size() int64 {
-	return 0
-}
-
-var _ Object = FakeObject("")
-var _ Directory = FakeDir("")
-
 func TestDirEntriesSort(t *testing.T) {
-	a := FakeObject("a")
-	aDir := FakeDir("a")
-	b := FakeObject("b")
-	bDir := FakeDir("b")
-	dirEntries := DirEntries{bDir, b, aDir, a}
-	sort.Sort(dirEntries)
-	assert.Equal(t, DirEntries{a, aDir, b, bDir}, dirEntries)
+	a := mockobject.New("a")
+	aDir := mockdir.New("a")
+	b := mockobject.New("b")
+	bDir := mockdir.New("b")
+	c := mockobject.New("c")
+	cDir := mockdir.New("c")
+	anotherc := mockobject.New("c")
+	dirEntries := fs.DirEntries{bDir, b, aDir, a, c, cDir, anotherc}
+
+	sort.Stable(dirEntries)
+
+	assert.Equal(t, fs.DirEntries{aDir, a, bDir, b, cDir, c, anotherc}, dirEntries)
 }

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -306,13 +306,12 @@ func matchListings(srcListEntries, dstListEntries fs.DirEntries, transforms []ma
 			}
 		}
 		if src != nil && dst != nil {
-			if srcName < dstName {
-				dst = nil
-				iDst-- // retry the dst
-			} else if srcName > dstName {
+			result := fs.CompareDirEntries(src, dst)
+			switch {
+			case result > 0:
 				src = nil
-				iSrc-- // retry the src
-			} else if fs.DirEntryType(src) != fs.DirEntryType(dst) {
+				iSrc--
+			case result < 0:
 				dst = nil
 				iDst--
 			}

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -282,23 +282,25 @@ func matchListings(srcListEntries, dstListEntries fs.DirEntries, transforms []ma
 			break
 		}
 		if src != nil && iSrc > 0 {
-			prev := srcList[iSrc-1].name
-			if srcName == prev {
+			prev := srcList[iSrc-1].entry
+			prevName := srcList[iSrc-1].name
+			if srcName == prevName && fs.DirEntryType(prev) == fs.DirEntryType(src) {
 				fs.Logf(src, "Duplicate %s found in source - ignoring", fs.DirEntryType(src))
 				iDst-- // ignore the src and retry the dst
 				continue
-			} else if srcName < prev {
+			} else if srcName < prevName {
 				// this should never happen since we sort the listings
 				panic("Out of order listing in source")
 			}
 		}
 		if dst != nil && iDst > 0 {
-			prev := dstList[iDst-1].name
-			if dstName == prev {
+			prev := dstList[iDst-1].entry
+			prevName := dstList[iDst-1].name
+			if dstName == prevName && fs.DirEntryType(dst) == fs.DirEntryType(prev) {
 				fs.Logf(dst, "Duplicate %s found in destination - ignoring", fs.DirEntryType(dst))
 				iSrc-- // ignore the dst and retry the src
 				continue
-			} else if dstName < prev {
+			} else if dstName < prevName {
 				// this should never happen since we sort the listings
 				panic("Out of order listing in destination")
 			}
@@ -310,6 +312,9 @@ func matchListings(srcListEntries, dstListEntries fs.DirEntries, transforms []ma
 			} else if srcName > dstName {
 				src = nil
 				iSrc-- // retry the src
+			} else if fs.DirEntryType(src) != fs.DirEntryType(dst) {
+				dst = nil
+				iDst--
 			}
 		}
 		// Debugf(nil, "src = %v, dst = %v", src, dst)

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -213,7 +213,7 @@ func (es matchEntries) Less(i, j int) bool {
 	ei, ej := &es[i], &es[j]
 	if ei.name == ej.name {
 		if ei.leaf == ej.leaf {
-			return ei.entry.Remote() < ej.entry.Remote()
+			return fs.CompareDirEntries(ei.entry, ej.entry) < 0
 		}
 		return ei.leaf < ej.leaf
 	}

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -267,6 +267,7 @@ type matchTransformFn func(name string) string
 func matchListings(srcListEntries, dstListEntries fs.DirEntries, transforms []matchTransformFn) (srcOnly fs.DirEntries, dstOnly fs.DirEntries, matches []matchPair) {
 	srcList := newMatchEntries(srcListEntries, transforms)
 	dstList := newMatchEntries(dstListEntries, transforms)
+
 	for iSrc, iDst := 0, 0; ; iSrc, iDst = iSrc+1, iDst+1 {
 		var src, dst fs.DirEntry
 		var srcName, dstName string
@@ -306,12 +307,14 @@ func matchListings(srcListEntries, dstListEntries fs.DirEntries, transforms []ma
 			}
 		}
 		if src != nil && dst != nil {
-			result := fs.CompareDirEntries(src, dst)
-			switch {
-			case result > 0:
+			// we can't use CompareDirEntries because srcName, dstName could
+			// be different then src.Remote() or dst.Remote()
+			srcType := fs.DirEntryType(src)
+			dstType := fs.DirEntryType(dst)
+			if srcName > dstName || (srcName == dstName && srcType > dstType) {
 				src = nil
 				iSrc--
-			case result < 0:
+			} else if srcName < dstName || (srcName == dstName && srcType < dstType) {
 				dst = nil
 				iDst--
 			}


### PR DESCRIPTION
#### This change allows to synchronize between two bucket based cloud storages that use key/value storage

This change adds sorting by object type to DirEntries sorting. Additionally it distinguishes between objects and directories in matchListings function. By adding this directories with the same name as object name are  distinguished from objects, and can be synchronized. This allows to synchronize files between cloud storages that are key/value stores. For example when the source has the following structure (taken with rclone ls -R --files-only)
```
index
index/test
index/test2
```
previously it couldn't synchronize the `index` file because it had the same name as directory `index/`. After this change the `index` file and `index` directory are distinguished and are not reported as duplicates. This could be a problem when you are synchronizing the files from Key/Value storage to local filesystem, because it doesn't support duplicate directory entries, and right now it reports the error about it. 

#### Was the change discussed in an issue or in the forum before?
The relevant discussion is here
https://forum.rclone.org/t/problem-when-cloning-one-cloud-storage-to-another-cloud-storage/10146/5

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
