### PR TITLE
drive: add --drive-size-as-quota to show storage quota usage for file…

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -368,6 +368,14 @@ will download it anyway.`,
 			Help:     "Keep new head revision of each file forever.",
 			Advanced: true,
 		}, {
+			Name:    "size_as_quota",
+			Default: false,
+			Help: `Show storage quota usage for file size.
+
+The storage used by a file is the size of the current version plus any
+older versions that have been set to keep forever.`,
+			Advanced: true,
+		}, {
 			Name:     "v2_download_min_size",
 			Default:  fs.SizeSuffix(-1),
 			Help:     "If Object's are greater, use drive v2 API to download.",
@@ -424,6 +432,7 @@ type Options struct {
 	ChunkSize                 fs.SizeSuffix `config:"chunk_size"`
 	AcknowledgeAbuse          bool          `config:"acknowledge_abuse"`
 	KeepRevisionForever       bool          `config:"keep_revision_forever"`
+	SizeAsQuota               bool          `config:"size_as_quota"`
 	V2DownloadMinSize         fs.SizeSuffix `config:"v2_download_min_size"`
 	PacerMinSleep             fs.Duration   `config:"pacer_min_sleep"`
 	PacerBurst                int           `config:"pacer_burst"`
@@ -631,6 +640,9 @@ func (f *Fs) list(dirIDs []string, title string, directoriesOnly, filesOnly, inc
 	}
 	if f.opt.SkipChecksumGphotos {
 		fields += ",spaces"
+	}
+	if f.opt.SizeAsQuota {
+		fields += ",quotaBytesUsed"
 	}
 
 	fields = fmt.Sprintf("files(%s),nextPageToken", fields)
@@ -1007,13 +1019,17 @@ func (f *Fs) newBaseObject(remote string, info *drive.File) baseObject {
 	if f.opt.UseCreatedDate {
 		modifiedDate = info.CreatedTime
 	}
+	size := info.Size
+	if f.opt.SizeAsQuota {
+		size = info.QuotaBytesUsed
+	}
 	return baseObject{
 		fs:           f,
 		remote:       remote,
 		id:           info.Id,
 		modifiedDate: modifiedDate,
 		mimeType:     info.MimeType,
-		bytes:        info.Size,
+		bytes:        size,
 	}
 }
 

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -960,7 +960,10 @@ func HashLister(ht hash.Type, f fs.Fs, w io.Writer) error {
 func Count(f fs.Fs) (objects int64, size int64, err error) {
 	err = ListFn(f, func(o fs.Object) {
 		atomic.AddInt64(&objects, 1)
-		atomic.AddInt64(&size, o.Size())
+		objectSize := o.Size()
+		if objectSize > 0 {
+			atomic.AddInt64(&size, objectSize)
+		}
 	})
 	return
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Add --drive-size-as-quota to show storage quota usage for file size.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
Fixes #3135

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
