### PR TITLE
Fix #3164 Onedrive skips files; add FsRootCollapse test

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -385,9 +385,19 @@ func (f *Fs) readMetaDataForPath(path string) (info *api.Item, resp *http.Respon
 	var dirCacheFoundRoot bool
 	var rootNormalizedID string
 	if f.dirCache != nil {
-		var ok bool
-		if rootNormalizedID, ok = f.dirCache.Get(""); ok {
-			dirCacheFoundRoot = true
+		var dirCacheRootIDExists bool
+		rootNormalizedID, dirCacheRootIDExists = f.dirCache.Get("")
+		if f.root == "" {
+			// if f.root == "", it means f.root is the absolute root of the drive
+			// and its ID should have been found in NewFs
+			dirCacheFoundRoot = dirCacheRootIDExists
+		} else if _, err := f.dirCache.RootParentID(); err == nil {
+			// if root is in a folder, it must have a parent folder, and
+			// if dirCache has found root in NewFs, the parent folder's ID
+			// should be present.
+			// This RootParentID() check is a fix for #3164 which describes
+			// a possible case where the root is not found.
+			dirCacheFoundRoot = dirCacheRootIDExists
 		}
 	}
 

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -1583,6 +1583,27 @@ func Run(t *testing.T, opt *Opt) {
 
 		})
 
+		// TestFsRootCollapse tests if the root of an fs "collapses" to the
+		// absolute root. It creates a new fs of the same backend type with its
+		// root set to a *non-existent* folder, and attempts to read the info of
+		// an object in that folder, whose name is taken from a directory that
+		// exists in the absolute root.
+		// This test is added after
+		// https://github.com/ncw/rclone/issues/3164.
+		t.Run("FsRootCollapse", func(t *testing.T) {
+			deepRemoteName := subRemoteName + "/deeper/nonexisting/directory"
+			deepRemote, err := fs.NewFs(deepRemoteName)
+			require.NoError(t, err)
+
+			colonIndex := strings.IndexRune(deepRemoteName, ':')
+			firstSlashIndex := strings.IndexRune(deepRemoteName, '/')
+			firstDir := deepRemoteName[colonIndex+1 : firstSlashIndex]
+			_, err = deepRemote.NewObject(firstDir)
+			require.Equal(t, fs.ErrorObjectNotFound, err)
+			// If err is not fs.ErrorObjectNotFound, it means the backend is
+			// somehow confused about root and absolute root.
+		})
+
 		// Purge the folder
 		err = operations.Purge(remote, "")
 		require.NoError(t, err)


### PR DESCRIPTION
#### What is the purpose of this change?

This PR fixes #3164, and also adds a unit test to prevent similar failures in the future.

#### Was the change discussed in an issue or in the forum before?

The changes have been discussed and explained in https://github.com/ncw/rclone/issues/3164.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
