### PR TITLE
Use rclone.conf from rclone executable directory if already existing

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -452,7 +452,11 @@ Specify the location of the rclone config file.
 Normally the config file is in your home directory as a file called
 `.config/rclone/rclone.conf` (or `.rclone.conf` if created with an
 older version). If `$XDG_CONFIG_HOME` is set it will be at
-`$XDG_CONFIG_HOME/rclone/rclone.conf`
+`$XDG_CONFIG_HOME/rclone/rclone.conf`.
+
+If there is a file `rclone.conf` in the same directory as the rclone
+executable it will be preferred. This file must be created manually
+for Rclone to use it, it will never be created automatically.
 
 If you run `rclone config file` you will see where the default
 location is for you.

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -105,6 +105,18 @@ func getConfigData() *goconfig.ConfigFile {
 
 // Return the path to the configuration file
 func makeConfigPath() string {
+
+	// Use rclone.conf from rclone executable directory if already existing
+	exe, err := os.Executable()
+	if err == nil {
+		exedir := filepath.Dir(exe)
+		cfgpath := filepath.Join(exedir, configFileName)
+		_, err := os.Stat(cfgpath)
+		if err == nil {
+			return cfgpath
+		}
+	}
+
 	// Find user's home directory
 	homeDir, err := homedir.Dir()
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

To run rclone in "portable" mode, as in "portable app", by putting rclone.exe together with rclone.conf in a folder on a memory stick. Rclone will pick up the local config file without having to always remember to specify the --config command line argument, and not having to resort to launcher script like described in [forum](https://forum.rclone.org/t/how-to-change-the-path-to-the-config-file-rclone-cong-permanently/10324/5).

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

The idea came from [this](https://forum.rclone.org/t/how-to-change-the-path-to-the-config-file-rclone-cong-permanently/10324/5) forum post, although it does not describe the solution itself. 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
