### PR TITLE
[WIP] Implement --suffix without --backup-dir for current dir

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -880,11 +880,23 @@ The default is `bytes`.
 
 ### --suffix=SUFFIX ###
 
-This is for use with `--backup-dir` only.  If this isn't set then
-`--backup-dir` will move files with their original name.  If it is set
-then the files will have SUFFIX added on to them.
+When using `sync`, `copy` or `move` any files which would have been
+overwritten or deleted will have the suffix added to them.  If there 
+is a file with the same path (after the suffix has been added), then 
+it will be overwritten.
 
-See `--backup-dir` for more info.
+The remote in use must support server side move or copy and you must
+use the same remote as the destination of the sync.
+
+This is for use with files to add the suffix in the current directory 
+or with `--backup-dir`. See `--backup-dir` for more info.
+
+For example
+
+    rclone sync /path/to/local/file remote:current --suffix .bak
+
+will sync `/path/to/local` to `remote:current`, but for any files
+which would have been updated or deleted have .bak added.
 
 ### --suffix-keep-extension ###
 

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -68,7 +68,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &fs.Config.NoTraverse, "no-traverse", "", fs.Config.NoTraverse, "Don't traverse destination file system on copy.")
 	flags.BoolVarP(flagSet, &fs.Config.NoUpdateModTime, "no-update-modtime", "", fs.Config.NoUpdateModTime, "Don't update destination mod-time if files identical.")
 	flags.StringVarP(flagSet, &fs.Config.BackupDir, "backup-dir", "", fs.Config.BackupDir, "Make backups into hierarchy based in DIR.")
-	flags.StringVarP(flagSet, &fs.Config.Suffix, "suffix", "", fs.Config.Suffix, "Suffix for use with --backup-dir.")
+	flags.StringVarP(flagSet, &fs.Config.Suffix, "suffix", "", fs.Config.Suffix, "Suffix to add to changed files.")
 	flags.BoolVarP(flagSet, &fs.Config.SuffixKeepExtension, "suffix-keep-extension", "", fs.Config.SuffixKeepExtension, "Preserve the extension when using --suffix.")
 	flags.BoolVarP(flagSet, &fs.Config.UseListR, "fast-list", "", fs.Config.UseListR, "Use recursive list if available. Uses more memory but fewer transactions.")
 	flags.Float64VarP(flagSet, &fs.Config.TPSLimit, "tpslimit", "", fs.Config.TPSLimit, "Limit HTTP transactions per second to this.")
@@ -150,10 +150,6 @@ func SetFlags() {
 
 	if fs.Config.IgnoreSize && fs.Config.SizeOnly {
 		log.Fatalf(`Can't use --size-only and --ignore-size together.`)
-	}
-
-	if fs.Config.Suffix != "" && fs.Config.BackupDir == "" {
-		log.Fatalf(`Can only use --suffix with --backup-dir.`)
 	}
 
 	switch {

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -141,6 +141,13 @@ func newSyncCopyMove(fdst, fsrc fs.Fs, deleteMode fs.DeleteMode, DoMove bool, de
 			return nil, fserrors.FatalError(errors.New("source and parameter to --backup-dir mustn't overlap"))
 		}
 		s.suffix = fs.Config.Suffix
+	} else if fs.Config.Suffix != "" {
+		// --backup-dir is not set but --suffix is - use the destination as the backupDir
+		s.backupDir = fdst
+		s.suffix = fs.Config.Suffix
+		if !operations.CanServerSideMove(s.backupDir) {
+			return nil, fserrors.FatalError(errors.New("can't use --suffix on a remote which doesn't support server side move or copy"))
+		}
 	}
 	return s, nil
 }


### PR DESCRIPTION


#### What is the purpose of this change?

allow --suffix by itself to add suffix and backup files in current directory

#### Was the change discussed in an issue or in the forum before?

discussed in and Fixes #2801
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
