### PR TITLE
Add context propagation to rclone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build
 docs/public
 rclone.iml
 .idea
+.history
+*.test
+*.log

--- a/backend/alias/alias_internal_test.go
+++ b/backend/alias/alias_internal_test.go
@@ -1,6 +1,7 @@
 package alias
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -69,7 +70,7 @@ func TestNewFS(t *testing.T) {
 		prepare(t, remoteRoot)
 		f, err := fs.NewFs(fmt.Sprintf("%s:%s", remoteName, test.fsRoot))
 		require.NoError(t, err, what)
-		gotEntries, err := f.List(test.fsList)
+		gotEntries, err := f.List(context.Background(), test.fsList)
 		require.NoError(t, err, what)
 
 		sort.Sort(gotEntries)

--- a/backend/amazonclouddrive/amazonclouddrive.go
+++ b/backend/amazonclouddrive/amazonclouddrive.go
@@ -12,6 +12,7 @@ we ignore assets completely!
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -246,6 +247,7 @@ func filterRequest(req *http.Request) {
 
 // NewFs constructs an Fs from the path, container:path
 func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
+	ctx := context.Background()
 	// Parse config into Options struct
 	opt := new(Options)
 	err := configstruct.Set(m, opt)
@@ -307,7 +309,7 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 	f.dirCache = dircache.New(root, f.trueRootID, f)
 
 	// Find the current root
-	err = f.dirCache.FindRoot(false)
+	err = f.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		// Assume it is a file
 		newRoot, remote := dircache.SplitPath(root)
@@ -315,12 +317,12 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 		tempF.dirCache = dircache.New(newRoot, f.trueRootID, &tempF)
 		tempF.root = newRoot
 		// Make new Fs which is the parent
-		err = tempF.dirCache.FindRoot(false)
+		err = tempF.dirCache.FindRoot(ctx, false)
 		if err != nil {
 			// No root so return old f
 			return f, nil
 		}
-		_, err := tempF.newObjectWithInfo(remote, nil)
+		_, err := tempF.newObjectWithInfo(ctx, remote, nil)
 		if err != nil {
 			if err == fs.ErrorObjectNotFound {
 				// File doesn't exist so return old f
@@ -352,7 +354,7 @@ func (f *Fs) getRootInfo() (rootInfo *acd.Folder, err error) {
 // Return an Object from a path
 //
 // If it can't be found it returns the error fs.ErrorObjectNotFound.
-func (f *Fs) newObjectWithInfo(remote string, info *acd.Node) (fs.Object, error) {
+func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *acd.Node) (fs.Object, error) {
 	o := &Object{
 		fs:     f,
 		remote: remote,
@@ -361,7 +363,7 @@ func (f *Fs) newObjectWithInfo(remote string, info *acd.Node) (fs.Object, error)
 		// Set info but not meta
 		o.info = info
 	} else {
-		err := o.readMetaData() // reads info and meta, returning an error
+		err := o.readMetaData(ctx) // reads info and meta, returning an error
 		if err != nil {
 			return nil, err
 		}
@@ -371,12 +373,12 @@ func (f *Fs) newObjectWithInfo(remote string, info *acd.Node) (fs.Object, error)
 
 // NewObject finds the Object at remote.  If it can't be found
 // it returns the error fs.ErrorObjectNotFound.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
-	return f.newObjectWithInfo(remote, nil)
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	return f.newObjectWithInfo(ctx, remote, nil)
 }
 
 // FindLeaf finds a directory of name leaf in the folder with ID pathID
-func (f *Fs) FindLeaf(pathID, leaf string) (pathIDOut string, found bool, err error) {
+func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
 	//fs.Debugf(f, "FindLeaf(%q, %q)", pathID, leaf)
 	folder := acd.FolderFromId(pathID, f.c.Nodes)
 	var resp *http.Response
@@ -403,7 +405,7 @@ func (f *Fs) FindLeaf(pathID, leaf string) (pathIDOut string, found bool, err er
 }
 
 // CreateDir makes a directory with pathID as parent and name leaf
-func (f *Fs) CreateDir(pathID, leaf string) (newID string, err error) {
+func (f *Fs) CreateDir(ctx context.Context, pathID, leaf string) (newID string, err error) {
 	//fmt.Printf("CreateDir(%q, %q)\n", pathID, leaf)
 	folder := acd.FolderFromId(pathID, f.c.Nodes)
 	var resp *http.Response
@@ -501,12 +503,12 @@ func (f *Fs) listAll(dirID string, title string, directoriesOnly bool, filesOnly
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
-	err = f.dirCache.FindRoot(false)
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
+	err = f.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		return nil, err
 	}
-	directoryID, err := f.dirCache.FindDir(dir, false)
+	directoryID, err := f.dirCache.FindDir(ctx, dir, false)
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +526,7 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 				d := fs.NewDir(remote, when).SetID(*node.Id)
 				entries = append(entries, d)
 			case fileKind:
-				o, err := f.newObjectWithInfo(remote, node)
+				o, err := f.newObjectWithInfo(ctx, remote, node)
 				if err != nil {
 					iErr = err
 					return true
@@ -568,7 +570,7 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 // At the end of large uploads.  The speculation is that the timeout
 // is waiting for the sha1 hashing to complete and the file may well
 // be properly uploaded.
-func (f *Fs) checkUpload(resp *http.Response, in io.Reader, src fs.ObjectInfo, inInfo *acd.File, inErr error, uploadTime time.Duration) (fixedError bool, info *acd.File, err error) {
+func (f *Fs) checkUpload(ctx context.Context, resp *http.Response, in io.Reader, src fs.ObjectInfo, inInfo *acd.File, inErr error, uploadTime time.Duration) (fixedError bool, info *acd.File, err error) {
 	// Return if no error - all is well
 	if inErr == nil {
 		return false, inInfo, inErr
@@ -608,7 +610,7 @@ func (f *Fs) checkUpload(resp *http.Response, in io.Reader, src fs.ObjectInfo, i
 	fs.Debugf(src, "Error detected after finished upload - waiting to see if object was uploaded correctly: %v (%q)", inErr, httpStatus)
 	remote := src.Remote()
 	for i := 1; i <= retries; i++ {
-		o, err := f.NewObject(remote)
+		o, err := f.NewObject(ctx, remote)
 		if err == fs.ErrorObjectNotFound {
 			fs.Debugf(src, "Object not found - waiting (%d/%d)", i, retries)
 		} else if err != nil {
@@ -634,7 +636,7 @@ func (f *Fs) checkUpload(resp *http.Response, in io.Reader, src fs.ObjectInfo, i
 // Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	remote := src.Remote()
 	size := src.Size()
 	// Temporary Object under construction
@@ -643,17 +645,17 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 		remote: remote,
 	}
 	// Check if object already exists
-	err := o.readMetaData()
+	err := o.readMetaData(ctx)
 	switch err {
 	case nil:
-		return o, o.Update(in, src, options...)
+		return o, o.Update(ctx, in, src, options...)
 	case fs.ErrorObjectNotFound:
 		// Not found so create it
 	default:
 		return nil, err
 	}
 	// If not create it
-	leaf, directoryID, err := f.dirCache.FindRootAndPath(remote, true)
+	leaf, directoryID, err := f.dirCache.FindRootAndPath(ctx, remote, true)
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +671,7 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 		info, resp, err = folder.Put(in, leaf)
 		f.tokenRenewer.Stop()
 		var ok bool
-		ok, info, err = f.checkUpload(resp, in, src, info, err, time.Since(start))
+		ok, info, err = f.checkUpload(ctx, resp, in, src, info, err, time.Since(start))
 		if ok {
 			return false, nil
 		}
@@ -683,13 +685,13 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 }
 
 // Mkdir creates the container if it doesn't exist
-func (f *Fs) Mkdir(dir string) error {
-	err := f.dirCache.FindRoot(true)
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
+	err := f.dirCache.FindRoot(ctx, true)
 	if err != nil {
 		return err
 	}
 	if dir != "" {
-		_, err = f.dirCache.FindDir(dir, true)
+		_, err = f.dirCache.FindDir(ctx, dir, true)
 	}
 	return err
 }
@@ -703,7 +705,7 @@ func (f *Fs) Mkdir(dir string) error {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantMove
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	//  go test -v -run '^Test(Setup|Init|FsMkdir|FsPutFile1|FsPutFile2|FsUpdateFile1|FsMove)$'
 	srcObj, ok := src.(*Object)
 	if !ok {
@@ -712,15 +714,15 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 	}
 
 	// create the destination directory if necessary
-	err := f.dirCache.FindRoot(true)
+	err := f.dirCache.FindRoot(ctx, true)
 	if err != nil {
 		return nil, err
 	}
-	srcLeaf, srcDirectoryID, err := srcObj.fs.dirCache.FindPath(srcObj.remote, false)
+	srcLeaf, srcDirectoryID, err := srcObj.fs.dirCache.FindPath(ctx, srcObj.remote, false)
 	if err != nil {
 		return nil, err
 	}
-	dstLeaf, dstDirectoryID, err := f.dirCache.FindPath(remote, true)
+	dstLeaf, dstDirectoryID, err := f.dirCache.FindPath(ctx, remote, true)
 	if err != nil {
 		return nil, err
 	}
@@ -736,12 +738,12 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 		srcErr, dstErr error
 	)
 	for i := 1; i <= fs.Config.LowLevelRetries; i++ {
-		_, srcErr = srcObj.fs.NewObject(srcObj.remote) // try reading the object
+		_, srcErr = srcObj.fs.NewObject(ctx, srcObj.remote) // try reading the object
 		if srcErr != nil && srcErr != fs.ErrorObjectNotFound {
 			// exit if error on source
 			return nil, srcErr
 		}
-		dstObj, dstErr = f.NewObject(remote)
+		dstObj, dstErr = f.NewObject(ctx, remote)
 		if dstErr != nil && dstErr != fs.ErrorObjectNotFound {
 			// exit if error on dst
 			return nil, dstErr
@@ -770,7 +772,7 @@ func (f *Fs) DirCacheFlush() {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) (err error) {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) (err error) {
 	srcFs, ok := src.(*Fs)
 	if !ok {
 		fs.Debugf(src, "DirMove error: not same remote type")
@@ -786,14 +788,14 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) (err error) {
 	}
 
 	// find the root src directory
-	err = srcFs.dirCache.FindRoot(false)
+	err = srcFs.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		return err
 	}
 
 	// find the root dst directory
 	if dstRemote != "" {
-		err = f.dirCache.FindRoot(true)
+		err = f.dirCache.FindRoot(ctx, true)
 		if err != nil {
 			return err
 		}
@@ -808,14 +810,14 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) (err error) {
 	if dstRemote == "" {
 		findPath = f.root
 	}
-	dstLeaf, dstDirectoryID, err := f.dirCache.FindPath(findPath, true)
+	dstLeaf, dstDirectoryID, err := f.dirCache.FindPath(ctx, findPath, true)
 	if err != nil {
 		return err
 	}
 
 	// Check destination does not exist
 	if dstRemote != "" {
-		_, err = f.dirCache.FindDir(dstRemote, false)
+		_, err = f.dirCache.FindDir(ctx, dstRemote, false)
 		if err == fs.ErrorDirNotFound {
 			// OK
 		} else if err != nil {
@@ -831,7 +833,7 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) (err error) {
 	if srcRemote == "" {
 		srcDirectoryID, err = srcFs.dirCache.RootParentID()
 	} else {
-		_, srcDirectoryID, err = srcFs.dirCache.FindPath(findPath, false)
+		_, srcDirectoryID, err = srcFs.dirCache.FindPath(ctx, findPath, false)
 	}
 	if err != nil {
 		return err
@@ -839,7 +841,7 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) (err error) {
 	srcLeaf, _ := dircache.SplitPath(srcPath)
 
 	// Find ID of src
-	srcID, err := srcFs.dirCache.FindDir(srcRemote, false)
+	srcID, err := srcFs.dirCache.FindDir(ctx, srcRemote, false)
 	if err != nil {
 		return err
 	}
@@ -872,17 +874,17 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) (err error) {
 
 // purgeCheck remotes the root directory, if check is set then it
 // refuses to do so if it has anything in
-func (f *Fs) purgeCheck(dir string, check bool) error {
+func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 	root := path.Join(f.root, dir)
 	if root == "" {
 		return errors.New("can't purge root directory")
 	}
 	dc := f.dirCache
-	err := dc.FindRoot(false)
+	err := dc.FindRoot(ctx, false)
 	if err != nil {
 		return err
 	}
-	rootID, err := dc.FindDir(dir, false)
+	rootID, err := dc.FindDir(ctx, dir, false)
 	if err != nil {
 		return err
 	}
@@ -931,8 +933,8 @@ func (f *Fs) purgeCheck(dir string, check bool) error {
 // Rmdir deletes the root folder
 //
 // Returns an error if it isn't empty
-func (f *Fs) Rmdir(dir string) error {
-	return f.purgeCheck(dir, true)
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
+	return f.purgeCheck(ctx, dir, true)
 }
 
 // Precision return the precision of this Fs
@@ -954,7 +956,7 @@ func (f *Fs) Hashes() hash.Set {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantCopy
-//func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+//func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 // srcObj, ok := src.(*Object)
 // if !ok {
 // 	fs.Debugf(src, "Can't copy - not same remote type")
@@ -965,7 +967,7 @@ func (f *Fs) Hashes() hash.Set {
 // if err != nil {
 // 	return nil, err
 // }
-// return f.NewObject(remote), nil
+// return f.NewObject(ctx, remote), nil
 //}
 
 // Purge deletes all the files and the container
@@ -973,8 +975,8 @@ func (f *Fs) Hashes() hash.Set {
 // Optional interface: Only implement this if you have a way of
 // deleting all the files quicker than just running Remove() on the
 // result of List()
-func (f *Fs) Purge() error {
-	return f.purgeCheck("", false)
+func (f *Fs) Purge(ctx context.Context) error {
+	return f.purgeCheck(ctx, "", false)
 }
 
 // ------------------------------------------------------------
@@ -998,7 +1000,7 @@ func (o *Object) Remote() string {
 }
 
 // Hash returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Hash(t hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {
 	if t != hash.MD5 {
 		return "", hash.ErrUnsupported
 	}
@@ -1021,11 +1023,11 @@ func (o *Object) Size() int64 {
 // it also sets the info
 //
 // If it can't be found it returns the error fs.ErrorObjectNotFound.
-func (o *Object) readMetaData() (err error) {
+func (o *Object) readMetaData(ctx context.Context) (err error) {
 	if o.info != nil {
 		return nil
 	}
-	leaf, directoryID, err := o.fs.dirCache.FindRootAndPath(o.remote, false)
+	leaf, directoryID, err := o.fs.dirCache.FindRootAndPath(ctx, o.remote, false)
 	if err != nil {
 		if err == fs.ErrorDirNotFound {
 			return fs.ErrorObjectNotFound
@@ -1054,8 +1056,8 @@ func (o *Object) readMetaData() (err error) {
 //
 // It attempts to read the objects mtime and if that isn't present the
 // LastModified returned in the http headers
-func (o *Object) ModTime() time.Time {
-	err := o.readMetaData()
+func (o *Object) ModTime(ctx context.Context) time.Time {
+	err := o.readMetaData(ctx)
 	if err != nil {
 		fs.Debugf(o, "Failed to read metadata: %v", err)
 		return time.Now()
@@ -1069,7 +1071,7 @@ func (o *Object) ModTime() time.Time {
 }
 
 // SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	// FIXME not implemented
 	return fs.ErrorCantSetModTime
 }
@@ -1080,7 +1082,7 @@ func (o *Object) Storable() bool {
 }
 
 // Open an object for read
-func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	bigObject := o.Size() >= int64(o.fs.opt.TempLinkThreshold)
 	if bigObject {
 		fs.Debugf(o, "Downloading large object via tempLink")
@@ -1102,7 +1104,7 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 // Update the object with the contents of the io.Reader, modTime and size
 //
 // The new object may have been created if an error is returned
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	file := acd.File{Node: o.info}
 	var info *acd.File
 	var resp *http.Response
@@ -1113,7 +1115,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 		info, resp, err = file.Overwrite(in)
 		o.fs.tokenRenewer.Stop()
 		var ok bool
-		ok, info, err = o.fs.checkUpload(resp, in, src, info, err, time.Since(start))
+		ok, info, err = o.fs.checkUpload(ctx, resp, in, src, info, err, time.Since(start))
 		if ok {
 			return false, nil
 		}
@@ -1138,7 +1140,7 @@ func (f *Fs) removeNode(info *acd.Node) error {
 }
 
 // Remove an object
-func (o *Object) Remove() error {
+func (o *Object) Remove(ctx context.Context) error {
 	return o.fs.removeNode(o.info)
 }
 
@@ -1260,7 +1262,7 @@ OnConflict:
 }
 
 // MimeType of an Object if known, "" otherwise
-func (o *Object) MimeType() string {
+func (o *Object) MimeType(ctx context.Context) string {
 	if o.info.ContentProperties != nil && o.info.ContentProperties.ContentType != nil {
 		return *o.info.ContentProperties.ContentType
 	}
@@ -1273,7 +1275,7 @@ func (o *Object) MimeType() string {
 // Automatically restarts itself in case of unexpected behaviour of the remote.
 //
 // Close the returned channel to stop being notified.
-func (f *Fs) ChangeNotify(notifyFunc func(string, fs.EntryType), pollIntervalChan <-chan time.Duration) {
+func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryType), pollIntervalChan <-chan time.Duration) {
 	checkpoint := f.opt.Checkpoint
 
 	go func() {

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -509,7 +509,7 @@ func NewFs(name, rootPath string, m configmap.Mapper) (fs.Fs, error) {
 	if doChangeNotify := wrappedFs.Features().ChangeNotify; doChangeNotify != nil {
 		pollInterval := make(chan time.Duration, 1)
 		pollInterval <- time.Duration(f.opt.ChunkCleanInterval)
-		doChangeNotify(f.receiveChangeNotify, pollInterval)
+		doChangeNotify(context.Background(), f.receiveChangeNotify, pollInterval)
 	}
 
 	f.features = (&fs.Features{
@@ -600,7 +600,7 @@ is used on top of the cache.
 	return f, fsErr
 }
 
-func (f *Fs) httpStats(in rc.Params) (out rc.Params, err error) {
+func (f *Fs) httpStats(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	out = make(rc.Params)
 	m, err := f.Stats()
 	if err != nil {
@@ -627,7 +627,7 @@ func (f *Fs) unwrapRemote(remote string) string {
 	return remote
 }
 
-func (f *Fs) httpExpireRemote(in rc.Params) (out rc.Params, err error) {
+func (f *Fs) httpExpireRemote(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	out = make(rc.Params)
 	remoteInt, ok := in["remote"]
 	if !ok {
@@ -672,7 +672,7 @@ func (f *Fs) httpExpireRemote(in rc.Params) (out rc.Params, err error) {
 	return out, nil
 }
 
-func (f *Fs) rcFetch(in rc.Params) (rc.Params, error) {
+func (f *Fs) rcFetch(ctx context.Context, in rc.Params) (rc.Params, error) {
 	type chunkRange struct {
 		start, end int64
 	}
@@ -777,18 +777,18 @@ func (f *Fs) rcFetch(in rc.Params) (rc.Params, error) {
 	for _, pair := range files {
 		file, remote := pair[0], pair[1]
 		var status fileStatus
-		o, err := f.NewObject(remote)
+		o, err := f.NewObject(ctx, remote)
 		if err != nil {
 			fetchedChunks[file] = fileStatus{Error: err.Error()}
 			continue
 		}
 		co := o.(*Object)
-		err = co.refreshFromSource(true)
+		err = co.refreshFromSource(ctx, true)
 		if err != nil {
 			fetchedChunks[file] = fileStatus{Error: err.Error()}
 			continue
 		}
-		handle := NewObjectHandle(co, f)
+		handle := NewObjectHandle(ctx, co, f)
 		handle.UseMemory = false
 		handle.scaleWorkers(1)
 		walkChunkRanges(crs, co.Size(), func(chunk int64) {
@@ -874,7 +874,7 @@ func (f *Fs) notifyChangeUpstream(remote string, entryType fs.EntryType) {
 // ChangeNotify can subscribe multiple callers
 // this is coupled with the wrapped fs ChangeNotify (if it supports it)
 // and also notifies other caches (i.e VFS) to clear out whenever something changes
-func (f *Fs) ChangeNotify(notifyFunc func(string, fs.EntryType), pollInterval <-chan time.Duration) {
+func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryType), pollInterval <-chan time.Duration) {
 	f.parentsForgetMu.Lock()
 	defer f.parentsForgetMu.Unlock()
 	fs.Debugf(f, "subscribing to ChangeNotify")
@@ -921,7 +921,7 @@ func (f *Fs) TempUploadWaitTime() time.Duration {
 }
 
 // NewObject finds the Object at remote.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	var err error
 
 	fs.Debugf(f, "new object '%s'", remote)
@@ -940,16 +940,16 @@ func (f *Fs) NewObject(remote string) (fs.Object, error) {
 	// search for entry in source or temp fs
 	var obj fs.Object
 	if f.opt.TempWritePath != "" {
-		obj, err = f.tempFs.NewObject(remote)
+		obj, err = f.tempFs.NewObject(ctx, remote)
 		// not found in temp fs
 		if err != nil {
 			fs.Debugf(remote, "find: not found in local cache fs")
-			obj, err = f.Fs.NewObject(remote)
+			obj, err = f.Fs.NewObject(ctx, remote)
 		} else {
 			fs.Debugf(obj, "find: found in local cache fs")
 		}
 	} else {
-		obj, err = f.Fs.NewObject(remote)
+		obj, err = f.Fs.NewObject(ctx, remote)
 	}
 
 	// not found in either fs
@@ -959,13 +959,13 @@ func (f *Fs) NewObject(remote string) (fs.Object, error) {
 	}
 
 	// cache the new entry
-	co = ObjectFromOriginal(f, obj).persist()
+	co = ObjectFromOriginal(ctx, f, obj).persist()
 	fs.Debugf(co, "find: cached object")
 	return co, nil
 }
 
 // List the objects and directories in dir into entries
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 	fs.Debugf(f, "list '%s'", dir)
 	cd := ShallowDirectory(f, dir)
 
@@ -995,12 +995,12 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 			fs.Debugf(dir, "list: temp fs entries: %v", queuedEntries)
 
 			for _, queuedRemote := range queuedEntries {
-				queuedEntry, err := f.tempFs.NewObject(f.cleanRootFromPath(queuedRemote))
+				queuedEntry, err := f.tempFs.NewObject(ctx, f.cleanRootFromPath(queuedRemote))
 				if err != nil {
 					fs.Debugf(dir, "list: temp file not found in local fs: %v", err)
 					continue
 				}
-				co := ObjectFromOriginal(f, queuedEntry).persist()
+				co := ObjectFromOriginal(ctx, f, queuedEntry).persist()
 				fs.Debugf(co, "list: cached temp object")
 				cachedEntries = append(cachedEntries, co)
 			}
@@ -1008,7 +1008,7 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 	}
 
 	// search from the source
-	sourceEntries, err := f.Fs.List(dir)
+	sourceEntries, err := f.Fs.List(ctx, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -1046,11 +1046,11 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 			if i < tmpCnt && cachedEntries[i].Remote() == oRemote {
 				continue
 			}
-			co := ObjectFromOriginal(f, o).persist()
+			co := ObjectFromOriginal(ctx, f, o).persist()
 			cachedEntries = append(cachedEntries, co)
 			fs.Debugf(dir, "list: cached object: %v", co)
 		case fs.Directory:
-			cdd := DirectoryFromOriginal(f, o)
+			cdd := DirectoryFromOriginal(ctx, f, o)
 			// check if the dir isn't expired and add it in cache if it isn't
 			if cdd2, err := f.cache.GetDir(cdd.abs()); err != nil || time.Now().Before(cdd2.CacheTs.Add(time.Duration(f.opt.InfoAge))) {
 				batchDirectories = append(batchDirectories, cdd)
@@ -1080,8 +1080,8 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 	return cachedEntries, nil
 }
 
-func (f *Fs) recurse(dir string, list *walk.ListRHelper) error {
-	entries, err := f.List(dir)
+func (f *Fs) recurse(ctx context.Context, dir string, list *walk.ListRHelper) error {
+	entries, err := f.List(ctx, dir)
 	if err != nil {
 		return err
 	}
@@ -1089,7 +1089,7 @@ func (f *Fs) recurse(dir string, list *walk.ListRHelper) error {
 	for i := 0; i < len(entries); i++ {
 		innerDir, ok := entries[i].(fs.Directory)
 		if ok {
-			err := f.recurse(innerDir.Remote(), list)
+			err := f.recurse(ctx, innerDir.Remote(), list)
 			if err != nil {
 				return err
 			}
@@ -1106,21 +1106,21 @@ func (f *Fs) recurse(dir string, list *walk.ListRHelper) error {
 
 // ListR lists the objects and directories of the Fs starting
 // from dir recursively into out.
-func (f *Fs) ListR(dir string, callback fs.ListRCallback) (err error) {
+func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (err error) {
 	fs.Debugf(f, "list recursively from '%s'", dir)
 
 	// we check if the source FS supports ListR
 	// if it does, we'll use that to get all the entries, cache them and return
 	do := f.Fs.Features().ListR
 	if do != nil {
-		return do(dir, func(entries fs.DirEntries) error {
+		return do(ctx, dir, func(entries fs.DirEntries) error {
 			// we got called back with a set of entries so let's cache them and call the original callback
 			for _, entry := range entries {
 				switch o := entry.(type) {
 				case fs.Object:
-					_ = f.cache.AddObject(ObjectFromOriginal(f, o))
+					_ = f.cache.AddObject(ObjectFromOriginal(ctx, f, o))
 				case fs.Directory:
-					_ = f.cache.AddDir(DirectoryFromOriginal(f, o))
+					_ = f.cache.AddDir(DirectoryFromOriginal(ctx, f, o))
 				default:
 					return errors.Errorf("Unknown object type %T", entry)
 				}
@@ -1133,7 +1133,7 @@ func (f *Fs) ListR(dir string, callback fs.ListRCallback) (err error) {
 
 	// if we're here, we're gonna do a standard recursive traversal and cache everything
 	list := walk.NewListRHelper(callback)
-	err = f.recurse(dir, list)
+	err = f.recurse(ctx, dir, list)
 	if err != nil {
 		return err
 	}
@@ -1142,9 +1142,9 @@ func (f *Fs) ListR(dir string, callback fs.ListRCallback) (err error) {
 }
 
 // Mkdir makes the directory (container, bucket)
-func (f *Fs) Mkdir(dir string) error {
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 	fs.Debugf(f, "mkdir '%s'", dir)
-	err := f.Fs.Mkdir(dir)
+	err := f.Fs.Mkdir(ctx, dir)
 	if err != nil {
 		return err
 	}
@@ -1172,7 +1172,7 @@ func (f *Fs) Mkdir(dir string) error {
 }
 
 // Rmdir removes the directory (container, bucket) if empty
-func (f *Fs) Rmdir(dir string) error {
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	fs.Debugf(f, "rmdir '%s'", dir)
 
 	if f.opt.TempWritePath != "" {
@@ -1182,9 +1182,9 @@ func (f *Fs) Rmdir(dir string) error {
 
 		// we check if the source exists on the remote and make the same move on it too if it does
 		// otherwise, we skip this step
-		_, err := f.UnWrap().List(dir)
+		_, err := f.UnWrap().List(ctx, dir)
 		if err == nil {
-			err := f.Fs.Rmdir(dir)
+			err := f.Fs.Rmdir(ctx, dir)
 			if err != nil {
 				return err
 			}
@@ -1192,10 +1192,10 @@ func (f *Fs) Rmdir(dir string) error {
 		}
 
 		var queuedEntries []*Object
-		err = walk.ListR(f.tempFs, dir, true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
+		err = walk.ListR(ctx, f.tempFs, dir, true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
 			for _, o := range entries {
 				if oo, ok := o.(fs.Object); ok {
-					co := ObjectFromOriginal(f, oo)
+					co := ObjectFromOriginal(ctx, f, oo)
 					queuedEntries = append(queuedEntries, co)
 				}
 			}
@@ -1212,7 +1212,7 @@ func (f *Fs) Rmdir(dir string) error {
 			}
 		}
 	} else {
-		err := f.Fs.Rmdir(dir)
+		err := f.Fs.Rmdir(ctx, dir)
 		if err != nil {
 			return err
 		}
@@ -1243,7 +1243,7 @@ func (f *Fs) Rmdir(dir string) error {
 
 // DirMove moves src, srcRemote to this remote at dstRemote
 // using server side move operations.
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	fs.Debugf(f, "move dir '%s'/'%s' -> '%s'/'%s'", src.Root(), srcRemote, f.Root(), dstRemote)
 
 	do := f.Fs.Features().DirMove
@@ -1265,8 +1265,8 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 		f.backgroundRunner.pause()
 		defer f.backgroundRunner.play()
 
-		_, errInWrap := srcFs.UnWrap().List(srcRemote)
-		_, errInTemp := f.tempFs.List(srcRemote)
+		_, errInWrap := srcFs.UnWrap().List(ctx, srcRemote)
+		_, errInTemp := f.tempFs.List(ctx, srcRemote)
 		// not found in either fs
 		if errInWrap != nil && errInTemp != nil {
 			return fs.ErrorDirNotFound
@@ -1275,7 +1275,7 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 		// we check if the source exists on the remote and make the same move on it too if it does
 		// otherwise, we skip this step
 		if errInWrap == nil {
-			err := do(srcFs.UnWrap(), srcRemote, dstRemote)
+			err := do(ctx, srcFs.UnWrap(), srcRemote, dstRemote)
 			if err != nil {
 				return err
 			}
@@ -1288,10 +1288,10 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 		}
 
 		var queuedEntries []*Object
-		err := walk.ListR(f.tempFs, srcRemote, true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
+		err := walk.ListR(ctx, f.tempFs, srcRemote, true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
 			for _, o := range entries {
 				if oo, ok := o.(fs.Object); ok {
-					co := ObjectFromOriginal(f, oo)
+					co := ObjectFromOriginal(ctx, f, oo)
 					queuedEntries = append(queuedEntries, co)
 					if co.tempFileStartedUpload() {
 						fs.Errorf(co, "can't move - upload has already started. need to finish that")
@@ -1312,16 +1312,16 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 			fs.Errorf(srcRemote, "dirmove: can't move dir in temp fs")
 			return fs.ErrorCantDirMove
 		}
-		err = do(f.tempFs, srcRemote, dstRemote)
+		err = do(ctx, f.tempFs, srcRemote, dstRemote)
 		if err != nil {
 			return err
 		}
-		err = f.cache.ReconcileTempUploads(f)
+		err = f.cache.ReconcileTempUploads(ctx, f)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := do(srcFs.UnWrap(), srcRemote, dstRemote)
+		err := do(ctx, srcFs.UnWrap(), srcRemote, dstRemote)
 		if err != nil {
 			return err
 		}
@@ -1427,10 +1427,10 @@ func (f *Fs) cacheReader(u io.Reader, src fs.ObjectInfo, originalRead func(inn i
 	}
 }
 
-type putFn func(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error)
+type putFn func(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error)
 
 // put in to the remote path
-func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put putFn) (fs.Object, error) {
+func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put putFn) (fs.Object, error) {
 	var err error
 	var obj fs.Object
 
@@ -1441,7 +1441,7 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 		_ = f.cache.ExpireDir(parentCd)
 		f.notifyChangeUpstreamIfNeeded(parentCd.Remote(), fs.EntryDirectory)
 
-		obj, err = f.tempFs.Put(in, src, options...)
+		obj, err = f.tempFs.Put(ctx, in, src, options...)
 		if err != nil {
 			fs.Errorf(obj, "put: failed to upload in temp fs: %v", err)
 			return nil, err
@@ -1456,14 +1456,14 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 		// if cache writes is enabled write it first through cache
 	} else if f.opt.StoreWrites {
 		f.cacheReader(in, src, func(inn io.Reader) {
-			obj, err = put(inn, src, options...)
+			obj, err = put(ctx, inn, src, options...)
 		})
 		if err == nil {
 			fs.Debugf(obj, "put: uploaded to remote fs and saved in cache")
 		}
 		// last option: save it directly in remote fs
 	} else {
-		obj, err = put(in, src, options...)
+		obj, err = put(ctx, in, src, options...)
 		if err == nil {
 			fs.Debugf(obj, "put: uploaded to remote fs")
 		}
@@ -1475,7 +1475,7 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 	}
 
 	// cache the new file
-	cachedObj := ObjectFromOriginal(f, obj)
+	cachedObj := ObjectFromOriginal(ctx, f, obj)
 
 	// deleting cached chunks and info to be replaced with new ones
 	_ = f.cache.RemoveObject(cachedObj.abs())
@@ -1498,33 +1498,33 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 }
 
 // Put in to the remote path with the modTime given of the given size
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	fs.Debugf(f, "put data at '%s'", src.Remote())
-	return f.put(in, src, options, f.Fs.Put)
+	return f.put(ctx, in, src, options, f.Fs.Put)
 }
 
 // PutUnchecked uploads the object
-func (f *Fs) PutUnchecked(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) PutUnchecked(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	do := f.Fs.Features().PutUnchecked
 	if do == nil {
 		return nil, errors.New("can't PutUnchecked")
 	}
 	fs.Debugf(f, "put data unchecked in '%s'", src.Remote())
-	return f.put(in, src, options, do)
+	return f.put(ctx, in, src, options, do)
 }
 
 // PutStream uploads the object
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	do := f.Fs.Features().PutStream
 	if do == nil {
 		return nil, errors.New("can't PutStream")
 	}
 	fs.Debugf(f, "put data streaming in '%s'", src.Remote())
-	return f.put(in, src, options, do)
+	return f.put(ctx, in, src, options, do)
 }
 
 // Copy src to this remote using server side copy operations.
-func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	fs.Debugf(f, "copy obj '%s' -> '%s'", src, remote)
 
 	do := f.Fs.Features().Copy
@@ -1544,7 +1544,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 		return nil, fs.ErrorCantCopy
 	}
 	// refresh from source or abort
-	if err := srcObj.refreshFromSource(false); err != nil {
+	if err := srcObj.refreshFromSource(ctx, false); err != nil {
 		fs.Errorf(f, "can't copy %v - %v", src, err)
 		return nil, fs.ErrorCantCopy
 	}
@@ -1563,7 +1563,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 		}
 	}
 
-	obj, err := do(srcObj.Object, remote)
+	obj, err := do(ctx, srcObj.Object, remote)
 	if err != nil {
 		fs.Errorf(srcObj, "error moving in cache: %v", err)
 		return nil, err
@@ -1571,7 +1571,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	fs.Debugf(obj, "copy: file copied")
 
 	// persist new
-	co := ObjectFromOriginal(f, obj).persist()
+	co := ObjectFromOriginal(ctx, f, obj).persist()
 	fs.Debugf(co, "copy: added to cache")
 	// expire the destination path
 	parentCd := NewDirectory(f, cleanPath(path.Dir(co.Remote())))
@@ -1598,7 +1598,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 }
 
 // Move src to this remote using server side move operations.
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	fs.Debugf(f, "moving obj '%s' -> %s", src, remote)
 
 	// if source fs doesn't support move abort
@@ -1619,7 +1619,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 		return nil, fs.ErrorCantMove
 	}
 	// refresh from source or abort
-	if err := srcObj.refreshFromSource(false); err != nil {
+	if err := srcObj.refreshFromSource(ctx, false); err != nil {
 		fs.Errorf(f, "can't move %v - %v", src, err)
 		return nil, fs.ErrorCantMove
 	}
@@ -1655,7 +1655,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 		fs.Debugf(srcObj, "move: queued file moved to %v", remote)
 	}
 
-	obj, err := do(srcObj.Object, remote)
+	obj, err := do(ctx, srcObj.Object, remote)
 	if err != nil {
 		fs.Errorf(srcObj, "error moving: %v", err)
 		return nil, err
@@ -1680,7 +1680,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 	// advertise to ChangeNotify if wrapped doesn't do that
 	f.notifyChangeUpstreamIfNeeded(parentCd.Remote(), fs.EntryDirectory)
 	// persist new
-	cachedObj := ObjectFromOriginal(f, obj).persist()
+	cachedObj := ObjectFromOriginal(ctx, f, obj).persist()
 	fs.Debugf(cachedObj, "move: added to cache")
 	// expire new parent
 	parentCd = NewDirectory(f, cleanPath(path.Dir(cachedObj.Remote())))
@@ -1702,7 +1702,7 @@ func (f *Fs) Hashes() hash.Set {
 }
 
 // Purge all files in the root and the root directory
-func (f *Fs) Purge() error {
+func (f *Fs) Purge(ctx context.Context) error {
 	fs.Infof(f, "purging cache")
 	f.cache.Purge()
 
@@ -1711,7 +1711,7 @@ func (f *Fs) Purge() error {
 		return nil
 	}
 
-	err := do()
+	err := do(ctx)
 	if err != nil {
 		return err
 	}
@@ -1720,7 +1720,7 @@ func (f *Fs) Purge() error {
 }
 
 // CleanUp the trash in the Fs
-func (f *Fs) CleanUp() error {
+func (f *Fs) CleanUp(ctx context.Context) error {
 	f.CleanUpCache(false)
 
 	do := f.Fs.Features().CleanUp
@@ -1728,16 +1728,16 @@ func (f *Fs) CleanUp() error {
 		return nil
 	}
 
-	return do()
+	return do(ctx)
 }
 
 // About gets quota information from the Fs
-func (f *Fs) About() (*fs.Usage, error) {
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	do := f.Fs.Features().About
 	if do == nil {
 		return nil, errors.New("About not supported")
 	}
-	return do()
+	return do(ctx)
 }
 
 // Stats returns stats about the cache storage

--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -4,6 +4,7 @@ package cache_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	goflag "flag"
 	"fmt"
@@ -120,7 +121,7 @@ func TestInternalListRootAndInnerRemotes(t *testing.T) {
 	require.NoError(t, err)
 	listRootInner, err := runInstance.list(t, rootFs, innerFolder)
 	require.NoError(t, err)
-	listInner, err := rootFs2.List("")
+	listInner, err := rootFs2.List(context.Background(), "")
 	require.NoError(t, err)
 
 	require.Len(t, listRoot, 1)
@@ -138,10 +139,10 @@ func TestInternalVfsCache(t *testing.T) {
 	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true, nil, map[string]string{"writes": "true", "info_age": "1h"})
 	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
-	err := rootFs.Mkdir("test")
+	err := rootFs.Mkdir(context.Background(), "test")
 	require.NoError(t, err)
 	runInstance.writeObjectString(t, rootFs, "test/second", "content")
-	_, err = rootFs.List("test")
+	_, err = rootFs.List(context.Background(), "test")
 	require.NoError(t, err)
 
 	testReader := runInstance.randomReader(t, testSize)
@@ -266,7 +267,7 @@ func TestInternalObjNotFound(t *testing.T) {
 	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
 	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
-	obj, err := rootFs.NewObject("404")
+	obj, err := rootFs.NewObject(context.Background(), "404")
 	require.Error(t, err)
 	require.Nil(t, obj)
 }
@@ -445,7 +446,7 @@ func TestInternalWrappedFsChangeNotSeen(t *testing.T) {
 	require.NoError(t, err)
 	log.Printf("original size: %v", originalSize)
 
-	o, err := cfs.UnWrap().NewObject(runInstance.encryptRemoteIfNeeded(t, "data.bin"))
+	o, err := cfs.UnWrap().NewObject(context.Background(), runInstance.encryptRemoteIfNeeded(t, "data.bin"))
 	require.NoError(t, err)
 	expectedSize := int64(len([]byte("test content")))
 	var data2 []byte
@@ -457,7 +458,7 @@ func TestInternalWrappedFsChangeNotSeen(t *testing.T) {
 		data2 = []byte("test content")
 	}
 	objInfo := object.NewStaticObjectInfo(runInstance.encryptRemoteIfNeeded(t, "data.bin"), time.Now(), int64(len(data2)), true, nil, cfs.UnWrap())
-	err = o.Update(bytes.NewReader(data2), objInfo)
+	err = o.Update(context.Background(), bytes.NewReader(data2), objInfo)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data2)), o.Size())
 	log.Printf("updated size: %v", len(data2))
@@ -503,9 +504,9 @@ func TestInternalMoveWithNotify(t *testing.T) {
 	} else {
 		testData = []byte("test content")
 	}
-	_ = cfs.UnWrap().Mkdir(runInstance.encryptRemoteIfNeeded(t, "test"))
-	_ = cfs.UnWrap().Mkdir(runInstance.encryptRemoteIfNeeded(t, "test/one"))
-	_ = cfs.UnWrap().Mkdir(runInstance.encryptRemoteIfNeeded(t, "test/second"))
+	_ = cfs.UnWrap().Mkdir(context.Background(), runInstance.encryptRemoteIfNeeded(t, "test"))
+	_ = cfs.UnWrap().Mkdir(context.Background(), runInstance.encryptRemoteIfNeeded(t, "test/one"))
+	_ = cfs.UnWrap().Mkdir(context.Background(), runInstance.encryptRemoteIfNeeded(t, "test/second"))
 	srcObj := runInstance.writeObjectBytes(t, cfs.UnWrap(), srcName, testData)
 
 	// list in mount
@@ -515,7 +516,7 @@ func TestInternalMoveWithNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	// move file
-	_, err = cfs.UnWrap().Features().Move(srcObj, dstName)
+	_, err = cfs.UnWrap().Features().Move(context.Background(), srcObj, dstName)
 	require.NoError(t, err)
 
 	err = runInstance.retryBlock(func() error {
@@ -589,9 +590,9 @@ func TestInternalNotifyCreatesEmptyParts(t *testing.T) {
 	} else {
 		testData = []byte("test content")
 	}
-	err = rootFs.Mkdir("test")
+	err = rootFs.Mkdir(context.Background(), "test")
 	require.NoError(t, err)
-	err = rootFs.Mkdir("test/one")
+	err = rootFs.Mkdir(context.Background(), "test/one")
 	require.NoError(t, err)
 	srcObj := runInstance.writeObjectBytes(t, cfs.UnWrap(), srcName, testData)
 
@@ -608,7 +609,7 @@ func TestInternalNotifyCreatesEmptyParts(t *testing.T) {
 	require.False(t, found)
 
 	// move file
-	_, err = cfs.UnWrap().Features().Move(srcObj, dstName)
+	_, err = cfs.UnWrap().Features().Move(context.Background(), srcObj, dstName)
 	require.NoError(t, err)
 
 	err = runInstance.retryBlock(func() error {
@@ -670,23 +671,23 @@ func TestInternalChangeSeenAfterDirCacheFlush(t *testing.T) {
 	runInstance.writeRemoteBytes(t, rootFs, "data.bin", testData)
 
 	// update in the wrapped fs
-	o, err := cfs.UnWrap().NewObject(runInstance.encryptRemoteIfNeeded(t, "data.bin"))
+	o, err := cfs.UnWrap().NewObject(context.Background(), runInstance.encryptRemoteIfNeeded(t, "data.bin"))
 	require.NoError(t, err)
 	wrappedTime := time.Now().Add(-1 * time.Hour)
-	err = o.SetModTime(wrappedTime)
+	err = o.SetModTime(context.Background(), wrappedTime)
 	require.NoError(t, err)
 
 	// get a new instance from the cache
-	co, err := rootFs.NewObject("data.bin")
+	co, err := rootFs.NewObject(context.Background(), "data.bin")
 	require.NoError(t, err)
-	require.NotEqual(t, o.ModTime().String(), co.ModTime().String())
+	require.NotEqual(t, o.ModTime(context.Background()).String(), co.ModTime(context.Background()).String())
 
 	cfs.DirCacheFlush() // flush the cache
 
 	// get a new instance from the cache
-	co, err = rootFs.NewObject("data.bin")
+	co, err = rootFs.NewObject(context.Background(), "data.bin")
 	require.NoError(t, err)
-	require.Equal(t, wrappedTime.Unix(), co.ModTime().Unix())
+	require.Equal(t, wrappedTime.Unix(), co.ModTime(context.Background()).Unix())
 }
 
 func TestInternalChangeSeenAfterRc(t *testing.T) {
@@ -713,19 +714,19 @@ func TestInternalChangeSeenAfterRc(t *testing.T) {
 	runInstance.writeRemoteBytes(t, rootFs, "data.bin", testData)
 
 	// update in the wrapped fs
-	o, err := cfs.UnWrap().NewObject(runInstance.encryptRemoteIfNeeded(t, "data.bin"))
+	o, err := cfs.UnWrap().NewObject(context.Background(), runInstance.encryptRemoteIfNeeded(t, "data.bin"))
 	require.NoError(t, err)
 	wrappedTime := time.Now().Add(-1 * time.Hour)
-	err = o.SetModTime(wrappedTime)
+	err = o.SetModTime(context.Background(), wrappedTime)
 	require.NoError(t, err)
 
 	// get a new instance from the cache
-	co, err := rootFs.NewObject("data.bin")
+	co, err := rootFs.NewObject(context.Background(), "data.bin")
 	require.NoError(t, err)
-	require.NotEqual(t, o.ModTime().String(), co.ModTime().String())
+	require.NotEqual(t, o.ModTime(context.Background()).String(), co.ModTime(context.Background()).String())
 
 	// Call the rc function
-	m, err := cacheExpire.Fn(rc.Params{"remote": "data.bin"})
+	m, err := cacheExpire.Fn(context.Background(), rc.Params{"remote": "data.bin"})
 	require.NoError(t, err)
 	require.Contains(t, m, "status")
 	require.Contains(t, m, "message")
@@ -733,9 +734,9 @@ func TestInternalChangeSeenAfterRc(t *testing.T) {
 	require.Contains(t, m["message"], "cached file cleared")
 
 	// get a new instance from the cache
-	co, err = rootFs.NewObject("data.bin")
+	co, err = rootFs.NewObject(context.Background(), "data.bin")
 	require.NoError(t, err)
-	require.Equal(t, wrappedTime.Unix(), co.ModTime().Unix())
+	require.Equal(t, wrappedTime.Unix(), co.ModTime(context.Background()).Unix())
 	_, err = runInstance.list(t, rootFs, "")
 	require.NoError(t, err)
 
@@ -749,7 +750,7 @@ func TestInternalChangeSeenAfterRc(t *testing.T) {
 	require.Len(t, li1, 1)
 
 	// Call the rc function
-	m, err = cacheExpire.Fn(rc.Params{"remote": "/"})
+	m, err = cacheExpire.Fn(context.Background(), rc.Params{"remote": "/"})
 	require.NoError(t, err)
 	require.Contains(t, m, "status")
 	require.Contains(t, m, "message")
@@ -794,7 +795,7 @@ func TestInternalMaxChunkSizeRespected(t *testing.T) {
 	// create some rand test data
 	testData := randStringBytes(int(int64(totalChunks-1)*chunkSize + chunkSize/2))
 	runInstance.writeRemoteBytes(t, rootFs, "data.bin", testData)
-	o, err := cfs.NewObject(runInstance.encryptRemoteIfNeeded(t, "data.bin"))
+	o, err := cfs.NewObject(context.Background(), runInstance.encryptRemoteIfNeeded(t, "data.bin"))
 	require.NoError(t, err)
 	co, ok := o.(*cache.Object)
 	require.True(t, ok)
@@ -833,7 +834,7 @@ func TestInternalExpiredEntriesRemoved(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, l, 1)
 
-	err = cfs.UnWrap().Mkdir(runInstance.encryptRemoteIfNeeded(t, "test/third"))
+	err = cfs.UnWrap().Mkdir(context.Background(), runInstance.encryptRemoteIfNeeded(t, "test/third"))
 	require.NoError(t, err)
 
 	l, err = runInstance.list(t, rootFs, "test")
@@ -868,14 +869,14 @@ func TestInternalBug2117(t *testing.T) {
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
 
-	err = cfs.UnWrap().Mkdir("test")
+	err = cfs.UnWrap().Mkdir(context.Background(), "test")
 	require.NoError(t, err)
 	for i := 1; i <= 4; i++ {
-		err = cfs.UnWrap().Mkdir(fmt.Sprintf("test/dir%d", i))
+		err = cfs.UnWrap().Mkdir(context.Background(), fmt.Sprintf("test/dir%d", i))
 		require.NoError(t, err)
 
 		for j := 1; j <= 4; j++ {
-			err = cfs.UnWrap().Mkdir(fmt.Sprintf("test/dir%d/dir%d", i, j))
+			err = cfs.UnWrap().Mkdir(context.Background(), fmt.Sprintf("test/dir%d/dir%d", i, j))
 			require.NoError(t, err)
 
 			runInstance.writeObjectString(t, cfs.UnWrap(), fmt.Sprintf("test/dir%d/dir%d/test.txt", i, j), "test")
@@ -1080,10 +1081,10 @@ func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool
 	}
 
 	if purge {
-		_ = f.Features().Purge()
+		_ = f.Features().Purge(context.Background())
 		require.NoError(t, err)
 	}
-	err = f.Mkdir("")
+	err = f.Mkdir(context.Background(), "")
 	require.NoError(t, err)
 	if r.useMount && !r.isMounted {
 		r.mountFs(t, f)
@@ -1097,7 +1098,7 @@ func (r *run) cleanupFs(t *testing.T, f fs.Fs, b *cache.Persistent) {
 		r.unmountFs(t, f)
 	}
 
-	err := f.Features().Purge()
+	err := f.Features().Purge(context.Background())
 	require.NoError(t, err)
 	cfs, err := r.getCacheFs(f)
 	require.NoError(t, err)
@@ -1199,7 +1200,7 @@ func (r *run) writeRemoteReader(t *testing.T, f fs.Fs, remote string, in io.Read
 func (r *run) writeObjectBytes(t *testing.T, f fs.Fs, remote string, data []byte) fs.Object {
 	in := bytes.NewReader(data)
 	_ = r.writeObjectReader(t, f, remote, in)
-	o, err := f.NewObject(remote)
+	o, err := f.NewObject(context.Background(), remote)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), o.Size())
 	return o
@@ -1208,7 +1209,7 @@ func (r *run) writeObjectBytes(t *testing.T, f fs.Fs, remote string, data []byte
 func (r *run) writeObjectReader(t *testing.T, f fs.Fs, remote string, in io.Reader) fs.Object {
 	modTime := time.Now()
 	objInfo := object.NewStaticObjectInfo(remote, modTime, -1, true, nil, f)
-	obj, err := f.Put(in, objInfo)
+	obj, err := f.Put(context.Background(), in, objInfo)
 	require.NoError(t, err)
 	if r.useMount {
 		r.vfs.WaitForWriters(10 * time.Second)
@@ -1228,18 +1229,18 @@ func (r *run) updateObjectRemote(t *testing.T, f fs.Fs, remote string, data1 []b
 		err = ioutil.WriteFile(path.Join(r.mntDir, remote), data2, 0600)
 		require.NoError(t, err)
 		r.vfs.WaitForWriters(10 * time.Second)
-		obj, err = f.NewObject(remote)
+		obj, err = f.NewObject(context.Background(), remote)
 	} else {
 		in1 := bytes.NewReader(data1)
 		in2 := bytes.NewReader(data2)
 		objInfo1 := object.NewStaticObjectInfo(remote, time.Now(), int64(len(data1)), true, nil, f)
 		objInfo2 := object.NewStaticObjectInfo(remote, time.Now(), int64(len(data2)), true, nil, f)
 
-		obj, err = f.Put(in1, objInfo1)
+		obj, err = f.Put(context.Background(), in1, objInfo1)
 		require.NoError(t, err)
-		obj, err = f.NewObject(remote)
+		obj, err = f.NewObject(context.Background(), remote)
 		require.NoError(t, err)
-		err = obj.Update(in2, objInfo2)
+		err = obj.Update(context.Background(), in2, objInfo2)
 	}
 	require.NoError(t, err)
 
@@ -1268,7 +1269,7 @@ func (r *run) readDataFromRemote(t *testing.T, f fs.Fs, remote string, offset, e
 			return checkSample, err
 		}
 	} else {
-		co, err := f.NewObject(remote)
+		co, err := f.NewObject(context.Background(), remote)
 		if err != nil {
 			return checkSample, err
 		}
@@ -1283,7 +1284,7 @@ func (r *run) readDataFromRemote(t *testing.T, f fs.Fs, remote string, offset, e
 func (r *run) readDataFromObj(t *testing.T, o fs.Object, offset, end int64, noLengthCheck bool) []byte {
 	size := end - offset
 	checkSample := make([]byte, size)
-	reader, err := o.Open(&fs.SeekOption{Offset: offset})
+	reader, err := o.Open(context.Background(), &fs.SeekOption{Offset: offset})
 	require.NoError(t, err)
 	totalRead, err := io.ReadFull(reader, checkSample)
 	if (err == io.EOF || err == io.ErrUnexpectedEOF) && noLengthCheck {
@@ -1300,7 +1301,7 @@ func (r *run) mkdir(t *testing.T, f fs.Fs, remote string) {
 	if r.useMount {
 		err = os.Mkdir(path.Join(r.mntDir, remote), 0700)
 	} else {
-		err = f.Mkdir(remote)
+		err = f.Mkdir(context.Background(), remote)
 	}
 	require.NoError(t, err)
 }
@@ -1312,11 +1313,11 @@ func (r *run) rm(t *testing.T, f fs.Fs, remote string) error {
 		err = os.Remove(path.Join(r.mntDir, remote))
 	} else {
 		var obj fs.Object
-		obj, err = f.NewObject(remote)
+		obj, err = f.NewObject(context.Background(), remote)
 		if err != nil {
-			err = f.Rmdir(remote)
+			err = f.Rmdir(context.Background(), remote)
 		} else {
-			err = obj.Remove()
+			err = obj.Remove(context.Background())
 		}
 	}
 
@@ -1334,7 +1335,7 @@ func (r *run) list(t *testing.T, f fs.Fs, remote string) ([]interface{}, error) 
 		}
 	} else {
 		var list fs.DirEntries
-		list, err = f.List(remote)
+		list, err = f.List(context.Background(), remote)
 		for _, ll := range list {
 			l = append(l, ll)
 		}
@@ -1353,7 +1354,7 @@ func (r *run) listPath(t *testing.T, f fs.Fs, remote string) []string {
 		}
 	} else {
 		var list fs.DirEntries
-		list, err = f.List(remote)
+		list, err = f.List(context.Background(), remote)
 		for _, ll := range list {
 			l = append(l, ll.Remote())
 		}
@@ -1393,7 +1394,7 @@ func (r *run) dirMove(t *testing.T, rootFs fs.Fs, src, dst string) error {
 		}
 		r.vfs.WaitForWriters(10 * time.Second)
 	} else if rootFs.Features().DirMove != nil {
-		err = rootFs.Features().DirMove(rootFs, src, dst)
+		err = rootFs.Features().DirMove(context.Background(), rootFs, src, dst)
 		if err != nil {
 			return err
 		}
@@ -1415,11 +1416,11 @@ func (r *run) move(t *testing.T, rootFs fs.Fs, src, dst string) error {
 		}
 		r.vfs.WaitForWriters(10 * time.Second)
 	} else if rootFs.Features().Move != nil {
-		obj1, err := rootFs.NewObject(src)
+		obj1, err := rootFs.NewObject(context.Background(), src)
 		if err != nil {
 			return err
 		}
-		_, err = rootFs.Features().Move(obj1, dst)
+		_, err = rootFs.Features().Move(context.Background(), obj1, dst)
 		if err != nil {
 			return err
 		}
@@ -1441,11 +1442,11 @@ func (r *run) copy(t *testing.T, rootFs fs.Fs, src, dst string) error {
 		}
 		r.vfs.WaitForWriters(10 * time.Second)
 	} else if rootFs.Features().Copy != nil {
-		obj, err := rootFs.NewObject(src)
+		obj, err := rootFs.NewObject(context.Background(), src)
 		if err != nil {
 			return err
 		}
-		_, err = rootFs.Features().Copy(obj, dst)
+		_, err = rootFs.Features().Copy(context.Background(), obj, dst)
 		if err != nil {
 			return err
 		}
@@ -1467,11 +1468,11 @@ func (r *run) modTime(t *testing.T, rootFs fs.Fs, src string) (time.Time, error)
 		}
 		return fi.ModTime(), nil
 	}
-	obj1, err := rootFs.NewObject(src)
+	obj1, err := rootFs.NewObject(context.Background(), src)
 	if err != nil {
 		return time.Time{}, err
 	}
-	return obj1.ModTime(), nil
+	return obj1.ModTime(context.Background()), nil
 }
 
 func (r *run) size(t *testing.T, rootFs fs.Fs, src string) (int64, error) {
@@ -1484,7 +1485,7 @@ func (r *run) size(t *testing.T, rootFs fs.Fs, src string) (int64, error) {
 		}
 		return fi.Size(), nil
 	}
-	obj1, err := rootFs.NewObject(src)
+	obj1, err := rootFs.NewObject(context.Background(), src)
 	if err != nil {
 		return int64(0), err
 	}
@@ -1507,14 +1508,14 @@ func (r *run) updateData(t *testing.T, rootFs fs.Fs, src, data, append string) e
 		_, err = f.WriteString(data + append)
 	} else {
 		var obj1 fs.Object
-		obj1, err = rootFs.NewObject(src)
+		obj1, err = rootFs.NewObject(context.Background(), src)
 		if err != nil {
 			return err
 		}
 		data1 := []byte(data + append)
 		r := bytes.NewReader(data1)
 		objInfo1 := object.NewStaticObjectInfo(src, time.Now(), int64(len(data1)), true, nil, rootFs)
-		err = obj1.Update(r, objInfo1)
+		err = obj1.Update(context.Background(), r, objInfo1)
 	}
 
 	return err

--- a/backend/cache/directory.go
+++ b/backend/cache/directory.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"path"
 	"time"
 
@@ -55,7 +56,7 @@ func ShallowDirectory(f *Fs, remote string) *Directory {
 }
 
 // DirectoryFromOriginal builds one from a generic fs.Directory
-func DirectoryFromOriginal(f *Fs, d fs.Directory) *Directory {
+func DirectoryFromOriginal(ctx context.Context, f *Fs, d fs.Directory) *Directory {
 	var cd *Directory
 	fullRemote := path.Join(f.Root(), d.Remote())
 
@@ -67,7 +68,7 @@ func DirectoryFromOriginal(f *Fs, d fs.Directory) *Directory {
 		CacheFs:      f,
 		Name:         name,
 		Dir:          dir,
-		CacheModTime: d.ModTime().UnixNano(),
+		CacheModTime: d.ModTime(ctx).UnixNano(),
 		CacheSize:    d.Size(),
 		CacheItems:   d.Items(),
 		CacheType:    "Directory",
@@ -110,7 +111,7 @@ func (d *Directory) parentRemote() string {
 }
 
 // ModTime returns the cached ModTime
-func (d *Directory) ModTime() time.Time {
+func (d *Directory) ModTime(ctx context.Context) time.Time {
 	return time.Unix(0, d.CacheModTime)
 }
 

--- a/backend/cache/object.go
+++ b/backend/cache/object.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"io"
 	"path"
 	"sync"
@@ -68,7 +69,7 @@ func NewObject(f *Fs, remote string) *Object {
 }
 
 // ObjectFromOriginal builds one from a generic fs.Object
-func ObjectFromOriginal(f *Fs, o fs.Object) *Object {
+func ObjectFromOriginal(ctx context.Context, f *Fs, o fs.Object) *Object {
 	var co *Object
 	fullRemote := cleanPath(path.Join(f.Root(), o.Remote()))
 	dir, name := path.Split(fullRemote)
@@ -92,13 +93,13 @@ func ObjectFromOriginal(f *Fs, o fs.Object) *Object {
 		CacheType: cacheType,
 		CacheTs:   time.Now(),
 	}
-	co.updateData(o)
+	co.updateData(ctx, o)
 	return co
 }
 
-func (o *Object) updateData(source fs.Object) {
+func (o *Object) updateData(ctx context.Context, source fs.Object) {
 	o.Object = source
-	o.CacheModTime = source.ModTime().UnixNano()
+	o.CacheModTime = source.ModTime(ctx).UnixNano()
 	o.CacheSize = source.Size()
 	o.CacheStorable = source.Storable()
 	o.CacheTs = time.Now()
@@ -130,20 +131,20 @@ func (o *Object) abs() string {
 }
 
 // ModTime returns the cached ModTime
-func (o *Object) ModTime() time.Time {
-	_ = o.refresh()
+func (o *Object) ModTime(ctx context.Context) time.Time {
+	_ = o.refresh(ctx)
 	return time.Unix(0, o.CacheModTime)
 }
 
 // Size returns the cached Size
 func (o *Object) Size() int64 {
-	_ = o.refresh()
+	_ = o.refresh(context.TODO())
 	return o.CacheSize
 }
 
 // Storable returns the cached Storable
 func (o *Object) Storable() bool {
-	_ = o.refresh()
+	_ = o.refresh(context.TODO())
 	return o.CacheStorable
 }
 
@@ -151,18 +152,18 @@ func (o *Object) Storable() bool {
 // all these conditions must be true to ignore a refresh
 // 1. cache ts didn't expire yet
 // 2. is not pending a notification from the wrapped fs
-func (o *Object) refresh() error {
+func (o *Object) refresh(ctx context.Context) error {
 	isNotified := o.CacheFs.isNotifiedRemote(o.Remote())
 	isExpired := time.Now().After(o.CacheTs.Add(time.Duration(o.CacheFs.opt.InfoAge)))
 	if !isExpired && !isNotified {
 		return nil
 	}
 
-	return o.refreshFromSource(true)
+	return o.refreshFromSource(ctx, true)
 }
 
 // refreshFromSource requests the original FS for the object in case it comes from a cached entry
-func (o *Object) refreshFromSource(force bool) error {
+func (o *Object) refreshFromSource(ctx context.Context, force bool) error {
 	o.refreshMutex.Lock()
 	defer o.refreshMutex.Unlock()
 	var err error
@@ -172,29 +173,29 @@ func (o *Object) refreshFromSource(force bool) error {
 		return nil
 	}
 	if o.isTempFile() {
-		liveObject, err = o.ParentFs.NewObject(o.Remote())
+		liveObject, err = o.ParentFs.NewObject(ctx, o.Remote())
 		err = errors.Wrapf(err, "in parent fs %v", o.ParentFs)
 	} else {
-		liveObject, err = o.CacheFs.Fs.NewObject(o.Remote())
+		liveObject, err = o.CacheFs.Fs.NewObject(ctx, o.Remote())
 		err = errors.Wrapf(err, "in cache fs %v", o.CacheFs.Fs)
 	}
 	if err != nil {
 		fs.Errorf(o, "error refreshing object in : %v", err)
 		return err
 	}
-	o.updateData(liveObject)
+	o.updateData(ctx, liveObject)
 	o.persist()
 
 	return nil
 }
 
 // SetModTime sets the ModTime of this object
-func (o *Object) SetModTime(t time.Time) error {
-	if err := o.refreshFromSource(false); err != nil {
+func (o *Object) SetModTime(ctx context.Context, t time.Time) error {
+	if err := o.refreshFromSource(ctx, false); err != nil {
 		return err
 	}
 
-	err := o.Object.SetModTime(t)
+	err := o.Object.SetModTime(ctx, t)
 	if err != nil {
 		return err
 	}
@@ -207,19 +208,19 @@ func (o *Object) SetModTime(t time.Time) error {
 }
 
 // Open is used to request a specific part of the file using fs.RangeOption
-func (o *Object) Open(options ...fs.OpenOption) (io.ReadCloser, error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
 	var err error
 
 	if o.Object == nil {
-		err = o.refreshFromSource(true)
+		err = o.refreshFromSource(ctx, true)
 	} else {
-		err = o.refresh()
+		err = o.refresh(ctx)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	cacheReader := NewObjectHandle(o, o.CacheFs)
+	cacheReader := NewObjectHandle(ctx, o, o.CacheFs)
 	var offset, limit int64 = 0, -1
 	for _, option := range options {
 		switch x := option.(type) {
@@ -238,8 +239,8 @@ func (o *Object) Open(options ...fs.OpenOption) (io.ReadCloser, error) {
 }
 
 // Update will change the object data
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
-	if err := o.refreshFromSource(false); err != nil {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+	if err := o.refreshFromSource(ctx, false); err != nil {
 		return err
 	}
 	// pause background uploads if active
@@ -254,7 +255,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	fs.Debugf(o, "updating object contents with size %v", src.Size())
 
 	// FIXME use reliable upload
-	err := o.Object.Update(in, src, options...)
+	err := o.Object.Update(ctx, in, src, options...)
 	if err != nil {
 		fs.Errorf(o, "error updating source: %v", err)
 		return err
@@ -265,7 +266,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	// advertise to ChangeNotify if wrapped doesn't do that
 	o.CacheFs.notifyChangeUpstreamIfNeeded(o.Remote(), fs.EntryObject)
 
-	o.CacheModTime = src.ModTime().UnixNano()
+	o.CacheModTime = src.ModTime(ctx).UnixNano()
 	o.CacheSize = src.Size()
 	o.CacheHashes = make(map[hash.Type]string)
 	o.CacheTs = time.Now()
@@ -275,8 +276,8 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 }
 
 // Remove deletes the object from both the cache and the source
-func (o *Object) Remove() error {
-	if err := o.refreshFromSource(false); err != nil {
+func (o *Object) Remove(ctx context.Context) error {
+	if err := o.refreshFromSource(ctx, false); err != nil {
 		return err
 	}
 	// pause background uploads if active
@@ -288,7 +289,7 @@ func (o *Object) Remove() error {
 			return errors.Errorf("%v is currently uploading, can't delete", o)
 		}
 	}
-	err := o.Object.Remove()
+	err := o.Object.Remove(ctx)
 	if err != nil {
 		return err
 	}
@@ -306,8 +307,8 @@ func (o *Object) Remove() error {
 
 // Hash requests a hash of the object and stores in the cache
 // since it might or might not be called, this is lazy loaded
-func (o *Object) Hash(ht hash.Type) (string, error) {
-	_ = o.refresh()
+func (o *Object) Hash(ctx context.Context, ht hash.Type) (string, error) {
+	_ = o.refresh(ctx)
 	if o.CacheHashes == nil {
 		o.CacheHashes = make(map[hash.Type]string)
 	}
@@ -316,10 +317,10 @@ func (o *Object) Hash(ht hash.Type) (string, error) {
 	if found {
 		return cachedHash, nil
 	}
-	if err := o.refreshFromSource(false); err != nil {
+	if err := o.refreshFromSource(ctx, false); err != nil {
 		return "", err
 	}
-	liveHash, err := o.Object.Hash(ht)
+	liveHash, err := o.Object.Hash(ctx, ht)
 	if err != nil {
 		return "", err
 	}

--- a/backend/cache/storage_persistent.go
+++ b/backend/cache/storage_persistent.go
@@ -4,6 +4,7 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -1014,7 +1015,7 @@ func (b *Persistent) SetPendingUploadToStarted(remote string) error {
 }
 
 // ReconcileTempUploads will recursively look for all the files in the temp directory and add them to the queue
-func (b *Persistent) ReconcileTempUploads(cacheFs *Fs) error {
+func (b *Persistent) ReconcileTempUploads(ctx context.Context, cacheFs *Fs) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		_ = tx.DeleteBucket([]byte(tempBucket))
 		bucket, err := tx.CreateBucketIfNotExists([]byte(tempBucket))
@@ -1023,7 +1024,7 @@ func (b *Persistent) ReconcileTempUploads(cacheFs *Fs) error {
 		}
 
 		var queuedEntries []fs.Object
-		err = walk.ListR(cacheFs.tempFs, "", true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
+		err = walk.ListR(ctx, cacheFs.tempFs, "", true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
 			for _, o := range entries {
 				if oo, ok := o.(fs.Object); ok {
 					queuedEntries = append(queuedEntries, oo)

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -2,6 +2,7 @@
 package crypt
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -232,7 +233,7 @@ func (f *Fs) add(entries *fs.DirEntries, obj fs.Object) {
 }
 
 // Encrypt an directory file name to entries.
-func (f *Fs) addDir(entries *fs.DirEntries, dir fs.Directory) {
+func (f *Fs) addDir(ctx context.Context, entries *fs.DirEntries, dir fs.Directory) {
 	remote := dir.Remote()
 	decryptedRemote, err := f.cipher.DecryptDirName(remote)
 	if err != nil {
@@ -242,18 +243,18 @@ func (f *Fs) addDir(entries *fs.DirEntries, dir fs.Directory) {
 	if f.opt.ShowMapping {
 		fs.Logf(decryptedRemote, "Encrypts to %q", remote)
 	}
-	*entries = append(*entries, f.newDir(dir))
+	*entries = append(*entries, f.newDir(ctx, dir))
 }
 
 // Encrypt some directory entries.  This alters entries returning it as newEntries.
-func (f *Fs) encryptEntries(entries fs.DirEntries) (newEntries fs.DirEntries, err error) {
+func (f *Fs) encryptEntries(ctx context.Context, entries fs.DirEntries) (newEntries fs.DirEntries, err error) {
 	newEntries = entries[:0] // in place filter
 	for _, entry := range entries {
 		switch x := entry.(type) {
 		case fs.Object:
 			f.add(&newEntries, x)
 		case fs.Directory:
-			f.addDir(&newEntries, x)
+			f.addDir(ctx, &newEntries, x)
 		default:
 			return nil, errors.Errorf("Unknown object type %T", entry)
 		}
@@ -270,12 +271,12 @@ func (f *Fs) encryptEntries(entries fs.DirEntries) (newEntries fs.DirEntries, er
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
-	entries, err = f.Fs.List(f.cipher.EncryptDirName(dir))
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
+	entries, err = f.Fs.List(ctx, f.cipher.EncryptDirName(dir))
 	if err != nil {
 		return nil, err
 	}
-	return f.encryptEntries(entries)
+	return f.encryptEntries(ctx, entries)
 }
 
 // ListR lists the objects and directories of the Fs starting
@@ -294,9 +295,9 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 //
 // Don't implement this unless you have a more efficient way
 // of listing recursively that doing a directory traversal.
-func (f *Fs) ListR(dir string, callback fs.ListRCallback) (err error) {
-	return f.Fs.Features().ListR(f.cipher.EncryptDirName(dir), func(entries fs.DirEntries) error {
-		newEntries, err := f.encryptEntries(entries)
+func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (err error) {
+	return f.Fs.Features().ListR(ctx, f.cipher.EncryptDirName(dir), func(entries fs.DirEntries) error {
+		newEntries, err := f.encryptEntries(ctx, entries)
 		if err != nil {
 			return err
 		}
@@ -305,18 +306,18 @@ func (f *Fs) ListR(dir string, callback fs.ListRCallback) (err error) {
 }
 
 // NewObject finds the Object at remote.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
-	o, err := f.Fs.NewObject(f.cipher.EncryptFileName(remote))
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	o, err := f.Fs.NewObject(ctx, f.cipher.EncryptFileName(remote))
 	if err != nil {
 		return nil, err
 	}
 	return f.newObject(o), nil
 }
 
-type putFn func(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error)
+type putFn func(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error)
 
 // put implements Put or PutStream
-func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put putFn) (fs.Object, error) {
+func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put putFn) (fs.Object, error) {
 	// Encrypt the data into wrappedIn
 	wrappedIn, err := f.cipher.EncryptData(in)
 	if err != nil {
@@ -342,7 +343,7 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 	}
 
 	// Transfer the data
-	o, err := put(wrappedIn, f.newObjectInfo(src), options...)
+	o, err := put(ctx, wrappedIn, f.newObjectInfo(src), options...)
 	if err != nil {
 		return nil, err
 	}
@@ -351,13 +352,13 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 	if ht != hash.None && hasher != nil {
 		srcHash := hasher.Sums()[ht]
 		var dstHash string
-		dstHash, err = o.Hash(ht)
+		dstHash, err = o.Hash(ctx, ht)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read destination hash")
 		}
 		if srcHash != "" && dstHash != "" && srcHash != dstHash {
 			// remove object
-			err = o.Remove()
+			err = o.Remove(ctx)
 			if err != nil {
 				fs.Errorf(o, "Failed to remove corrupted object: %v", err)
 			}
@@ -373,13 +374,13 @@ func (f *Fs) put(in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put p
 // May create the object even if it returns an error - if so
 // will return the object and the error, otherwise will return
 // nil and the error
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	return f.put(in, src, options, f.Fs.Put)
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	return f.put(ctx, in, src, options, f.Fs.Put)
 }
 
 // PutStream uploads to the remote path with the modTime given of indeterminate size
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	return f.put(in, src, options, f.Fs.Features().PutStream)
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	return f.put(ctx, in, src, options, f.Fs.Features().PutStream)
 }
 
 // Hashes returns the supported hash sets.
@@ -390,15 +391,15 @@ func (f *Fs) Hashes() hash.Set {
 // Mkdir makes the directory (container, bucket)
 //
 // Shouldn't return an error if it already exists
-func (f *Fs) Mkdir(dir string) error {
-	return f.Fs.Mkdir(f.cipher.EncryptDirName(dir))
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
+	return f.Fs.Mkdir(ctx, f.cipher.EncryptDirName(dir))
 }
 
 // Rmdir removes the directory (container, bucket) if empty
 //
 // Return an error if it doesn't exist or isn't empty
-func (f *Fs) Rmdir(dir string) error {
-	return f.Fs.Rmdir(f.cipher.EncryptDirName(dir))
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
+	return f.Fs.Rmdir(ctx, f.cipher.EncryptDirName(dir))
 }
 
 // Purge all files in the root and the root directory
@@ -407,12 +408,12 @@ func (f *Fs) Rmdir(dir string) error {
 // quicker than just running Remove() on the result of List()
 //
 // Return an error if it doesn't exist
-func (f *Fs) Purge() error {
+func (f *Fs) Purge(ctx context.Context) error {
 	do := f.Fs.Features().Purge
 	if do == nil {
 		return fs.ErrorCantPurge
 	}
-	return do()
+	return do(ctx)
 }
 
 // Copy src to this remote using server side copy operations.
@@ -424,7 +425,7 @@ func (f *Fs) Purge() error {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantCopy
-func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	do := f.Fs.Features().Copy
 	if do == nil {
 		return nil, fs.ErrorCantCopy
@@ -433,7 +434,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	if !ok {
 		return nil, fs.ErrorCantCopy
 	}
-	oResult, err := do(o.Object, f.cipher.EncryptFileName(remote))
+	oResult, err := do(ctx, o.Object, f.cipher.EncryptFileName(remote))
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +450,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantMove
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	do := f.Fs.Features().Move
 	if do == nil {
 		return nil, fs.ErrorCantMove
@@ -458,7 +459,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 	if !ok {
 		return nil, fs.ErrorCantMove
 	}
-	oResult, err := do(o.Object, f.cipher.EncryptFileName(remote))
+	oResult, err := do(ctx, o.Object, f.cipher.EncryptFileName(remote))
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +474,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	do := f.Fs.Features().DirMove
 	if do == nil {
 		return fs.ErrorCantDirMove
@@ -483,14 +484,14 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 		fs.Debugf(srcFs, "Can't move directory - not same remote type")
 		return fs.ErrorCantDirMove
 	}
-	return do(srcFs.Fs, f.cipher.EncryptDirName(srcRemote), f.cipher.EncryptDirName(dstRemote))
+	return do(ctx, srcFs.Fs, f.cipher.EncryptDirName(srcRemote), f.cipher.EncryptDirName(dstRemote))
 }
 
 // PutUnchecked uploads the object
 //
 // This will create a duplicate if we upload a new file without
 // checking to see if there is one already - use Put() for that.
-func (f *Fs) PutUnchecked(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) PutUnchecked(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	do := f.Fs.Features().PutUnchecked
 	if do == nil {
 		return nil, errors.New("can't PutUnchecked")
@@ -499,7 +500,7 @@ func (f *Fs) PutUnchecked(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOpt
 	if err != nil {
 		return nil, err
 	}
-	o, err := do(wrappedIn, f.newObjectInfo(src))
+	o, err := do(ctx, wrappedIn, f.newObjectInfo(src))
 	if err != nil {
 		return nil, err
 	}
@@ -510,21 +511,21 @@ func (f *Fs) PutUnchecked(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOpt
 //
 // Implement this if you have a way of emptying the trash or
 // otherwise cleaning up old versions of files.
-func (f *Fs) CleanUp() error {
+func (f *Fs) CleanUp(ctx context.Context) error {
 	do := f.Fs.Features().CleanUp
 	if do == nil {
 		return errors.New("can't CleanUp")
 	}
-	return do()
+	return do(ctx)
 }
 
 // About gets quota information from the Fs
-func (f *Fs) About() (*fs.Usage, error) {
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	do := f.Fs.Features().About
 	if do == nil {
 		return nil, errors.New("About not supported")
 	}
-	return do()
+	return do(ctx)
 }
 
 // UnWrap returns the Fs that this Fs is wrapping
@@ -556,10 +557,10 @@ func (f *Fs) DecryptFileName(encryptedFileName string) (string, error) {
 // src with it, and calculates the hash given by HashType on the fly
 //
 // Note that we break lots of encapsulation in this function.
-func (f *Fs) ComputeHash(o *Object, src fs.Object, hashType hash.Type) (hashStr string, err error) {
+func (f *Fs) ComputeHash(ctx context.Context, o *Object, src fs.Object, hashType hash.Type) (hashStr string, err error) {
 	// Read the nonce - opening the file is sufficient to read the nonce in
 	// use a limited read so we only read the header
-	in, err := o.Object.Open(&fs.RangeOption{Start: 0, End: int64(fileHeaderSize) - 1})
+	in, err := o.Object.Open(ctx, &fs.RangeOption{Start: 0, End: int64(fileHeaderSize) - 1})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open object to read nonce")
 	}
@@ -589,7 +590,7 @@ func (f *Fs) ComputeHash(o *Object, src fs.Object, hashType hash.Type) (hashStr 
 	}
 
 	// Open the src for input
-	in, err = src.Open()
+	in, err = src.Open(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open src")
 	}
@@ -616,16 +617,16 @@ func (f *Fs) ComputeHash(o *Object, src fs.Object, hashType hash.Type) (hashStr 
 
 // MergeDirs merges the contents of all the directories passed
 // in into the first one and rmdirs the other directories.
-func (f *Fs) MergeDirs(dirs []fs.Directory) error {
+func (f *Fs) MergeDirs(ctx context.Context, dirs []fs.Directory) error {
 	do := f.Fs.Features().MergeDirs
 	if do == nil {
 		return errors.New("MergeDirs not supported")
 	}
 	out := make([]fs.Directory, len(dirs))
 	for i, dir := range dirs {
-		out[i] = fs.NewDirCopy(dir).SetRemote(f.cipher.EncryptDirName(dir.Remote()))
+		out[i] = fs.NewDirCopy(ctx, dir).SetRemote(f.cipher.EncryptDirName(dir.Remote()))
 	}
-	return do(out)
+	return do(ctx, out)
 }
 
 // DirCacheFlush resets the directory cache - used in testing
@@ -638,23 +639,23 @@ func (f *Fs) DirCacheFlush() {
 }
 
 // PublicLink generates a public link to the remote path (usually readable by anyone)
-func (f *Fs) PublicLink(remote string) (string, error) {
+func (f *Fs) PublicLink(ctx context.Context, remote string) (string, error) {
 	do := f.Fs.Features().PublicLink
 	if do == nil {
 		return "", errors.New("PublicLink not supported")
 	}
-	o, err := f.NewObject(remote)
+	o, err := f.NewObject(ctx, remote)
 	if err != nil {
 		// assume it is a directory
-		return do(f.cipher.EncryptDirName(remote))
+		return do(ctx, f.cipher.EncryptDirName(remote))
 	}
-	return do(o.(*Object).Object.Remote())
+	return do(ctx, o.(*Object).Object.Remote())
 }
 
 // ChangeNotify calls the passed function with a path
 // that has had changes. If the implementation
 // uses polling, it should adhere to the given interval.
-func (f *Fs) ChangeNotify(notifyFunc func(string, fs.EntryType), pollIntervalChan <-chan time.Duration) {
+func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryType), pollIntervalChan <-chan time.Duration) {
 	do := f.Fs.Features().ChangeNotify
 	if do == nil {
 		return
@@ -680,7 +681,7 @@ func (f *Fs) ChangeNotify(notifyFunc func(string, fs.EntryType), pollIntervalCha
 		}
 		notifyFunc(decrypted, entryType)
 	}
-	do(wrappedNotifyFunc, pollIntervalChan)
+	do(ctx, wrappedNotifyFunc, pollIntervalChan)
 }
 
 // Object describes a wrapped for being read from the Fs
@@ -733,7 +734,7 @@ func (o *Object) Size() int64 {
 
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
-func (o *Object) Hash(ht hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, ht hash.Type) (string, error) {
 	return "", hash.ErrUnsupported
 }
 
@@ -743,7 +744,7 @@ func (o *Object) UnWrap() fs.Object {
 }
 
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
-func (o *Object) Open(options ...fs.OpenOption) (rc io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (rc io.ReadCloser, err error) {
 	var openOptions []fs.OpenOption
 	var offset, limit int64 = 0, -1
 	for _, option := range options {
@@ -757,10 +758,10 @@ func (o *Object) Open(options ...fs.OpenOption) (rc io.ReadCloser, err error) {
 			openOptions = append(openOptions, option)
 		}
 	}
-	rc, err = o.f.cipher.DecryptDataSeek(func(underlyingOffset, underlyingLimit int64) (io.ReadCloser, error) {
+	rc, err = o.f.cipher.DecryptDataSeek(ctx, func(ctx context.Context, underlyingOffset, underlyingLimit int64) (io.ReadCloser, error) {
 		if underlyingOffset == 0 && underlyingLimit < 0 {
 			// Open with no seek
-			return o.Object.Open(openOptions...)
+			return o.Object.Open(ctx, openOptions...)
 		}
 		// Open stream with a range of underlyingOffset, underlyingLimit
 		end := int64(-1)
@@ -771,7 +772,7 @@ func (o *Object) Open(options ...fs.OpenOption) (rc io.ReadCloser, err error) {
 			}
 		}
 		newOpenOptions := append(openOptions, &fs.RangeOption{Start: underlyingOffset, End: end})
-		return o.Object.Open(newOpenOptions...)
+		return o.Object.Open(ctx, newOpenOptions...)
 	}, offset, limit)
 	if err != nil {
 		return nil, err
@@ -780,17 +781,17 @@ func (o *Object) Open(options ...fs.OpenOption) (rc io.ReadCloser, err error) {
 }
 
 // Update in to the object with the modTime given of the given size
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
-	update := func(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-		return o.Object, o.Object.Update(in, src, options...)
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+	update := func(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+		return o.Object, o.Object.Update(ctx, in, src, options...)
 	}
-	_, err := o.f.put(in, src, options, update)
+	_, err := o.f.put(ctx, in, src, options, update)
 	return err
 }
 
 // newDir returns a dir with the Name decrypted
-func (f *Fs) newDir(dir fs.Directory) fs.Directory {
-	newDir := fs.NewDirCopy(dir)
+func (f *Fs) newDir(ctx context.Context, dir fs.Directory) fs.Directory {
+	newDir := fs.NewDirCopy(ctx, dir)
 	remote := dir.Remote()
 	decryptedRemote, err := f.cipher.DecryptDirName(remote)
 	if err != nil {
@@ -837,7 +838,7 @@ func (o *ObjectInfo) Size() int64 {
 
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
-func (o *ObjectInfo) Hash(hash hash.Type) (string, error) {
+func (o *ObjectInfo) Hash(ctx context.Context, hash hash.Type) (string, error) {
 	return "", nil
 }
 

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -2,6 +2,7 @@ package drive
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -195,7 +196,7 @@ func (f *Fs) InternalTestDocumentImport(t *testing.T) {
 	_, f.importMimeTypes, err = parseExtensions("odt,ods,doc")
 	require.NoError(t, err)
 
-	err = operations.CopyFile(f, testFilesFs, "example2.doc", "example2.doc")
+	err = operations.CopyFile(context.Background(), f, testFilesFs, "example2.doc", "example2.doc")
 	require.NoError(t, err)
 }
 
@@ -209,7 +210,7 @@ func (f *Fs) InternalTestDocumentUpdate(t *testing.T) {
 	_, f.importMimeTypes, err = parseExtensions("odt,ods,doc")
 	require.NoError(t, err)
 
-	err = operations.CopyFile(f, testFilesFs, "example2.xlsx", "example1.ods")
+	err = operations.CopyFile(context.Background(), f, testFilesFs, "example2.xlsx", "example1.ods")
 	require.NoError(t, err)
 }
 
@@ -220,10 +221,10 @@ func (f *Fs) InternalTestDocumentExport(t *testing.T) {
 	f.exportExtensions, _, err = parseExtensions("txt")
 	require.NoError(t, err)
 
-	obj, err := f.NewObject("example2.txt")
+	obj, err := f.NewObject(context.Background(), "example2.txt")
 	require.NoError(t, err)
 
-	rc, err := obj.Open()
+	rc, err := obj.Open(context.Background())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, rc.Close()) }()
 
@@ -246,10 +247,10 @@ func (f *Fs) InternalTestDocumentLink(t *testing.T) {
 	f.exportExtensions, _, err = parseExtensions("link.html")
 	require.NoError(t, err)
 
-	obj, err := f.NewObject("example2.link.html")
+	obj, err := f.NewObject(context.Background(), "example2.link.html")
 	require.NoError(t, err)
 
-	rc, err := obj.Open()
+	rc, err := obj.Open(context.Background())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, rc.Close()) }()
 

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -5,6 +5,7 @@
 package http
 
 import (
+	"context"
 	"io"
 	"mime"
 	"net/http"
@@ -207,7 +208,7 @@ func (f *Fs) Precision() time.Duration {
 }
 
 // NewObject creates a new remote http file object
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	o := &Object{
 		fs:     f,
 		remote: remote,
@@ -359,7 +360,7 @@ func (f *Fs) readDir(dir string) (names []string, err error) {
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 	if !strings.HasSuffix(dir, "/") && dir != "" {
 		dir += "/"
 	}
@@ -399,12 +400,12 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 // May create the object even if it returns an error - if so
 // will return the object and the error, otherwise will return
 // nil and the error
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	return nil, errorReadOnly
 }
 
 // PutStream uploads to the remote path with the modTime given of indeterminate size
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	return nil, errorReadOnly
 }
 
@@ -427,7 +428,7 @@ func (o *Object) Remote() string {
 }
 
 // Hash returns "" since HTTP (in Go or OpenSSH) doesn't support remote calculation of hashes
-func (o *Object) Hash(r hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, r hash.Type) (string, error) {
 	return "", hash.ErrUnsupported
 }
 
@@ -437,7 +438,7 @@ func (o *Object) Size() int64 {
 }
 
 // ModTime returns the modification time of the remote http file
-func (o *Object) ModTime() time.Time {
+func (o *Object) ModTime(ctx context.Context) time.Time {
 	return o.modTime
 }
 
@@ -480,7 +481,7 @@ func (o *Object) stat() error {
 // SetModTime sets the modification and access time to the specified time
 //
 // it also updates the info field
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	return errorReadOnly
 }
 
@@ -490,7 +491,7 @@ func (o *Object) Storable() bool {
 }
 
 // Open a remote http file object for reading. Seek is supported
-func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	url := o.url()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -517,27 +518,27 @@ func (f *Fs) Hashes() hash.Set {
 }
 
 // Mkdir makes the root directory of the Fs object
-func (f *Fs) Mkdir(dir string) error {
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 	return errorReadOnly
 }
 
 // Remove a remote http file object
-func (o *Object) Remove() error {
+func (o *Object) Remove(ctx context.Context) error {
 	return errorReadOnly
 }
 
 // Rmdir removes the root directory of the Fs object
-func (f *Fs) Rmdir(dir string) error {
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	return errorReadOnly
 }
 
 // Update in to the object with the modTime given of the given size
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	return errorReadOnly
 }
 
 // MimeType of an Object if known, "" otherwise
-func (o *Object) MimeType() string {
+func (o *Object) MimeType(ctx context.Context) string {
 	return o.contentType
 }
 

--- a/backend/local/about_unix.go
+++ b/backend/local/about_unix.go
@@ -3,6 +3,7 @@
 package local
 
 import (
+	"context"
 	"syscall"
 
 	"github.com/ncw/rclone/fs"
@@ -10,7 +11,7 @@ import (
 )
 
 // About gets quota information
-func (f *Fs) About() (*fs.Usage, error) {
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	var s syscall.Statfs_t
 	err := syscall.Statfs(f.root, &s)
 	if err != nil {

--- a/backend/local/about_windows.go
+++ b/backend/local/about_windows.go
@@ -3,6 +3,7 @@
 package local
 
 import (
+	"context"
 	"syscall"
 	"unsafe"
 
@@ -13,7 +14,7 @@ import (
 var getFreeDiskSpace = syscall.NewLazyDLL("kernel32.dll").NewProc("GetDiskFreeSpaceExW")
 
 // About gets quota information
-func (f *Fs) About() (*fs.Usage, error) {
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	var available, total, free int64
 	_, _, e1 := getFreeDiskSpace.Call(
 		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(f.root))),

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -3,6 +3,7 @@ package local
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -303,7 +304,7 @@ func (f *Fs) newObjectWithInfo(remote, dstPath string, info os.FileInfo) (fs.Obj
 
 // NewObject finds the Object at remote.  If it can't be found
 // it returns the error ErrorObjectNotFound.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	return f.newObjectWithInfo(remote, "", nil)
 }
 
@@ -316,7 +317,7 @@ func (f *Fs) NewObject(remote string) (fs.Object, error) {
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 
 	dir = f.dirNames.Load(dir)
 	fsDirPath := f.cleanPath(filepath.Join(f.root, dir))
@@ -481,11 +482,11 @@ func (m *mapper) Save(in, out string) string {
 }
 
 // Put the Object to the local filesystem
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	remote := src.Remote()
 	// Temporary Object under construction - info filled in by Update()
 	o := f.newObject(remote, "")
-	err := o.Update(in, src, options...)
+	err := o.Update(ctx, in, src, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -493,12 +494,12 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 }
 
 // PutStream uploads to the remote path with the modTime given of indeterminate size
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	return f.Put(in, src, options...)
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	return f.Put(ctx, in, src, options...)
 }
 
 // Mkdir creates the directory if it doesn't exist
-func (f *Fs) Mkdir(dir string) error {
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 	// FIXME: https://github.com/syncthing/syncthing/blob/master/lib/osutil/mkdirall_windows.go
 	root := f.cleanPath(filepath.Join(f.root, dir))
 	err := os.MkdirAll(root, 0777)
@@ -518,7 +519,7 @@ func (f *Fs) Mkdir(dir string) error {
 // Rmdir removes the directory
 //
 // If it isn't empty it will return an error
-func (f *Fs) Rmdir(dir string) error {
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	root := f.cleanPath(filepath.Join(f.root, dir))
 	return os.Remove(root)
 }
@@ -574,7 +575,7 @@ func (f *Fs) readPrecision() (precision time.Duration) {
 		}
 
 		// If it matches - have found the precision
-		// fmt.Println("compare", fi.ModTime(), t)
+		// fmt.Println("compare", fi.ModTime(ctx), t)
 		if fi.ModTime().Equal(t) {
 			// fmt.Println("Precision detected as", duration)
 			return duration
@@ -588,7 +589,7 @@ func (f *Fs) readPrecision() (precision time.Duration) {
 // Optional interface: Only implement this if you have a way of
 // deleting all the files quicker than just running Remove() on the
 // result of List()
-func (f *Fs) Purge() error {
+func (f *Fs) Purge(ctx context.Context) error {
 	fi, err := f.lstat(f.root)
 	if err != nil {
 		return err
@@ -608,7 +609,7 @@ func (f *Fs) Purge() error {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantMove
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	srcObj, ok := src.(*Object)
 	if !ok {
 		fs.Debugf(src, "Can't move - not same remote type")
@@ -667,7 +668,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	srcFs, ok := src.(*Fs)
 	if !ok {
 		fs.Debugf(srcFs, "Can't move directory - not same remote type")
@@ -732,7 +733,7 @@ func (o *Object) Remote() string {
 }
 
 // Hash returns the requested hash of a file as a lowercase hex string
-func (o *Object) Hash(r hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, r hash.Type) (string, error) {
 	// Check that the underlying file hasn't changed
 	oldtime := o.modTime
 	oldsize := o.size
@@ -783,12 +784,12 @@ func (o *Object) Size() int64 {
 }
 
 // ModTime returns the modification time of the object
-func (o *Object) ModTime() time.Time {
+func (o *Object) ModTime(ctx context.Context) time.Time {
 	return o.modTime
 }
 
 // SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	var err error
 	if o.translatedLink {
 		err = lChtimes(o.path, modTime, modTime)
@@ -884,7 +885,7 @@ func (o *Object) openTranslatedLink(offset, limit int64) (lrc io.ReadCloser, err
 }
 
 // Open an object for read
-func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	var offset, limit int64 = 0, -1
 	hashes := hash.Supported
 	for _, option := range options {
@@ -948,7 +949,7 @@ func (nwc nopWriterCloser) Close() error {
 }
 
 // Update the object from in with modTime and size
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	var out io.WriteCloser
 
 	hashes := hash.Supported
@@ -1029,7 +1030,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	o.fs.objectHashesMu.Unlock()
 
 	// Set the mtime
-	err = o.SetModTime(src.ModTime())
+	err = o.SetModTime(ctx, src.ModTime(ctx))
 	if err != nil {
 		return err
 	}
@@ -1043,7 +1044,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 // Pass in the remote desired and the size if known.
 //
 // It truncates any existing object
-func (f *Fs) OpenWriterAt(remote string, size int64) (fs.WriterAtCloser, error) {
+func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.WriterAtCloser, error) {
 	// Temporary Object under construction
 	o := f.newObject(remote, "")
 
@@ -1093,7 +1094,7 @@ func (o *Object) lstat() error {
 }
 
 // Remove an object
-func (o *Object) Remove() error {
+func (o *Object) Remove(ctx context.Context) error {
 	return remove(o.path)
 }
 

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -3,6 +3,7 @@
 package onedrive
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -353,7 +354,7 @@ func (f *Fs) readMetaDataForPathRelativeToID(normalizedID string, relPath string
 }
 
 // readMetaDataForPath reads the metadata from the path (relative to the absolute root)
-func (f *Fs) readMetaDataForPath(path string) (info *api.Item, resp *http.Response, err error) {
+func (f *Fs) readMetaDataForPath(ctx context.Context, path string) (info *api.Item, resp *http.Response, err error) {
 	firstSlashIndex := strings.IndexRune(path, '/')
 
 	if f.driveType != driveTypePersonal || firstSlashIndex == -1 {
@@ -406,7 +407,7 @@ func (f *Fs) readMetaDataForPath(path string) (info *api.Item, resp *http.Respon
 	if !insideRoot || !dirCacheFoundRoot {
 		// We do not have the normalized ID in dirCache for our query to base on. Query it manually.
 		firstDir, relPath = path[:firstSlashIndex], path[firstSlashIndex+1:]
-		info, resp, err := f.readMetaDataForPath(firstDir)
+		info, resp, err := f.readMetaDataForPath(ctx, firstDir)
 		if err != nil {
 			return info, resp, err
 		}
@@ -418,7 +419,7 @@ func (f *Fs) readMetaDataForPath(path string) (info *api.Item, resp *http.Respon
 		} else {
 			// Read metadata based on firstDir
 			firstDir, relPath = path[:firstSlashIndex], path[firstSlashIndex+1:]
-			baseNormalizedID, err = f.dirCache.FindDir(firstDir, false)
+			baseNormalizedID, err = f.dirCache.FindDir(ctx, firstDir, false)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -463,6 +464,7 @@ func (f *Fs) setUploadChunkSize(cs fs.SizeSuffix) (old fs.SizeSuffix, err error)
 
 // NewFs constructs an Fs from the path, container:path
 func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
+	ctx := context.Background()
 	// Parse config into Options struct
 	opt := new(Options)
 	err := configstruct.Set(m, opt)
@@ -503,12 +505,12 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 
 	// Renew the token in the background
 	f.tokenRenewer = oauthutil.NewRenew(f.String(), ts, func() error {
-		_, _, err := f.readMetaDataForPath("")
+		_, _, err := f.readMetaDataForPath(ctx, "")
 		return err
 	})
 
 	// Get rootID
-	rootInfo, _, err := f.readMetaDataForPath("")
+	rootInfo, _, err := f.readMetaDataForPath(ctx, "")
 	if err != nil || rootInfo.GetID() == "" {
 		return nil, errors.Wrap(err, "failed to get root")
 	}
@@ -516,7 +518,7 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 	f.dirCache = dircache.New(root, rootInfo.GetID(), f)
 
 	// Find the current root
-	err = f.dirCache.FindRoot(false)
+	err = f.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		// Assume it is a file
 		newRoot, remote := dircache.SplitPath(root)
@@ -524,12 +526,12 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 		tempF.dirCache = dircache.New(newRoot, rootInfo.ID, &tempF)
 		tempF.root = newRoot
 		// Make new Fs which is the parent
-		err = tempF.dirCache.FindRoot(false)
+		err = tempF.dirCache.FindRoot(ctx, false)
 		if err != nil {
 			// No root so return old f
 			return f, nil
 		}
-		_, err := tempF.newObjectWithInfo(remote, nil)
+		_, err := tempF.newObjectWithInfo(ctx, remote, nil)
 		if err != nil {
 			if err == fs.ErrorObjectNotFound {
 				// File doesn't exist so return old f
@@ -559,7 +561,7 @@ func (f *Fs) rootSlash() string {
 // Return an Object from a path
 //
 // If it can't be found it returns the error fs.ErrorObjectNotFound.
-func (f *Fs) newObjectWithInfo(remote string, info *api.Item) (fs.Object, error) {
+func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *api.Item) (fs.Object, error) {
 	o := &Object{
 		fs:     f,
 		remote: remote,
@@ -569,7 +571,7 @@ func (f *Fs) newObjectWithInfo(remote string, info *api.Item) (fs.Object, error)
 		// Set info
 		err = o.setMetaData(info)
 	} else {
-		err = o.readMetaData() // reads info and meta, returning an error
+		err = o.readMetaData(ctx) // reads info and meta, returning an error
 	}
 	if err != nil {
 		return nil, err
@@ -579,12 +581,12 @@ func (f *Fs) newObjectWithInfo(remote string, info *api.Item) (fs.Object, error)
 
 // NewObject finds the Object at remote.  If it can't be found
 // it returns the error fs.ErrorObjectNotFound.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
-	return f.newObjectWithInfo(remote, nil)
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	return f.newObjectWithInfo(ctx, remote, nil)
 }
 
 // FindLeaf finds a directory of name leaf in the folder with ID pathID
-func (f *Fs) FindLeaf(pathID, leaf string) (pathIDOut string, found bool, err error) {
+func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
 	// fs.Debugf(f, "FindLeaf(%q, %q)", pathID, leaf)
 	_, ok := f.dirCache.GetInv(pathID)
 	if !ok {
@@ -607,7 +609,7 @@ func (f *Fs) FindLeaf(pathID, leaf string) (pathIDOut string, found bool, err er
 }
 
 // CreateDir makes a directory with pathID as parent and name leaf
-func (f *Fs) CreateDir(dirID, leaf string) (newID string, err error) {
+func (f *Fs) CreateDir(ctx context.Context, dirID, leaf string) (newID string, err error) {
 	// fs.Debugf(f, "CreateDir(%q, %q)\n", dirID, leaf)
 	var resp *http.Response
 	var info *api.Item
@@ -697,12 +699,12 @@ OUTER:
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
-	err = f.dirCache.FindRoot(false)
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
+	err = f.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		return nil, err
 	}
-	directoryID, err := f.dirCache.FindDir(dir, false)
+	directoryID, err := f.dirCache.FindDir(ctx, dir, false)
 	if err != nil {
 		return nil, err
 	}
@@ -723,7 +725,7 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 			d.SetItems(folder.ChildCount)
 			entries = append(entries, d)
 		} else {
-			o, err := f.newObjectWithInfo(remote, info)
+			o, err := f.newObjectWithInfo(ctx, remote, info)
 			if err != nil {
 				iErr = err
 				return true
@@ -747,9 +749,9 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 // Returns the object, leaf, directoryID and error
 //
 // Used to create new objects
-func (f *Fs) createObject(remote string, modTime time.Time, size int64) (o *Object, leaf string, directoryID string, err error) {
+func (f *Fs) createObject(ctx context.Context, remote string, modTime time.Time, size int64) (o *Object, leaf string, directoryID string, err error) {
 	// Create the directory for the object if it doesn't exist
-	leaf, directoryID, err = f.dirCache.FindRootAndPath(remote, true)
+	leaf, directoryID, err = f.dirCache.FindRootAndPath(ctx, remote, true)
 	if err != nil {
 		return nil, leaf, directoryID, err
 	}
@@ -766,26 +768,26 @@ func (f *Fs) createObject(remote string, modTime time.Time, size int64) (o *Obje
 // Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	remote := src.Remote()
 	size := src.Size()
-	modTime := src.ModTime()
+	modTime := src.ModTime(ctx)
 
-	o, _, _, err := f.createObject(remote, modTime, size)
+	o, _, _, err := f.createObject(ctx, remote, modTime, size)
 	if err != nil {
 		return nil, err
 	}
-	return o, o.Update(in, src, options...)
+	return o, o.Update(ctx, in, src, options...)
 }
 
 // Mkdir creates the container if it doesn't exist
-func (f *Fs) Mkdir(dir string) error {
-	err := f.dirCache.FindRoot(true)
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
+	err := f.dirCache.FindRoot(ctx, true)
 	if err != nil {
 		return err
 	}
 	if dir != "" {
-		_, err = f.dirCache.FindDir(dir, true)
+		_, err = f.dirCache.FindDir(ctx, dir, true)
 	}
 	return err
 }
@@ -803,17 +805,17 @@ func (f *Fs) deleteObject(id string) error {
 
 // purgeCheck removes the root directory, if check is set then it
 // refuses to do so if it has anything in
-func (f *Fs) purgeCheck(dir string, check bool) error {
+func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 	root := path.Join(f.root, dir)
 	if root == "" {
 		return errors.New("can't purge root directory")
 	}
 	dc := f.dirCache
-	err := dc.FindRoot(false)
+	err := dc.FindRoot(ctx, false)
 	if err != nil {
 		return err
 	}
-	rootID, err := dc.FindDir(dir, false)
+	rootID, err := dc.FindDir(ctx, dir, false)
 	if err != nil {
 		return err
 	}
@@ -840,8 +842,8 @@ func (f *Fs) purgeCheck(dir string, check bool) error {
 // Rmdir deletes the root folder
 //
 // Returns an error if it isn't empty
-func (f *Fs) Rmdir(dir string) error {
-	return f.purgeCheck(dir, true)
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
+	return f.purgeCheck(ctx, dir, true)
 }
 
 // Precision return the precision of this Fs
@@ -850,7 +852,7 @@ func (f *Fs) Precision() time.Duration {
 }
 
 // waitForJob waits for the job with status in url to complete
-func (f *Fs) waitForJob(location string, o *Object) error {
+func (f *Fs) waitForJob(ctx context.Context, location string, o *Object) error {
 	deadline := time.Now().Add(fs.Config.Timeout)
 	for time.Now().Before(deadline) {
 		var resp *http.Response
@@ -881,7 +883,7 @@ func (f *Fs) waitForJob(location string, o *Object) error {
 				return errors.Errorf("%s: async operation returned %q", o.remote, status.Status)
 			}
 		case "completed":
-			err = o.readMetaData()
+			err = o.readMetaData(ctx)
 			return errors.Wrapf(err, "async operation completed but readMetaData failed")
 		}
 
@@ -899,13 +901,13 @@ func (f *Fs) waitForJob(location string, o *Object) error {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantCopy
-func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	srcObj, ok := src.(*Object)
 	if !ok {
 		fs.Debugf(src, "Can't copy - not same remote type")
 		return nil, fs.ErrorCantCopy
 	}
-	err := srcObj.readMetaData()
+	err := srcObj.readMetaData(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -917,7 +919,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	}
 
 	// Create temporary object
-	dstObj, leaf, directoryID, err := f.createObject(remote, srcObj.modTime, srcObj.size)
+	dstObj, leaf, directoryID, err := f.createObject(ctx, remote, srcObj.modTime, srcObj.size)
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +955,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	}
 
 	// Wait for job to finish
-	err = f.waitForJob(location, dstObj)
+	err = f.waitForJob(ctx, location, dstObj)
 	if err != nil {
 		return nil, err
 	}
@@ -961,7 +963,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	// Copy does NOT copy the modTime from the source and there seems to
 	// be no way to set date before
 	// This will create TWO versions on OneDrive
-	err = dstObj.SetModTime(srcObj.ModTime())
+	err = dstObj.SetModTime(ctx, srcObj.ModTime(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -974,8 +976,8 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 // Optional interface: Only implement this if you have a way of
 // deleting all the files quicker than just running Remove() on the
 // result of List()
-func (f *Fs) Purge() error {
-	return f.purgeCheck("", false)
+func (f *Fs) Purge(ctx context.Context) error {
+	return f.purgeCheck(ctx, "", false)
 }
 
 // Move src to this remote using server side move operations.
@@ -987,7 +989,7 @@ func (f *Fs) Purge() error {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantMove
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	srcObj, ok := src.(*Object)
 	if !ok {
 		fs.Debugf(src, "Can't move - not same remote type")
@@ -995,7 +997,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 	}
 
 	// Create temporary object
-	dstObj, leaf, directoryID, err := f.createObject(remote, srcObj.modTime, srcObj.size)
+	dstObj, leaf, directoryID, err := f.createObject(ctx, remote, srcObj.modTime, srcObj.size)
 	if err != nil {
 		return nil, err
 	}
@@ -1049,7 +1051,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	srcFs, ok := src.(*Fs)
 	if !ok {
 		fs.Debugf(srcFs, "Can't move directory - not same remote type")
@@ -1065,14 +1067,14 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 	}
 
 	// find the root src directory
-	err := srcFs.dirCache.FindRoot(false)
+	err := srcFs.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		return err
 	}
 
 	// find the root dst directory
 	if dstRemote != "" {
-		err = f.dirCache.FindRoot(true)
+		err = f.dirCache.FindRoot(ctx, true)
 		if err != nil {
 			return err
 		}
@@ -1088,14 +1090,14 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 	if dstRemote == "" {
 		findPath = f.root
 	}
-	leaf, dstDirectoryID, err = f.dirCache.FindPath(findPath, true)
+	leaf, dstDirectoryID, err = f.dirCache.FindPath(ctx, findPath, true)
 	if err != nil {
 		return err
 	}
 	parsedDstDirID, dstDriveID, _ := parseNormalizedID(dstDirectoryID)
 
 	// Find ID of src
-	srcID, err := srcFs.dirCache.FindDir(srcRemote, false)
+	srcID, err := srcFs.dirCache.FindDir(ctx, srcRemote, false)
 	if err != nil {
 		return err
 	}
@@ -1109,7 +1111,7 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 
 	// Check destination does not exist
 	if dstRemote != "" {
-		_, err = f.dirCache.FindDir(dstRemote, false)
+		_, err = f.dirCache.FindDir(ctx, dstRemote, false)
 		if err == fs.ErrorDirNotFound {
 			// OK
 		} else if err != nil {
@@ -1160,7 +1162,7 @@ func (f *Fs) DirCacheFlush() {
 }
 
 // About gets quota information
-func (f *Fs) About() (usage *fs.Usage, err error) {
+func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 	var drive api.Drive
 	opts := rest.Opts{
 		Method: "GET",
@@ -1193,8 +1195,8 @@ func (f *Fs) Hashes() hash.Set {
 }
 
 // PublicLink returns a link for downloading without accout.
-func (f *Fs) PublicLink(remote string) (link string, err error) {
-	info, _, err := f.readMetaDataForPath(f.srvPath(remote))
+func (f *Fs) PublicLink(ctx context.Context, remote string) (link string, err error) {
+	info, _, err := f.readMetaDataForPath(ctx, f.srvPath(remote))
 	if err != nil {
 		return "", err
 	}
@@ -1249,7 +1251,7 @@ func (o *Object) srvPath() string {
 }
 
 // Hash returns the SHA-1 of an object returning a lowercase hex string
-func (o *Object) Hash(t hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {
 	if o.fs.driveType == driveTypePersonal {
 		if t == hash.SHA1 {
 			return o.sha1, nil
@@ -1264,7 +1266,7 @@ func (o *Object) Hash(t hash.Type) (string, error) {
 
 // Size returns the size of an object in bytes
 func (o *Object) Size() int64 {
-	err := o.readMetaData()
+	err := o.readMetaData(context.TODO())
 	if err != nil {
 		fs.Logf(o, "Failed to read metadata: %v", err)
 		return 0
@@ -1313,11 +1315,11 @@ func (o *Object) setMetaData(info *api.Item) (err error) {
 // readMetaData gets the metadata if it hasn't already been fetched
 //
 // it also sets the info
-func (o *Object) readMetaData() (err error) {
+func (o *Object) readMetaData(ctx context.Context) (err error) {
 	if o.hasMetaData {
 		return nil
 	}
-	info, _, err := o.fs.readMetaDataForPath(o.srvPath())
+	info, _, err := o.fs.readMetaDataForPath(ctx, o.srvPath())
 	if err != nil {
 		if apiErr, ok := err.(*api.Error); ok {
 			if apiErr.ErrorInfo.Code == "itemNotFound" {
@@ -1334,8 +1336,8 @@ func (o *Object) readMetaData() (err error) {
 //
 // It attempts to read the objects mtime and if that isn't present the
 // LastModified returned in the http headers
-func (o *Object) ModTime() time.Time {
-	err := o.readMetaData()
+func (o *Object) ModTime(ctx context.Context) time.Time {
+	err := o.readMetaData(ctx)
 	if err != nil {
 		fs.Logf(o, "Failed to read metadata: %v", err)
 		return time.Now()
@@ -1344,9 +1346,9 @@ func (o *Object) ModTime() time.Time {
 }
 
 // setModTime sets the modification time of the local fs object
-func (o *Object) setModTime(modTime time.Time) (*api.Item, error) {
+func (o *Object) setModTime(ctx context.Context, modTime time.Time) (*api.Item, error) {
 	var opts rest.Opts
-	leaf, directoryID, _ := o.fs.dirCache.FindPath(o.remote, false)
+	leaf, directoryID, _ := o.fs.dirCache.FindPath(ctx, o.remote, false)
 	trueDirID, drive, rootURL := parseNormalizedID(directoryID)
 	if drive != "" {
 		opts = rest.Opts{
@@ -1375,8 +1377,8 @@ func (o *Object) setModTime(modTime time.Time) (*api.Item, error) {
 }
 
 // SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
-	info, err := o.setModTime(modTime)
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
+	info, err := o.setModTime(ctx, modTime)
 	if err != nil {
 		return err
 	}
@@ -1389,7 +1391,7 @@ func (o *Object) Storable() bool {
 }
 
 // Open an object for read
-func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	if o.id == "" {
 		return nil, errors.New("can't download - no id")
 	}
@@ -1418,8 +1420,8 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 }
 
 // createUploadSession creates an upload session for the object
-func (o *Object) createUploadSession(modTime time.Time) (response *api.CreateUploadResponse, err error) {
-	leaf, directoryID, _ := o.fs.dirCache.FindPath(o.remote, false)
+func (o *Object) createUploadSession(ctx context.Context, modTime time.Time) (response *api.CreateUploadResponse, err error) {
+	leaf, directoryID, _ := o.fs.dirCache.FindPath(ctx, o.remote, false)
 	id, drive, rootURL := parseNormalizedID(directoryID)
 	var opts rest.Opts
 	if drive != "" {
@@ -1498,7 +1500,7 @@ func (o *Object) cancelUploadSession(url string) (err error) {
 }
 
 // uploadMultipart uploads a file using multipart upload
-func (o *Object) uploadMultipart(in io.Reader, size int64, modTime time.Time) (info *api.Item, err error) {
+func (o *Object) uploadMultipart(ctx context.Context, in io.Reader, size int64, modTime time.Time) (info *api.Item, err error) {
 	if size <= 0 {
 		return nil, errors.New("unknown-sized upload not supported")
 	}
@@ -1522,7 +1524,7 @@ func (o *Object) uploadMultipart(in io.Reader, size int64, modTime time.Time) (i
 
 	// Create upload session
 	fs.Debugf(o, "Starting multipart upload")
-	session, err := o.createUploadSession(modTime)
+	session, err := o.createUploadSession(ctx, modTime)
 	if err != nil {
 		close(uploadURLChan)
 		atexit.Unregister(cancelFuncHandle)
@@ -1562,7 +1564,7 @@ func (o *Object) uploadMultipart(in io.Reader, size int64, modTime time.Time) (i
 
 // Update the content of a remote file within 4MB size in one single request
 // This function will set modtime after uploading, which will create a new version for the remote file
-func (o *Object) uploadSinglepart(in io.Reader, size int64, modTime time.Time) (info *api.Item, err error) {
+func (o *Object) uploadSinglepart(ctx context.Context, in io.Reader, size int64, modTime time.Time) (info *api.Item, err error) {
 	if size < 0 || size > int64(fs.SizeSuffix(4*1024*1024)) {
 		return nil, errors.New("size passed into uploadSinglepart must be >= 0 and <= 4MiB")
 	}
@@ -1570,7 +1572,7 @@ func (o *Object) uploadSinglepart(in io.Reader, size int64, modTime time.Time) (
 	fs.Debugf(o, "Starting singlepart upload")
 	var resp *http.Response
 	var opts rest.Opts
-	leaf, directoryID, _ := o.fs.dirCache.FindPath(o.remote, false)
+	leaf, directoryID, _ := o.fs.dirCache.FindPath(ctx, o.remote, false)
 	trueDirID, drive, rootURL := parseNormalizedID(directoryID)
 	if drive != "" {
 		opts = rest.Opts{
@@ -1608,13 +1610,13 @@ func (o *Object) uploadSinglepart(in io.Reader, size int64, modTime time.Time) (
 		return nil, err
 	}
 	// Set the mod time now and read metadata
-	return o.setModTime(modTime)
+	return o.setModTime(ctx, modTime)
 }
 
 // Update the object with the contents of the io.Reader, modTime and size
 //
 // The new object may have been created if an error is returned
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
 	if o.hasMetaData && o.isOneNoteFile {
 		return errors.New("can't upload content to a OneNote file")
 	}
@@ -1623,13 +1625,13 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	defer o.fs.tokenRenewer.Stop()
 
 	size := src.Size()
-	modTime := src.ModTime()
+	modTime := src.ModTime(ctx)
 
 	var info *api.Item
 	if size > 0 {
-		info, err = o.uploadMultipart(in, size, modTime)
+		info, err = o.uploadMultipart(ctx, in, size, modTime)
 	} else if size == 0 {
-		info, err = o.uploadSinglepart(in, size, modTime)
+		info, err = o.uploadSinglepart(ctx, in, size, modTime)
 	} else {
 		return errors.New("unknown-sized upload not supported")
 	}
@@ -1641,12 +1643,12 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 }
 
 // Remove an object
-func (o *Object) Remove() error {
+func (o *Object) Remove(ctx context.Context) error {
 	return o.fs.deleteObject(o.id)
 }
 
 // MimeType of an Object if known, "" otherwise
-func (o *Object) MimeType() string {
+func (o *Object) MimeType(ctx context.Context) string {
 	return o.mimeType
 }
 

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -321,6 +321,7 @@ func (f *Fs) putSftpConnection(pc **conn, err error) {
 // NewFs creates a new Fs object from the name and root. It connects to
 // the host specified in the config file.
 func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
+	ctx := context.Background()
 	// Parse config into Options struct
 	opt := new(Options)
 	err := configstruct.Set(m, opt)
@@ -419,12 +420,12 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 		sshConfig.Auth = append(sshConfig.Auth, ssh.Password(clearpass))
 	}
 
-	return NewFsWithConnection(name, root, opt, sshConfig)
+	return NewFsWithConnection(ctx, name, root, opt, sshConfig)
 }
 
 // NewFsWithConnection creates a new Fs object from the name and root and a ssh.ClientConfig. It connects to
 // the host specified in the ssh.ClientConfig
-func NewFsWithConnection(name string, root string, opt *Options, sshConfig *ssh.ClientConfig) (fs.Fs, error) {
+func NewFsWithConnection(ctx context.Context, name string, root string, opt *Options, sshConfig *ssh.ClientConfig) (fs.Fs, error) {
 	f := &Fs{
 		name:      name,
 		root:      root,
@@ -450,7 +451,7 @@ func NewFsWithConnection(name string, root string, opt *Options, sshConfig *ssh.
 		if f.root == "." {
 			f.root = ""
 		}
-		_, err := f.NewObject(remote)
+		_, err := f.NewObject(ctx, remote)
 		if err != nil {
 			if err == fs.ErrorObjectNotFound || errors.Cause(err) == fs.ErrorNotAFile {
 				// File doesn't exist so return old f
@@ -491,7 +492,7 @@ func (f *Fs) Precision() time.Duration {
 }
 
 // NewObject creates a new remote sftp file object
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	o := &Object{
 		fs:     f,
 		remote: remote,
@@ -536,7 +537,7 @@ func (f *Fs) dirExists(dir string) (bool, error) {
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 	root := path.Join(f.root, dir)
 	ok, err := f.dirExists(root)
 	if err != nil {
@@ -587,8 +588,8 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 	return entries, nil
 }
 
-// Put data from <in> into a new remote sftp file object described by <src.Remote()> and <src.ModTime()>
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+// Put data from <in> into a new remote sftp file object described by <src.Remote()> and <src.ModTime(ctx)>
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	err := f.mkParentDir(src.Remote())
 	if err != nil {
 		return nil, errors.Wrap(err, "Put mkParentDir failed")
@@ -598,7 +599,7 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 		fs:     f,
 		remote: src.Remote(),
 	}
-	err = o.Update(in, src, options...)
+	err = o.Update(ctx, in, src, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -606,8 +607,8 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 }
 
 // PutStream uploads to the remote path with the modTime given of indeterminate size
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	return f.Put(in, src, options...)
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	return f.Put(ctx, in, src, options...)
 }
 
 // mkParentDir makes the parent of remote if necessary and any
@@ -649,16 +650,16 @@ func (f *Fs) mkdir(dirPath string) error {
 }
 
 // Mkdir makes the root directory of the Fs object
-func (f *Fs) Mkdir(dir string) error {
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 	root := path.Join(f.root, dir)
 	return f.mkdir(root)
 }
 
 // Rmdir removes the root directory of the Fs object
-func (f *Fs) Rmdir(dir string) error {
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	// Check to see if directory is empty as some servers will
 	// delete recursively with RemoveDirectory
-	entries, err := f.List(dir)
+	entries, err := f.List(ctx, dir)
 	if err != nil {
 		return errors.Wrap(err, "Rmdir")
 	}
@@ -677,7 +678,7 @@ func (f *Fs) Rmdir(dir string) error {
 }
 
 // Move renames a remote sftp file object
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	srcObj, ok := src.(*Object)
 	if !ok {
 		fs.Debugf(src, "Can't move - not same remote type")
@@ -699,7 +700,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Move Rename failed")
 	}
-	dstObj, err := f.NewObject(remote)
+	dstObj, err := f.NewObject(ctx, remote)
 	if err != nil {
 		return nil, errors.Wrap(err, "Move NewObject failed")
 	}
@@ -714,7 +715,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	srcFs, ok := src.(*Fs)
 	if !ok {
 		fs.Debugf(srcFs, "Can't move directory - not same remote type")
@@ -868,7 +869,7 @@ func (o *Object) Remote() string {
 
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
-func (o *Object) Hash(r hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, r hash.Type) (string, error) {
 	var hashCmd string
 	if r == hash.MD5 {
 		if o.md5sum != nil {
@@ -973,7 +974,7 @@ func (o *Object) Size() int64 {
 }
 
 // ModTime returns the modification time of the remote sftp file
-func (o *Object) ModTime() time.Time {
+func (o *Object) ModTime(ctx context.Context) time.Time {
 	return o.modTime
 }
 
@@ -1020,7 +1021,7 @@ func (o *Object) stat() error {
 // SetModTime sets the modification and access time to the specified time
 //
 // it also updates the info field
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	c, err := o.fs.getSftpConnection()
 	if err != nil {
 		return errors.Wrap(err, "SetModTime")
@@ -1091,7 +1092,7 @@ func (file *objectReader) Close() (err error) {
 }
 
 // Open a remote sftp file object for reading. Seek is supported
-func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	var offset, limit int64 = 0, -1
 	for _, option := range options {
 		switch x := option.(type) {
@@ -1125,7 +1126,7 @@ func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
 }
 
 // Update a remote sftp file using the data <in> and ModTime from <src>
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	// Clear the hash cache since we are about to update the object
 	o.md5sum = nil
 	o.sha1sum = nil
@@ -1163,7 +1164,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 		remove()
 		return errors.Wrap(err, "Update Close failed")
 	}
-	err = o.SetModTime(src.ModTime())
+	err = o.SetModTime(ctx, src.ModTime(ctx))
 	if err != nil {
 		return errors.Wrap(err, "Update SetModTime failed")
 	}
@@ -1171,7 +1172,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 }
 
 // Remove a remote sftp file object
-func (o *Object) Remove() error {
+func (o *Object) Remove(ctx context.Context) error {
 	c, err := o.fs.getSftpConnection()
 	if err != nil {
 		return errors.Wrap(err, "Remove")

--- a/backend/union/union.go
+++ b/backend/union/union.go
@@ -1,6 +1,7 @@
 package union
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path"
@@ -89,8 +90,8 @@ func (f *Fs) Features() *fs.Features {
 }
 
 // Rmdir removes the root directory of the Fs object
-func (f *Fs) Rmdir(dir string) error {
-	return f.wr.Rmdir(dir)
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
+	return f.wr.Rmdir(ctx, dir)
 }
 
 // Hashes returns hash.HashNone to indicate remote hashing is unavailable
@@ -99,8 +100,8 @@ func (f *Fs) Hashes() hash.Set {
 }
 
 // Mkdir makes the root directory of the Fs object
-func (f *Fs) Mkdir(dir string) error {
-	return f.wr.Mkdir(dir)
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
+	return f.wr.Mkdir(ctx, dir)
 }
 
 // Purge all files in the root and the root directory
@@ -109,8 +110,8 @@ func (f *Fs) Mkdir(dir string) error {
 // quicker than just running Remove() on the result of List()
 //
 // Return an error if it doesn't exist
-func (f *Fs) Purge() error {
-	return f.wr.Features().Purge()
+func (f *Fs) Purge(ctx context.Context) error {
+	return f.wr.Features().Purge(ctx)
 }
 
 // Copy src to this remote using server side copy operations.
@@ -122,12 +123,12 @@ func (f *Fs) Purge() error {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantCopy
-func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	if src.Fs() != f.wr {
 		fs.Debugf(src, "Can't copy - not same remote type")
 		return nil, fs.ErrorCantCopy
 	}
-	o, err := f.wr.Features().Copy(src, remote)
+	o, err := f.wr.Features().Copy(ctx, src, remote)
 	if err != nil {
 		return nil, err
 	}
@@ -143,12 +144,12 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantMove
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	if src.Fs() != f.wr {
 		fs.Debugf(src, "Can't move - not same remote type")
 		return nil, fs.ErrorCantMove
 	}
-	o, err := f.wr.Features().Move(src, remote)
+	o, err := f.wr.Features().Move(ctx, src, remote)
 	if err != nil {
 		return nil, err
 	}
@@ -163,13 +164,13 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	srcFs, ok := src.(*Fs)
 	if !ok {
 		fs.Debugf(srcFs, "Can't move directory - not same remote type")
 		return fs.ErrorCantDirMove
 	}
-	return f.wr.Features().DirMove(srcFs.wr, srcRemote, dstRemote)
+	return f.wr.Features().DirMove(ctx, srcFs.wr, srcRemote, dstRemote)
 }
 
 // ChangeNotify calls the passed function with a path
@@ -181,14 +182,14 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 // The ChangeNotify implementation must empty the channel
 // regularly. When the channel gets closed, the implementation
 // should stop polling and release resources.
-func (f *Fs) ChangeNotify(fn func(string, fs.EntryType), ch <-chan time.Duration) {
+func (f *Fs) ChangeNotify(ctx context.Context, fn func(string, fs.EntryType), ch <-chan time.Duration) {
 	var remoteChans []chan time.Duration
 
 	for _, remote := range f.remotes {
 		if ChangeNotify := remote.Features().ChangeNotify; ChangeNotify != nil {
 			ch := make(chan time.Duration)
 			remoteChans = append(remoteChans, ch)
-			ChangeNotify(fn, ch)
+			ChangeNotify(ctx, fn, ch)
 		}
 	}
 
@@ -219,8 +220,8 @@ func (f *Fs) DirCacheFlush() {
 // May create the object even if it returns an error - if so
 // will return the object and the error, otherwise will return
 // nil and the error
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	o, err := f.wr.Features().PutStream(in, src, options...)
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	o, err := f.wr.Features().PutStream(ctx, in, src, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -228,8 +229,8 @@ func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption
 }
 
 // About gets quota information from the Fs
-func (f *Fs) About() (*fs.Usage, error) {
-	return f.wr.Features().About()
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
+	return f.wr.Features().About(ctx)
 }
 
 // Put in to the remote path with the modTime given of the given size
@@ -237,8 +238,8 @@ func (f *Fs) About() (*fs.Usage, error) {
 // May create the object even if it returns an error - if so
 // will return the object and the error, otherwise will return
 // nil and the error
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	o, err := f.wr.Put(in, src, options...)
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	o, err := f.wr.Put(ctx, in, src, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -254,11 +255,11 @@ func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 	set := make(map[string]fs.DirEntry)
 	found := false
 	for _, remote := range f.remotes {
-		var remoteEntries, err = remote.List(dir)
+		var remoteEntries, err = remote.List(ctx, dir)
 		if err == fs.ErrorDirNotFound {
 			continue
 		}
@@ -283,10 +284,10 @@ func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
 }
 
 // NewObject creates a new remote union file object based on the first Object it finds (reverse remote order)
-func (f *Fs) NewObject(path string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, path string) (fs.Object, error) {
 	for i := range f.remotes {
 		var remote = f.remotes[len(f.remotes)-i-1]
-		var obj, err = remote.NewObject(path)
+		var obj, err = remote.NewObject(ctx, path)
 		if err == fs.ErrorObjectNotFound {
 			continue
 		}

--- a/backend/yandex/yandex.go
+++ b/backend/yandex/yandex.go
@@ -1,6 +1,7 @@
 package yandex
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -330,7 +331,7 @@ func (f *Fs) itemToDirEntry(remote string, object *api.ResourceInfoResponse) (fs
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 	root := f.dirPath(dir)
 
 	var limit uint64 = 1000 // max number of objects per request
@@ -410,7 +411,7 @@ func (f *Fs) newObjectWithInfo(remote string, info *api.ResourceInfoResponse) (f
 
 // NewObject finds the Object at remote.  If it can't be found it
 // returns the error fs.ErrorObjectNotFound.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	return f.newObjectWithInfo(remote, nil)
 }
 
@@ -434,14 +435,14 @@ func (f *Fs) createObject(remote string, modTime time.Time, size int64) (o *Obje
 // Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	o := f.createObject(src.Remote(), src.ModTime(), src.Size())
-	return o, o.Update(in, src, options...)
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	o := f.createObject(src.Remote(), src.ModTime(ctx), src.Size())
+	return o, o.Update(ctx, in, src, options...)
 }
 
 // PutStream uploads to the remote path with the modTime given of indeterminate size
-func (f *Fs) PutStream(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	return f.Put(in, src, options...)
+func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	return f.Put(ctx, in, src, options...)
 }
 
 // CreateDir makes a directory
@@ -518,7 +519,7 @@ func (f *Fs) mkParentDirs(resPath string) error {
 }
 
 // Mkdir creates the container if it doesn't exist
-func (f *Fs) Mkdir(dir string) error {
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 	path := f.filePath(dir)
 	return f.mkDirs(path)
 }
@@ -621,7 +622,7 @@ func (f *Fs) purgeCheck(dir string, check bool) error {
 // Rmdir deletes the container
 //
 // Returns an error if it isn't empty
-func (f *Fs) Rmdir(dir string) error {
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	return f.purgeCheck(dir, true)
 }
 
@@ -630,7 +631,7 @@ func (f *Fs) Rmdir(dir string) error {
 // Optional interface: Only implement this if you have a way of
 // deleting all the files quicker than just running Remove() on the
 // result of List()
-func (f *Fs) Purge() error {
+func (f *Fs) Purge(ctx context.Context) error {
 	return f.purgeCheck("", false)
 }
 
@@ -681,7 +682,7 @@ func (f *Fs) copyOrMove(method, src, dst string, overwrite bool) (err error) {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantCopy
-func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	srcObj, ok := src.(*Object)
 	if !ok {
 		fs.Debugf(src, "Can't copy - not same remote type")
@@ -699,7 +700,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 		return nil, errors.Wrap(err, "couldn't copy file")
 	}
 
-	return f.NewObject(remote)
+	return f.NewObject(ctx, remote)
 }
 
 // Move src to this remote using server side move operations.
@@ -711,7 +712,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 // Will only be called if src.Fs().Name() == f.Name()
 //
 // If it isn't possible then return fs.ErrorCantMove
-func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	srcObj, ok := src.(*Object)
 	if !ok {
 		fs.Debugf(src, "Can't move - not same remote type")
@@ -729,7 +730,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 		return nil, errors.Wrap(err, "couldn't move file")
 	}
 
-	return f.NewObject(remote)
+	return f.NewObject(ctx, remote)
 }
 
 // DirMove moves src, srcRemote to this remote at dstRemote
@@ -740,7 +741,7 @@ func (f *Fs) Move(src fs.Object, remote string) (fs.Object, error) {
 // If it isn't possible then return fs.ErrorCantDirMove
 //
 // If destination exists then return fs.ErrorDirExists
-func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
+func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string) error {
 	srcFs, ok := src.(*Fs)
 	if !ok {
 		fs.Debugf(srcFs, "Can't move directory - not same remote type")
@@ -783,7 +784,7 @@ func (f *Fs) DirMove(src fs.Fs, srcRemote, dstRemote string) error {
 }
 
 // PublicLink generates a public link to the remote path (usually readable by anyone)
-func (f *Fs) PublicLink(remote string) (link string, err error) {
+func (f *Fs) PublicLink(ctx context.Context, remote string) (link string, err error) {
 	var path string
 	if f.opt.Unlink {
 		path = "/resources/unpublish"
@@ -830,7 +831,7 @@ func (f *Fs) PublicLink(remote string) (link string, err error) {
 }
 
 // CleanUp permanently deletes all trashed files/folders
-func (f *Fs) CleanUp() (err error) {
+func (f *Fs) CleanUp(ctx context.Context) (err error) {
 	var resp *http.Response
 	opts := rest.Opts{
 		Method:     "DELETE",
@@ -846,7 +847,7 @@ func (f *Fs) CleanUp() (err error) {
 }
 
 // About gets quota information
-func (f *Fs) About() (*fs.Usage, error) {
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	opts := rest.Opts{
 		Method: "GET",
 		Path:   "/",
@@ -941,7 +942,7 @@ func (o *Object) readMetaData() (err error) {
 //
 // It attempts to read the objects mtime and if that isn't present the
 // LastModified returned in the http headers
-func (o *Object) ModTime() time.Time {
+func (o *Object) ModTime(ctx context.Context) time.Time {
 	err := o.readMetaData()
 	if err != nil {
 		fs.Logf(o, "Failed to read metadata: %v", err)
@@ -961,7 +962,7 @@ func (o *Object) Size() int64 {
 }
 
 // Hash returns the Md5sum of an object returning a lowercase hex string
-func (o *Object) Hash(t hash.Type) (string, error) {
+func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {
 	if t != hash.MD5 {
 		return "", hash.ErrUnsupported
 	}
@@ -998,7 +999,7 @@ func (o *Object) setCustomProperty(property string, value string) (err error) {
 // SetModTime sets the modification time of the local fs object
 //
 // Commits the datastore
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	// set custom_property 'rclone_modified' of object to modTime
 	err := o.setCustomProperty("rclone_modified", modTime.Format(time.RFC3339Nano))
 	if err != nil {
@@ -1009,7 +1010,7 @@ func (o *Object) SetModTime(modTime time.Time) error {
 }
 
 // Open an object for read
-func (o *Object) Open(options ...fs.OpenOption) (in io.ReadCloser, err error) {
+func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	// prepare download
 	var resp *http.Response
 	var dl api.AsyncInfo
@@ -1090,9 +1091,9 @@ func (o *Object) upload(in io.Reader, overwrite bool, mimeType string) (err erro
 // Copy the reader into the object updating modTime and size
 //
 // The new object may have been created if an error is returned
-func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	in1 := readers.NewCountingReader(in)
-	modTime := src.ModTime()
+	modTime := src.ModTime(ctx)
 	remote := o.filePath()
 
 	//create full path to file before upload.
@@ -1102,7 +1103,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	}
 
 	//upload file
-	err = o.upload(in1, true, fs.MimeType(src))
+	err = o.upload(in1, true, fs.MimeType(ctx, src))
 	if err != nil {
 		return err
 	}
@@ -1112,18 +1113,18 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	o.md5sum = ""                   // according to unit tests after put the md5 is empty.
 	o.size = int64(in1.BytesRead()) // better solution o.readMetaData() ?
 	//and set modTime of uploaded file
-	err = o.SetModTime(modTime)
+	err = o.SetModTime(ctx, modTime)
 
 	return err
 }
 
 // Remove an object
-func (o *Object) Remove() error {
+func (o *Object) Remove(ctx context.Context) error {
 	return o.fs.delete(o.filePath(), false)
 }
 
 // MimeType of an Object if known, "" otherwise
-func (o *Object) MimeType() string {
+func (o *Object) MimeType(ctx context.Context) string {
 	return o.mimeType
 }
 

--- a/cmd/about/about.go
+++ b/cmd/about/about.go
@@ -1,6 +1,7 @@
 package about
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -91,7 +92,7 @@ Use the --json flag for a computer readable output, eg
 			if doAbout == nil {
 				return errors.Errorf("%v doesn't support about", f)
 			}
-			u, err := doAbout()
+			u, err := doAbout(context.Background())
 			if err != nil {
 				return errors.Wrap(err, "About call failed")
 			}

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -1,6 +1,7 @@
 package cat
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"log"
@@ -74,7 +75,7 @@ Note that if offset is negative it will count from the end, so
 			w = ioutil.Discard
 		}
 		cmd.Run(false, false, command, func() error {
-			return operations.Cat(fsrc, w, offset, count)
+			return operations.Cat(context.Background(), fsrc, w, offset, count)
 		})
 	},
 }

--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -43,9 +45,9 @@ destination that are not in the source will not trigger an error.
 		fsrc, fdst := cmd.NewFsSrcDst(args)
 		cmd.Run(false, false, command, func() error {
 			if download {
-				return operations.CheckDownload(fdst, fsrc, oneway)
+				return operations.CheckDownload(context.Background(), fdst, fsrc, oneway)
 			}
-			return operations.Check(fdst, fsrc, oneway)
+			return operations.Check(context.Background(), fdst, fsrc, oneway)
 		})
 	},
 }

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -1,6 +1,8 @@
 package cleanup
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -21,7 +23,7 @@ versions. Not supported by all remotes.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(true, false, command, func() error {
-			return operations.CleanUp(fsrc)
+			return operations.CleanUp(context.Background(), fsrc)
 		})
 	},
 }

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -1,6 +1,8 @@
 package copy
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/ncw/rclone/fs/sync"
@@ -74,9 +76,9 @@ changed recently very efficiently like this:
 		fsrc, srcFileName, fdst := cmd.NewFsSrcFileDst(args)
 		cmd.Run(true, true, command, func() error {
 			if srcFileName == "" {
-				return sync.CopyDir(fdst, fsrc, createEmptySrcDirs)
+				return sync.CopyDir(context.Background(), fdst, fsrc, createEmptySrcDirs)
 			}
-			return operations.CopyFile(fdst, fsrc, srcFileName, srcFileName)
+			return operations.CopyFile(context.Background(), fdst, fsrc, srcFileName, srcFileName)
 		})
 	},
 }

--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -1,6 +1,8 @@
 package copyto
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/ncw/rclone/fs/sync"
@@ -48,9 +50,9 @@ destination.
 		fsrc, srcFileName, fdst, dstFileName := cmd.NewFsSrcDstFiles(args)
 		cmd.Run(true, true, command, func() error {
 			if srcFileName == "" {
-				return sync.CopyDir(fdst, fsrc, false)
+				return sync.CopyDir(context.Background(), fdst, fsrc, false)
 			}
-			return operations.CopyFile(fdst, fsrc, dstFileName, srcFileName)
+			return operations.CopyFile(context.Background(), fdst, fsrc, dstFileName, srcFileName)
 		})
 	},
 }

--- a/cmd/copyurl/copyurl.go
+++ b/cmd/copyurl/copyurl.go
@@ -1,6 +1,8 @@
 package copyurl
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -22,7 +24,7 @@ without saving it in tmp storage.
 		fsdst, dstFileName := cmd.NewFsDstFile(args[1:])
 
 		cmd.Run(true, true, command, func() error {
-			_, err := operations.CopyURL(fsdst, dstFileName, args[0])
+			_, err := operations.CopyURL(context.Background(), fsdst, dstFileName, args[0])
 			return err
 		})
 	},

--- a/cmd/dbhashsum/dbhashsum.go
+++ b/cmd/dbhashsum/dbhashsum.go
@@ -1,6 +1,7 @@
 package dbhashsum
 
 import (
+	"context"
 	"os"
 
 	"github.com/ncw/rclone/cmd"
@@ -25,7 +26,7 @@ The output is in the same format as md5sum and sha1sum.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.DropboxHashSum(fsrc, os.Stdout)
+			return operations.DropboxHashSum(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }

--- a/cmd/dedupe/dedupe.go
+++ b/cmd/dedupe/dedupe.go
@@ -1,6 +1,7 @@
 package dedupe
 
 import (
+	"context"
 	"log"
 
 	"github.com/ncw/rclone/cmd"
@@ -112,7 +113,7 @@ Or
 		}
 		fdst := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.Deduplicate(fdst, dedupeMode)
+			return operations.Deduplicate(context.Background(), fdst, dedupeMode)
 		})
 	},
 }

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -1,6 +1,8 @@
 package delete
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -39,7 +41,7 @@ delete all files bigger than 100MBytes.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(true, false, command, func() error {
-			return operations.Delete(fsrc)
+			return operations.Delete(context.Background(), fsrc)
 		})
 	},
 }

--- a/cmd/deletefile/deletefile.go
+++ b/cmd/deletefile/deletefile.go
@@ -1,6 +1,8 @@
 package deletefile
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/pkg/errors"
@@ -26,11 +28,11 @@ it will always be removed.
 			if fileName == "" {
 				return errors.Errorf("%s is a directory or doesn't exist", args[0])
 			}
-			fileObj, err := fs.NewObject(fileName)
+			fileObj, err := fs.NewObject(context.Background(), fileName)
 			if err != nil {
 				return err
 			}
-			return operations.DeleteFile(fileObj)
+			return operations.DeleteFile(context.Background(), fileObj)
 		})
 	},
 }

--- a/cmd/hashsum/hashsum.go
+++ b/cmd/hashsum/hashsum.go
@@ -1,6 +1,7 @@
 package hashsum
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -54,7 +55,7 @@ Then
 		}
 		fsrc := cmd.NewFsSrc(args[1:])
 		cmd.Run(false, false, command, func() error {
-			return operations.HashLister(ht, fsrc, os.Stdout)
+			return operations.HashLister(context.Background(), ht, fsrc, os.Stdout)
 		})
 		return nil
 	},

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -5,6 +5,7 @@ package info
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -61,13 +62,14 @@ a bit of go code for each one.
 		for i := range args {
 			f := cmd.NewFsDir(args[i : i+1])
 			cmd.Run(false, false, command, func() error {
-				return readInfo(f)
+				return readInfo(context.Background(), f)
 			})
 		}
 	},
 }
 
 type results struct {
+	ctx                  context.Context
 	f                    fs.Fs
 	mu                   sync.Mutex
 	stringNeedsEscaping  map[string]position
@@ -78,8 +80,9 @@ type results struct {
 	canStream            bool
 }
 
-func newResults(f fs.Fs) *results {
+func newResults(ctx context.Context, f fs.Fs) *results {
 	return &results{
+		ctx:                 ctx,
 		f:                   f,
 		stringNeedsEscaping: make(map[string]position),
 	}
@@ -117,7 +120,7 @@ func (r *results) Print() {
 func (r *results) writeFile(path string) (fs.Object, error) {
 	contents := fstest.RandomString(50)
 	src := object.NewStaticObjectInfo(path, time.Now(), int64(len(contents)), true, nil, r.f)
-	return r.f.Put(bytes.NewBufferString(contents), src)
+	return r.f.Put(r.ctx, bytes.NewBufferString(contents), src)
 }
 
 // check whether normalization is enforced and check whether it is
@@ -131,11 +134,11 @@ func (r *results) checkUTF8Normalization() {
 		return
 	}
 	r.canWriteUnnormalized = true
-	_, err = r.f.NewObject(unnormalized)
+	_, err = r.f.NewObject(r.ctx, unnormalized)
 	if err == nil {
 		r.canReadUnnormalized = true
 	}
-	_, err = r.f.NewObject(normalized)
+	_, err = r.f.NewObject(r.ctx, normalized)
 	if err == nil {
 		r.canReadRenormalized = true
 	}
@@ -163,7 +166,7 @@ func (r *results) checkStringPositions(s string) {
 		} else {
 			fs.Infof(r.f, "Writing %s position file 0x%0X OK", pos.String(), s)
 		}
-		obj, getErr := r.f.NewObject(path)
+		obj, getErr := r.f.NewObject(r.ctx, path)
 		if getErr != nil {
 			fs.Infof(r.f, "Getting %s position file 0x%0X Error: %s", pos.String(), s, getErr)
 		} else {
@@ -262,7 +265,7 @@ func (r *results) checkStreaming() {
 	in := io.TeeReader(buf, hashIn)
 
 	objIn := object.NewStaticObjectInfo("checkStreamingTest", time.Now(), -1, true, nil, r.f)
-	objR, err := putter(in, objIn)
+	objR, err := putter(r.ctx, in, objIn)
 	if err != nil {
 		fs.Infof(r.f, "Streamed file failed to upload (%v)", err)
 		r.canStream = false
@@ -272,7 +275,7 @@ func (r *results) checkStreaming() {
 	hashes := hashIn.Sums()
 	types := objR.Fs().Hashes().Array()
 	for _, Hash := range types {
-		sum, err := objR.Hash(Hash)
+		sum, err := objR.Hash(r.ctx, Hash)
 		if err != nil {
 			fs.Infof(r.f, "Streamed file failed when getting hash %v (%v)", Hash, err)
 			r.canStream = false
@@ -292,12 +295,12 @@ func (r *results) checkStreaming() {
 	r.canStream = true
 }
 
-func readInfo(f fs.Fs) error {
-	err := f.Mkdir("")
+func readInfo(ctx context.Context, f fs.Fs) error {
+	err := f.Mkdir(ctx, "")
 	if err != nil {
 		return errors.Wrap(err, "couldn't mkdir")
 	}
-	r := newResults(f)
+	r := newResults(ctx, f)
 	if checkControl {
 		r.checkControls()
 	}

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -1,6 +1,7 @@
 package link
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ncw/rclone/cmd"
@@ -30,7 +31,7 @@ without account.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc, remote := cmd.NewFsFile(args[0])
 		cmd.Run(false, false, command, func() error {
-			link, err := operations.PublicLink(fsrc, remote)
+			link, err := operations.PublicLink(context.Background(), fsrc, remote)
 			if err != nil {
 				return err
 			}

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -1,6 +1,7 @@
 package ls
 
 import (
+	"context"
 	"os"
 
 	"github.com/ncw/rclone/cmd"
@@ -33,7 +34,7 @@ Eg
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.List(fsrc, os.Stdout)
+			return operations.List(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }

--- a/cmd/lsd/lsd.go
+++ b/cmd/lsd/lsd.go
@@ -1,6 +1,7 @@
 package lsd
 
 import (
+	"context"
 	"os"
 
 	"github.com/ncw/rclone/cmd"
@@ -52,7 +53,7 @@ If you just want the directory names use "rclone lsf --dirs-only".
 		}
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.ListDir(fsrc, os.Stdout)
+			return operations.ListDir(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }

--- a/cmd/lsf/lsf.go
+++ b/cmd/lsf/lsf.go
@@ -1,6 +1,7 @@
 package lsf
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -150,14 +151,14 @@ those only (without traversing the whole directory structure):
 			if csv && !separatorFlagSupplied {
 				separator = ","
 			}
-			return Lsf(fsrc, os.Stdout)
+			return Lsf(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }
 
 // Lsf lists all the objects in the path with modification time, size
 // and path in specific format.
-func Lsf(fsrc fs.Fs, out io.Writer) error {
+func Lsf(ctx context.Context, fsrc fs.Fs, out io.Writer) error {
 	var list operations.ListFormat
 	list.SetSeparator(separator)
 	list.SetCSV(csv)
@@ -199,7 +200,7 @@ func Lsf(fsrc fs.Fs, out io.Writer) error {
 		}
 	}
 
-	return operations.ListJSON(fsrc, "", &opt, func(item *operations.ListJSONItem) error {
+	return operations.ListJSON(ctx, fsrc, "", &opt, func(item *operations.ListJSONItem) error {
 		_, _ = fmt.Fprintln(out, list.Format(item))
 		return nil
 	})

--- a/cmd/lsf/lsf_test.go
+++ b/cmd/lsf/lsf_test.go
@@ -2,6 +2,7 @@ package lsf
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	_ "github.com/ncw/rclone/backend/local"
@@ -19,7 +20,7 @@ func TestDefaultLsf(t *testing.T) {
 	f, err := fs.NewFs("testfiles")
 	require.NoError(t, err)
 
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1
 file2
@@ -36,7 +37,7 @@ func TestRecurseFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	recurse = true
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1
 file2
@@ -58,7 +59,7 @@ func TestDirSlashFlag(t *testing.T) {
 
 	dirSlash = true
 	format = "p"
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1
 file2
@@ -68,7 +69,7 @@ subdir/
 
 	buf = new(bytes.Buffer)
 	dirSlash = false
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1
 file2
@@ -84,7 +85,7 @@ func TestFormat(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	format = "p"
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1
 file2
@@ -94,7 +95,7 @@ subdir
 
 	buf = new(bytes.Buffer)
 	format = "s"
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `0
 321
@@ -104,7 +105,7 @@ subdir
 
 	buf = new(bytes.Buffer)
 	format = "hp"
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `d41d8cd98f00b204e9800998ecf8427e;file1
 409d6c19451dd39d4a94e42d2ff2c834;file2
@@ -115,7 +116,7 @@ subdir
 	buf = new(bytes.Buffer)
 	format = "p"
 	filesOnly = true
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1
 file2
@@ -126,7 +127,7 @@ file3
 	buf = new(bytes.Buffer)
 	format = "p"
 	dirsOnly = true
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `subdir
 `, buf.String())
@@ -134,20 +135,20 @@ file3
 
 	buf = new(bytes.Buffer)
 	format = "t"
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 
-	items, _ := list.DirSorted(f, true, "")
+	items, _ := list.DirSorted(context.Background(), f, true, "")
 	var expectedOutput string
 	for _, item := range items {
-		expectedOutput += item.ModTime().Format("2006-01-02 15:04:05") + "\n"
+		expectedOutput += item.ModTime(context.Background()).Format("2006-01-02 15:04:05") + "\n"
 	}
 
 	assert.Equal(t, expectedOutput, buf.String())
 
 	buf = new(bytes.Buffer)
 	format = "sp"
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `0;file1
 321;file2
@@ -164,7 +165,7 @@ func TestSeparator(t *testing.T) {
 	format = "ps"
 
 	buf := new(bytes.Buffer)
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1;0
 file2;321
@@ -174,7 +175,7 @@ subdir;-1
 
 	separator = "__SEP__"
 	buf = new(bytes.Buffer)
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 	assert.Equal(t, `file1__SEP__0
 file2__SEP__321
@@ -195,17 +196,17 @@ func TestWholeLsf(t *testing.T) {
 	dirSlash = true
 
 	buf := new(bytes.Buffer)
-	err = Lsf(f, buf)
+	err = Lsf(context.Background(), f, buf)
 	require.NoError(t, err)
 
-	items, _ := list.DirSorted(f, true, "")
-	itemsInSubdir, _ := list.DirSorted(f, true, "subdir")
+	items, _ := list.DirSorted(context.Background(), f, true, "")
+	itemsInSubdir, _ := list.DirSorted(context.Background(), f, true, "subdir")
 	var expectedOutput []string
 	for _, item := range items {
-		expectedOutput = append(expectedOutput, item.ModTime().Format("2006-01-02 15:04:05"))
+		expectedOutput = append(expectedOutput, item.ModTime(context.Background()).Format("2006-01-02 15:04:05"))
 	}
 	for _, item := range itemsInSubdir {
-		expectedOutput = append(expectedOutput, item.ModTime().Format("2006-01-02 15:04:05"))
+		expectedOutput = append(expectedOutput, item.ModTime(context.Background()).Format("2006-01-02 15:04:05"))
 	}
 
 	assert.Equal(t, `file1_+_0_+_`+expectedOutput[0]+`

--- a/cmd/lsjson/lsjson.go
+++ b/cmd/lsjson/lsjson.go
@@ -1,6 +1,7 @@
 package lsjson
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -90,7 +91,7 @@ can be processed line by line as each item is written one to a line.
 		cmd.Run(false, false, command, func() error {
 			fmt.Println("[")
 			first := true
-			err := operations.ListJSON(fsrc, "", &opt, func(item *operations.ListJSONItem) error {
+			err := operations.ListJSON(context.Background(), fsrc, "", &opt, func(item *operations.ListJSONItem) error {
 				out, err := json.Marshal(item)
 				if err != nil {
 					return errors.Wrap(err, "failed to marshal list object")

--- a/cmd/lsl/lsl.go
+++ b/cmd/lsl/lsl.go
@@ -1,6 +1,7 @@
 package lsl
 
 import (
+	"context"
 	"os"
 
 	"github.com/ncw/rclone/cmd"
@@ -33,7 +34,7 @@ Eg
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.ListLong(fsrc, os.Stdout)
+			return operations.ListLong(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }

--- a/cmd/md5sum/md5sum.go
+++ b/cmd/md5sum/md5sum.go
@@ -1,6 +1,7 @@
 package md5sum
 
 import (
+	"context"
 	"os"
 
 	"github.com/ncw/rclone/cmd"
@@ -23,7 +24,7 @@ is in the same format as the standard md5sum tool produces.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.Md5sum(fsrc, os.Stdout)
+			return operations.Md5sum(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }

--- a/cmd/memtest/memtest.go
+++ b/cmd/memtest/memtest.go
@@ -1,6 +1,7 @@
 package memtest
 
 import (
+	"context"
 	"runtime"
 	"sync"
 
@@ -22,7 +23,8 @@ var commandDefintion = &cobra.Command{
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			objects, _, err := operations.Count(fsrc)
+			ctx := context.Background()
+			objects, _, err := operations.Count(ctx, fsrc)
 			if err != nil {
 				return err
 			}
@@ -31,7 +33,7 @@ var commandDefintion = &cobra.Command{
 			runtime.GC()
 			runtime.ReadMemStats(&before)
 			var mu sync.Mutex
-			err = operations.ListFn(fsrc, func(o fs.Object) {
+			err = operations.ListFn(ctx, fsrc, func(o fs.Object) {
 				mu.Lock()
 				objs = append(objs, o)
 				mu.Unlock()

--- a/cmd/mkdir/mkdir.go
+++ b/cmd/mkdir/mkdir.go
@@ -1,6 +1,8 @@
 package mkdir
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -17,7 +19,7 @@ var commandDefintion = &cobra.Command{
 		cmd.CheckArgs(1, 1, command, args)
 		fdst := cmd.NewFsDir(args)
 		cmd.Run(true, false, command, func() error {
-			return operations.Mkdir(fdst, "")
+			return operations.Mkdir(context.Background(), fdst, "")
 		})
 	},
 }

--- a/cmd/mountlib/mounttest/dir.go
+++ b/cmd/mountlib/mounttest/dir.go
@@ -1,6 +1,7 @@
 package mounttest
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -172,7 +173,7 @@ func TestDirCacheFlush(t *testing.T) {
 	run.readLocal(t, localDm, "")
 	assert.Equal(t, dm, localDm, "expected vs fuse mount")
 
-	err := run.fremote.Mkdir("dir/subdir")
+	err := run.fremote.Mkdir(context.Background(), "dir/subdir")
 	require.NoError(t, err)
 
 	root, err := run.vfs.Root()
@@ -208,7 +209,7 @@ func TestDirCacheFlushOnDirRename(t *testing.T) {
 	assert.Equal(t, dm, localDm, "expected vs fuse mount")
 
 	// expect remotely created directory to not show up
-	err := run.fremote.Mkdir("dir/subdir")
+	err := run.fremote.Mkdir(context.Background(), "dir/subdir")
 	require.NoError(t, err)
 	run.readLocal(t, localDm, "")
 	assert.Equal(t, dm, localDm, "expected vs fuse mount")

--- a/cmd/mountlib/mounttest/fs.go
+++ b/cmd/mountlib/mounttest/fs.go
@@ -3,6 +3,7 @@
 package mounttest
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -119,7 +120,7 @@ func newRun() *Run {
 		log.Fatalf("Failed to open remote %q: %v", *fstest.RemoteName, err)
 	}
 
-	err = r.fremote.Mkdir("")
+	err = r.fremote.Mkdir(context.Background(), "")
 	if err != nil {
 		log.Fatalf("Failed to open mkdir %q: %v", *fstest.RemoteName, err)
 	}
@@ -211,7 +212,7 @@ func (r *Run) cacheMode(cacheMode vfs.CacheMode) {
 	r.vfs.WaitForWriters(30 * time.Second)
 	// Empty and remake the remote
 	r.cleanRemote()
-	err := r.fremote.Mkdir("")
+	err := r.fremote.Mkdir(context.Background(), "")
 	if err != nil {
 		log.Fatalf("Failed to open mkdir %q: %v", *fstest.RemoteName, err)
 	}
@@ -296,7 +297,7 @@ func (r *Run) readLocal(t *testing.T, dir dirMap, filePath string) {
 
 // reads the remote tree into dir
 func (r *Run) readRemote(t *testing.T, dir dirMap, filepath string) {
-	objs, dirs, err := walk.GetAll(r.fremote, filepath, true, 1)
+	objs, dirs, err := walk.GetAll(context.Background(), r.fremote, filepath, true, 1)
 	if err == fs.ErrorDirNotFound {
 		return
 	}

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -1,6 +1,8 @@
 package move
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/ncw/rclone/fs/sync"
@@ -54,9 +56,9 @@ can speed transfers up greatly.
 		fsrc, srcFileName, fdst := cmd.NewFsSrcFileDst(args)
 		cmd.Run(true, true, command, func() error {
 			if srcFileName == "" {
-				return sync.MoveDir(fdst, fsrc, deleteEmptySrcDirs, createEmptySrcDirs)
+				return sync.MoveDir(context.Background(), fdst, fsrc, deleteEmptySrcDirs, createEmptySrcDirs)
 			}
-			return operations.MoveFile(fdst, fsrc, srcFileName, srcFileName)
+			return operations.MoveFile(context.Background(), fdst, fsrc, srcFileName, srcFileName)
 		})
 	},
 }

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -1,6 +1,8 @@
 package moveto
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/ncw/rclone/fs/sync"
@@ -52,9 +54,9 @@ transfer.
 
 		cmd.Run(true, true, command, func() error {
 			if srcFileName == "" {
-				return sync.MoveDir(fdst, fsrc, false, false)
+				return sync.MoveDir(context.Background(), fdst, fsrc, false, false)
 			}
-			return operations.MoveFile(fdst, fsrc, dstFileName, srcFileName)
+			return operations.MoveFile(context.Background(), fdst, fsrc, dstFileName, srcFileName)
 		})
 	},
 }

--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -5,6 +5,7 @@
 package ncdu
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -423,6 +424,7 @@ func (u *UI) removeEntry(pos int) {
 
 // delete the entry at the current position
 func (u *UI) delete() {
+	ctx := context.Background()
 	dirPos := u.sortPerm[u.dirPosMap[u.path].entry]
 	entry := u.entries[dirPos]
 	u.boxMenu = []string{"cancel", "confirm"}
@@ -431,7 +433,7 @@ func (u *UI) delete() {
 			if o != 1 {
 				return "Aborted!", nil
 			}
-			err := operations.DeleteFile(obj)
+			err := operations.DeleteFile(ctx, obj)
 			if err != nil {
 				return "", err
 			}
@@ -446,7 +448,7 @@ func (u *UI) delete() {
 			if o != 1 {
 				return "Aborted!", nil
 			}
-			err := operations.Purge(f, entry.String())
+			err := operations.Purge(ctx, f, entry.String())
 			if err != nil {
 				return "", err
 			}
@@ -636,7 +638,7 @@ func (u *UI) Show() error {
 
 	// scan the disk in the background
 	u.listing = true
-	rootChan, errChan, updated := scan.Scan(u.f)
+	rootChan, errChan, updated := scan.Scan(context.Background(), u.f)
 
 	// Poll the events into a channel
 	events := make(chan termbox.Event)

--- a/cmd/ncdu/scan/scan.go
+++ b/cmd/ncdu/scan/scan.go
@@ -2,6 +2,7 @@
 package scan
 
 import (
+	"context"
 	"path"
 	"sync"
 
@@ -160,13 +161,13 @@ func (d *Dir) AttrI(i int) (size int64, count int64, isDir bool, readable bool) 
 
 // Scan the Fs passed in, returning a root directory channel and an
 // error channel
-func Scan(f fs.Fs) (chan *Dir, chan error, chan struct{}) {
+func Scan(ctx context.Context, f fs.Fs) (chan *Dir, chan error, chan struct{}) {
 	root := make(chan *Dir, 1)
 	errChan := make(chan error, 1)
 	updated := make(chan struct{}, 1)
 	go func() {
 		parents := map[string]*Dir{}
-		err := walk.Walk(f, "", false, fs.Config.MaxDepth, func(dirPath string, entries fs.DirEntries, err error) error {
+		err := walk.Walk(ctx, f, "", false, fs.Config.MaxDepth, func(dirPath string, entries fs.DirEntries, err error) error {
 			if err != nil {
 				return err // FIXME mark directory as errored instead of aborting
 			}

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -1,6 +1,8 @@
 package purge
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -22,7 +24,7 @@ you want to selectively delete files.
 		cmd.CheckArgs(1, 1, command, args)
 		fdst := cmd.NewFsDir(args)
 		cmd.Run(true, false, command, func() error {
-			return operations.Purge(fdst, "")
+			return operations.Purge(context.Background(), fdst, "")
 		})
 	},
 }

--- a/cmd/rc/rc.go
+++ b/cmd/rc/rc.go
@@ -2,6 +2,7 @@ package rc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -116,7 +117,7 @@ func doCall(path string, in rc.Params) (out rc.Params, err error) {
 		if call == nil {
 			return nil, errors.Errorf("method %q not found", path)
 		}
-		return call.Fn(in)
+		return call.Fn(context.Background(), in)
 	}
 
 	// Do HTTP request

--- a/cmd/rcat/rcat.go
+++ b/cmd/rcat/rcat.go
@@ -1,6 +1,7 @@
 package rcat
 
 import (
+	"context"
 	"log"
 	"os"
 	"time"
@@ -50,7 +51,7 @@ a lot of data, you're better off caching locally and then
 
 		fdst, dstFileName := cmd.NewFsDstFile(args)
 		cmd.Run(false, false, command, func() error {
-			_, err := operations.Rcat(fdst, dstFileName, os.Stdin, time.Now())
+			_, err := operations.Rcat(context.Background(), fdst, dstFileName, os.Stdin, time.Now())
 			return err
 		})
 	},

--- a/cmd/rmdir/rmdir.go
+++ b/cmd/rmdir/rmdir.go
@@ -1,6 +1,8 @@
 package rmdir
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -20,7 +22,7 @@ objects in it, use purge for that.`,
 		cmd.CheckArgs(1, 1, command, args)
 		fdst := cmd.NewFsDir(args)
 		cmd.Run(true, false, command, func() error {
-			return operations.Rmdir(fdst, "")
+			return operations.Rmdir(context.Background(), fdst, "")
 		})
 	},
 }

--- a/cmd/rmdirs/rmdirs.go
+++ b/cmd/rmdirs/rmdirs.go
@@ -1,6 +1,8 @@
 package rmdir
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -32,7 +34,7 @@ empty directories in.
 		cmd.CheckArgs(1, 1, command, args)
 		fdst := cmd.NewFsDir(args)
 		cmd.Run(true, false, command, func() error {
-			return operations.Rmdirs(fdst, "", leaveRoot)
+			return operations.Rmdirs(context.Background(), fdst, "", leaveRoot)
 		})
 	},
 }

--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -1,6 +1,7 @@
 package dlna
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -39,7 +40,7 @@ func TestInit(t *testing.T) {
 	config.LoadConfig()
 
 	f, err := fs.NewFs("testdata/files")
-	l, _ := f.List("")
+	l, _ := f.List(context.Background(), "")
 	fmt.Println(l)
 	require.NoError(t, err)
 

--- a/cmd/serve/ftp/ftp_test.go
+++ b/cmd/serve/ftp/ftp_test.go
@@ -8,6 +8,7 @@
 package ftp
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,7 +42,7 @@ func TestFTP(t *testing.T) {
 	assert.NoError(t, err)
 	defer clean()
 
-	err = fremote.Mkdir("")
+	err = fremote.Mkdir(context.Background(), "")
 	assert.NoError(t, err)
 
 	// Start the server

--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -161,7 +161,7 @@ func (s *server) serveFile(w http.ResponseWriter, r *http.Request, remote string
 	w.Header().Set("Content-Length", strconv.FormatInt(node.Size(), 10))
 
 	// Set content type
-	mimeType := fs.MimeType(obj)
+	mimeType := fs.MimeType(r.Context(), obj)
 	if mimeType == "application/octet-stream" && path.Ext(remote) == "" {
 		// Leave header blank so http server guesses
 	} else {

--- a/cmd/serve/httplib/serve/serve.go
+++ b/cmd/serve/httplib/serve/serve.go
@@ -28,7 +28,7 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 	}
 
 	// Set content type
-	mimeType := fs.MimeType(o)
+	mimeType := fs.MimeType(r.Context(), o)
 	if mimeType == "application/octet-stream" && path.Ext(o.Remote()) == "" {
 		// Leave header blank so http server guesses
 	} else {
@@ -69,7 +69,7 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 	}
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 
-	file, err := o.Open(options...)
+	file, err := o.Open(r.Context(), options...)
 	if err != nil {
 		fs.Debugf(o, "Get request open error: %v", err)
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/cmd/serve/restic/restic_test.go
+++ b/cmd/serve/restic/restic_test.go
@@ -6,6 +6,7 @@
 package restic
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"testing"
@@ -38,7 +39,7 @@ func TestRestic(t *testing.T) {
 	assert.NoError(t, err)
 	defer clean()
 
-	err = fremote.Mkdir("")
+	err = fremote.Mkdir(context.Background(), "")
 	assert.NoError(t, err)
 
 	// Start the server

--- a/cmd/serve/sftp/sftp_test.go
+++ b/cmd/serve/sftp/sftp_test.go
@@ -8,6 +8,7 @@
 package sftp
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
@@ -43,7 +44,7 @@ func TestSftp(t *testing.T) {
 	assert.NoError(t, err)
 	defer clean()
 
-	err = fremote.Mkdir("")
+	err = fremote.Mkdir(context.Background(), "")
 	assert.NoError(t, err)
 
 	opt := DefaultOpt

--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -284,7 +284,7 @@ func (fi FileInfo) ETag(ctx context.Context) (etag string, err error) {
 	if !ok {
 		return "", webdav.ErrNotImplemented
 	}
-	hash, err := o.Hash(hashType)
+	hash, err := o.Hash(ctx, hashType)
 	if err != nil || hash == "" {
 		return "", webdav.ErrNotImplemented
 	}
@@ -302,7 +302,7 @@ func (fi FileInfo) ContentType(ctx context.Context) (contentType string, err err
 	entry := node.DirEntry()
 	switch x := entry.(type) {
 	case fs.Object:
-		return fs.MimeType(x), nil
+		return fs.MimeType(ctx, x), nil
 	case fs.Directory:
 		return "inode/directory", nil
 	}

--- a/cmd/serve/webdav/webdav_test.go
+++ b/cmd/serve/webdav/webdav_test.go
@@ -8,6 +8,7 @@
 package webdav
 
 import (
+	"context"
 	"flag"
 	"io/ioutil"
 	"net/http"
@@ -50,7 +51,7 @@ func TestWebDav(t *testing.T) {
 	assert.NoError(t, err)
 	defer clean()
 
-	err = fremote.Mkdir("")
+	err = fremote.Mkdir(context.Background(), "")
 	assert.NoError(t, err)
 
 	// Start the server

--- a/cmd/settier/settier.go
+++ b/cmd/settier/settier.go
@@ -1,6 +1,8 @@
 package settier
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/pkg/errors"
@@ -48,7 +50,7 @@ Or just provide remote directory and all files in directory will be tiered
 				return errors.Errorf("Remote %s does not support settier", fsrc.Name())
 			}
 
-			return operations.SetTier(fsrc, tier)
+			return operations.SetTier(context.Background(), fsrc, tier)
 		})
 	},
 }

--- a/cmd/sha1sum/sha1sum.go
+++ b/cmd/sha1sum/sha1sum.go
@@ -1,6 +1,7 @@
 package sha1sum
 
 import (
+	"context"
 	"os"
 
 	"github.com/ncw/rclone/cmd"
@@ -23,7 +24,7 @@ is in the same format as the standard sha1sum tool produces.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.Sha1sum(fsrc, os.Stdout)
+			return operations.Sha1sum(context.Background(), fsrc, os.Stdout)
 		})
 	},
 }

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -1,6 +1,7 @@
 package size
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,7 +32,7 @@ var commandDefinition = &cobra.Command{
 				Bytes int64 `json:"bytes"`
 			}
 
-			results.Count, results.Bytes, err = operations.Count(fsrc)
+			results.Count, results.Bytes, err = operations.Count(context.Background(), fsrc)
 			if err != nil {
 				return err
 			}

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/cmd"
 	"github.com/ncw/rclone/fs/sync"
 	"github.com/spf13/cobra"
@@ -44,7 +46,7 @@ go there.
 		cmd.CheckArgs(2, 2, command, args)
 		fsrc, fdst := cmd.NewFsSrcDst(args)
 		cmd.Run(true, true, command, func() error {
-			return sync.Sync(fdst, fsrc, createEmptySrcDirs)
+			return sync.Sync(context.Background(), fdst, fsrc, createEmptySrcDirs)
 		})
 	},
 }

--- a/cmd/touch/touch_test.go
+++ b/cmd/touch/touch_test.go
@@ -1,6 +1,7 @@
 package touch
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -34,9 +35,9 @@ func TestTouchOneFile(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 
-	err := Touch(r.Fremote, "newFile")
+	err := Touch(context.Background(), r.Fremote, "newFile")
 	require.NoError(t, err)
-	_, err = r.Fremote.NewObject("newFile")
+	_, err = r.Fremote.NewObject(context.Background(), "newFile")
 	require.NoError(t, err)
 }
 
@@ -45,9 +46,9 @@ func TestTouchWithNoCreateFlag(t *testing.T) {
 	defer r.Finalise()
 
 	notCreateNewFile = true
-	err := Touch(r.Fremote, "newFile")
+	err := Touch(context.Background(), r.Fremote, "newFile")
 	require.NoError(t, err)
-	_, err = r.Fremote.NewObject("newFile")
+	_, err = r.Fremote.NewObject(context.Background(), "newFile")
 	require.Error(t, err)
 	notCreateNewFile = false
 }
@@ -58,7 +59,7 @@ func TestTouchWithTimestamp(t *testing.T) {
 
 	timeAsArgument = "060102"
 	srcFileName := "oldFile"
-	err := Touch(r.Fremote, srcFileName)
+	err := Touch(context.Background(), r.Fremote, srcFileName)
 	require.NoError(t, err)
 	checkFile(t, r.Fremote, srcFileName, "")
 }
@@ -69,7 +70,7 @@ func TestTouchWithLognerTimestamp(t *testing.T) {
 
 	timeAsArgument = "2006-01-02T15:04:05"
 	srcFileName := "oldFile"
-	err := Touch(r.Fremote, srcFileName)
+	err := Touch(context.Background(), r.Fremote, srcFileName)
 	require.NoError(t, err)
 	checkFile(t, r.Fremote, srcFileName, "")
 }
@@ -80,11 +81,11 @@ func TestTouchUpdateTimestamp(t *testing.T) {
 
 	srcFileName := "a"
 	content := "aaa"
-	file1 := r.WriteObject(srcFileName, content, t1)
+	file1 := r.WriteObject(context.Background(), srcFileName, content, t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	timeAsArgument = "121212"
-	err := Touch(r.Fremote, "a")
+	err := Touch(context.Background(), r.Fremote, "a")
 	require.NoError(t, err)
 	checkFile(t, r.Fremote, srcFileName, content)
 }
@@ -95,12 +96,12 @@ func TestTouchUpdateTimestampWithCFlag(t *testing.T) {
 
 	srcFileName := "a"
 	content := "aaa"
-	file1 := r.WriteObject(srcFileName, content, t1)
+	file1 := r.WriteObject(context.Background(), srcFileName, content, t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	notCreateNewFile = true
 	timeAsArgument = "121212"
-	err := Touch(r.Fremote, "a")
+	err := Touch(context.Background(), r.Fremote, "a")
 	require.NoError(t, err)
 	checkFile(t, r.Fremote, srcFileName, content)
 	notCreateNewFile = false
@@ -111,7 +112,7 @@ func TestTouchCreateMultipleDirAndFile(t *testing.T) {
 	defer r.Finalise()
 
 	longPath := "a/b/c.txt"
-	err := Touch(r.Fremote, longPath)
+	err := Touch(context.Background(), r.Fremote, longPath)
 	require.NoError(t, err)
 	file1 := fstest.NewItem("a/b/c.txt", "", t1)
 	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1}, []string{"a", "a/b"}, fs.ModTimeNotSupported)

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -117,7 +118,7 @@ short options as they conflict with rclone's short options.
 
 // Tree lists fsrc to outFile using the Options passed in
 func Tree(fsrc fs.Fs, outFile io.Writer, opts *tree.Options) error {
-	dirs, err := walk.NewDirTree(fsrc, "", false, opts.DeepLevel)
+	dirs, err := walk.NewDirTree(context.Background(), fsrc, "", false, opts.DeepLevel)
 	if err != nil {
 		return err
 	}
@@ -165,7 +166,7 @@ func (to *FileInfo) Mode() os.FileMode {
 
 // ModTime is modification time
 func (to *FileInfo) ModTime() time.Time {
-	return to.entry.ModTime()
+	return to.entry.ModTime(context.Background())
 }
 
 // IsDir is abbreviation for Mode().IsDir()

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -2,6 +2,7 @@ package accounting
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -101,7 +102,7 @@ func NewStats() *StatsInfo {
 }
 
 // RemoteStats returns stats for rc
-func (s *StatsInfo) RemoteStats(in rc.Params) (out rc.Params, err error) {
+func (s *StatsInfo) RemoteStats(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	out = make(rc.Params)
 	s.mu.RLock()
 	dt := time.Now().Sub(s.start)

--- a/fs/accounting/token_bucket.go
+++ b/fs/accounting/token_bucket.go
@@ -132,7 +132,7 @@ func SetBwLimit(bandwidth fs.SizeSuffix) {
 func init() {
 	rc.Add(rc.Call{
 		Path: "core/bwlimit",
-		Fn: func(in rc.Params) (out rc.Params, err error) {
+		Fn: func(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 			ibwlimit, ok := in["rate"]
 			if !ok {
 				return out, errors.Errorf("parameter rate not found")

--- a/fs/chunkedreader/chunkedreader_test.go
+++ b/fs/chunkedreader/chunkedreader_test.go
@@ -1,6 +1,7 @@
 package chunkedreader
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -38,13 +39,13 @@ func testRead(content []byte, mode mockobject.SeekMode) func(*testing.T) {
 				}
 
 				t.Run(fmt.Sprintf("Chunksize_%d_%d", cs, csMax), func(t *testing.T) {
-					cr := New(o, cs, csMax)
+					cr := New(context.Background(), o, cs, csMax)
 
 					for _, offset := range offsets {
 						for _, limit := range limits {
 							what := fmt.Sprintf("offset %d, limit %d", offset, limit)
 
-							p, err := cr.RangeSeek(offset, io.SeekStart, limit)
+							p, err := cr.RangeSeek(context.Background(), offset, io.SeekStart, limit)
 							if offset >= cl {
 								require.Error(t, err, what)
 								return
@@ -78,27 +79,27 @@ func TestErrorAfterClose(t *testing.T) {
 	o := mockobject.New("test.bin").WithContent(content, mockobject.SeekModeNone)
 
 	// Close
-	cr := New(o, 0, 0)
+	cr := New(context.Background(), o, 0, 0)
 	require.NoError(t, cr.Close())
 	require.Error(t, cr.Close())
 
 	// Read
-	cr = New(o, 0, 0)
+	cr = New(context.Background(), o, 0, 0)
 	require.NoError(t, cr.Close())
 	var buf [1]byte
 	_, err := cr.Read(buf[:])
 	require.Error(t, err)
 
 	// Seek
-	cr = New(o, 0, 0)
+	cr = New(context.Background(), o, 0, 0)
 	require.NoError(t, cr.Close())
 	_, err = cr.Seek(1, io.SeekCurrent)
 	require.Error(t, err)
 
 	// RangeSeek
-	cr = New(o, 0, 0)
+	cr = New(context.Background(), o, 0, 0)
 	require.NoError(t, cr.Close())
-	_, err = cr.RangeSeek(1, io.SeekCurrent, 0)
+	_, err = cr.RangeSeek(context.Background(), 1, io.SeekCurrent, 0)
 	require.Error(t, err)
 }
 

--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fs/rc"
 )
@@ -23,7 +25,7 @@ See the [config dump command](/commands/rclone_config_dump/) command for more in
 }
 
 // Return the config file dump
-func rcDump(in rc.Params) (out rc.Params, err error) {
+func rcDump(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	return DumpRcBlob(), nil
 }
 
@@ -43,7 +45,7 @@ See the [config dump command](/commands/rclone_config_dump/) command for more in
 }
 
 // Return the config file get
-func rcGet(in rc.Params) (out rc.Params, err error) {
+func rcGet(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	name, err := in.GetString("name")
 	if err != nil {
 		return nil, err
@@ -67,7 +69,7 @@ See the [listremotes command](/commands/rclone_listremotes/) command for more in
 }
 
 // Return the a list of remotes in the config file
-func rcListRemotes(in rc.Params) (out rc.Params, err error) {
+func rcListRemotes(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	var remotes = []string{}
 	for _, remote := range getConfigData().GetSectionList() {
 		remotes = append(remotes, remote)
@@ -94,7 +96,7 @@ See the [config providers command](/commands/rclone_config_providers/) command f
 }
 
 // Return the config file providers
-func rcProviders(in rc.Params) (out rc.Params, err error) {
+func rcProviders(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	out = rc.Params{
 		"providers": fs.Registry,
 	}
@@ -111,8 +113,8 @@ func init() {
 		rc.Add(rc.Call{
 			Path:         "config/" + name,
 			AuthRequired: true,
-			Fn: func(in rc.Params) (rc.Params, error) {
-				return rcConfig(in, name)
+			Fn: func(ctx context.Context, in rc.Params) (rc.Params, error) {
+				return rcConfig(ctx, in, name)
 			},
 			Title: name + " the config for a remote.",
 			Help: `This takes the following parameters
@@ -126,7 +128,7 @@ See the [config ` + name + ` command](/commands/rclone_config_` + name + `/) com
 }
 
 // Manipulate the config file
-func rcConfig(in rc.Params, what string) (out rc.Params, err error) {
+func rcConfig(ctx context.Context, in rc.Params, what string) (out rc.Params, err error) {
 	name, err := in.GetString("name")
 	if err != nil {
 		return nil, err
@@ -167,7 +169,7 @@ See the [config delete command](/commands/rclone_config_delete/) command for mor
 }
 
 // Return the config file delete
-func rcDelete(in rc.Params) (out rc.Params, err error) {
+func rcDelete(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	name, err := in.GetString("name")
 	if err != nil {
 		return nil, err

--- a/fs/config/rc_test.go
+++ b/fs/config/rc_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"testing"
 
 	_ "github.com/ncw/rclone/backend/local"
@@ -24,7 +25,7 @@ func TestRc(t *testing.T) {
 			"test_key": "sausage",
 		},
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.Nil(t, out)
 	assert.Equal(t, "local", FileGet(testName, "type"))
@@ -37,7 +38,7 @@ func TestRc(t *testing.T) {
 		call := rc.Calls.Get("config/dump")
 		assert.NotNil(t, call)
 		in := rc.Params{}
-		out, err := call.Fn(in)
+		out, err := call.Fn(context.Background(), in)
 		require.NoError(t, err)
 		require.NotNil(t, out)
 
@@ -54,7 +55,7 @@ func TestRc(t *testing.T) {
 		in := rc.Params{
 			"name": testName,
 		}
-		out, err := call.Fn(in)
+		out, err := call.Fn(context.Background(), in)
 		require.NoError(t, err)
 		require.NotNil(t, out)
 
@@ -66,7 +67,7 @@ func TestRc(t *testing.T) {
 		call := rc.Calls.Get("config/listremotes")
 		assert.NotNil(t, call)
 		in := rc.Params{}
-		out, err := call.Fn(in)
+		out, err := call.Fn(context.Background(), in)
 		require.NoError(t, err)
 		require.NotNil(t, out)
 
@@ -87,7 +88,7 @@ func TestRc(t *testing.T) {
 				"test_key2": "cabbage",
 			},
 		}
-		out, err := call.Fn(in)
+		out, err := call.Fn(context.Background(), in)
 		require.NoError(t, err)
 		assert.Nil(t, out)
 
@@ -106,7 +107,7 @@ func TestRc(t *testing.T) {
 				"test_key2": "cabbage",
 			},
 		}
-		out, err := call.Fn(in)
+		out, err := call.Fn(context.Background(), in)
 		require.NoError(t, err)
 		assert.Nil(t, out)
 
@@ -121,7 +122,7 @@ func TestRc(t *testing.T) {
 	in = rc.Params{
 		"name": testName,
 	}
-	out, err = call.Fn(in)
+	out, err = call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Nil(t, out)
 	assert.Equal(t, "", FileGet(testName, "type"))
@@ -132,7 +133,7 @@ func TestRcProviders(t *testing.T) {
 	call := rc.Calls.Get("config/providers")
 	assert.NotNil(t, call)
 	in := rc.Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	var registry []*fs.RegInfo

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -1,6 +1,9 @@
 package fs
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Dir describes an unspecialized directory for directory/container/bucket lists
 type Dir struct {
@@ -22,10 +25,10 @@ func NewDir(remote string, modTime time.Time) *Dir {
 }
 
 // NewDirCopy creates an unspecialized copy of the Directory object passed in
-func NewDirCopy(d Directory) *Dir {
+func NewDirCopy(ctx context.Context, d Directory) *Dir {
 	return &Dir{
 		remote:  d.Remote(),
-		modTime: d.ModTime(),
+		modTime: d.ModTime(ctx),
 		size:    d.Size(),
 		items:   d.Items(),
 		id:      d.ID(),
@@ -61,7 +64,7 @@ func (d *Dir) SetID(id string) *Dir {
 
 // ModTime returns the modification date of the file
 // It should return a best guess if one isn't available
-func (d *Dir) ModTime() time.Time {
+func (d *Dir) ModTime(ctx context.Context) time.Time {
 	if !d.modTime.IsZero() {
 		return d.modTime
 	}

--- a/fs/filter/filter_test.go
+++ b/fs/filter/filter_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -159,7 +160,7 @@ type includeDirTest struct {
 
 func testDirInclude(t *testing.T, f *Filter, tests []includeDirTest) {
 	for _, test := range tests {
-		got, err := f.IncludeDirectory(nil)(test.in)
+		got, err := f.IncludeDirectory(context.Background(), nil)(test.in)
 		require.NoError(t, err)
 		assert.Equal(t, test.want, got, test.in)
 	}
@@ -235,8 +236,8 @@ func TestNewFilterMakeListR(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check error if no files
-	listR := f.MakeListR(nil)
-	err = listR("", nil)
+	listR := f.MakeListR(context.Background(), nil)
+	err = listR(context.Background(), "", nil)
 	assert.EqualError(t, err, errFilesFromNotSet.Error())
 
 	// Add some files
@@ -256,7 +257,7 @@ func TestNewFilterMakeListR(t *testing.T) {
 	// NewObject function for MakeListR
 	newObjects := FilesMap{}
 	var newObjectMu sync.Mutex
-	NewObject := func(remote string) (fs.Object, error) {
+	NewObject := func(ctx context.Context, remote string) (fs.Object, error) {
 		newObjectMu.Lock()
 		defer newObjectMu.Unlock()
 		if remote == "notfound" {
@@ -282,8 +283,8 @@ func TestNewFilterMakeListR(t *testing.T) {
 	}
 
 	// Make the listR and call it
-	listR = f.MakeListR(NewObject)
-	err = listR("", listRcallback)
+	listR = f.MakeListR(context.Background(), NewObject)
+	err = listR(context.Background(), "", listRcallback)
 	require.NoError(t, err)
 
 	// Check that the correct objects were created and listed
@@ -298,7 +299,7 @@ func TestNewFilterMakeListR(t *testing.T) {
 
 	// Now check an error is returned from NewObject
 	require.NoError(t, f.AddFile("error"))
-	err = listR("", listRcallback)
+	err = listR(context.Background(), "", listRcallback)
 	require.EqualError(t, err, assert.AnError.Error())
 }
 

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -17,7 +18,7 @@ import (
 
 func TestFeaturesDisable(t *testing.T) {
 	ft := new(Features)
-	ft.Copy = func(src Object, remote string) (Object, error) {
+	ft.Copy = func(ctx context.Context, src Object, remote string) (Object, error) {
 		return nil, nil
 	}
 	ft.CaseInsensitive = true
@@ -44,7 +45,7 @@ func TestFeaturesList(t *testing.T) {
 func TestFeaturesEnabled(t *testing.T) {
 	ft := new(Features)
 	ft.CaseInsensitive = true
-	ft.Purge = func() error { return nil }
+	ft.Purge = func(ctx context.Context) error { return nil }
 	enabled := ft.Enabled()
 
 	flag, ok := enabled["CaseInsensitive"]
@@ -68,7 +69,7 @@ func TestFeaturesEnabled(t *testing.T) {
 
 func TestFeaturesDisableList(t *testing.T) {
 	ft := new(Features)
-	ft.Copy = func(src Object, remote string) (Object, error) {
+	ft.Copy = func(ctx context.Context, src Object, remote string) (Object, error) {
 		return nil, nil
 	}
 	ft.CaseInsensitive = true

--- a/fs/list/list_test.go
+++ b/fs/list/list_test.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -24,21 +25,21 @@ func TestFilterAndSortIncludeAll(t *testing.T) {
 	dd := mockdir.New("d")
 	oD := mockobject.Object("D")
 	entries := fs.DirEntries{da, oA, db, oB, dc, oC, dd, oD}
-	includeObject := func(o fs.Object) bool {
+	includeObject := func(ctx context.Context, o fs.Object) bool {
 		return o != oB
 	}
 	includeDirectory := func(remote string) (bool, error) {
 		return remote != "c", nil
 	}
 	// no filter
-	newEntries, err := filterAndSortDir(entries, true, "", includeObject, includeDirectory)
+	newEntries, err := filterAndSortDir(context.Background(), entries, true, "", includeObject, includeDirectory)
 	require.NoError(t, err)
 	assert.Equal(t,
 		newEntries,
 		fs.DirEntries{oA, oB, oC, oD, da, db, dc, dd},
 	)
 	// filter
-	newEntries, err = filterAndSortDir(entries, false, "", includeObject, includeDirectory)
+	newEntries, err = filterAndSortDir(context.Background(), entries, false, "", includeObject, includeDirectory)
 	require.NoError(t, err)
 	assert.Equal(t,
 		newEntries,
@@ -57,7 +58,7 @@ func TestFilterAndSortCheckDir(t *testing.T) {
 	dd := mockdir.New("dir/d")
 	oD := mockobject.Object("dir/D")
 	entries := fs.DirEntries{da, oA, db, oB, dc, oC, dd, oD}
-	newEntries, err := filterAndSortDir(entries, true, "dir", nil, nil)
+	newEntries, err := filterAndSortDir(context.Background(), entries, true, "dir", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t,
 		newEntries,
@@ -76,7 +77,7 @@ func TestFilterAndSortCheckDirRoot(t *testing.T) {
 	dd := mockdir.New("d")
 	oD := mockobject.Object("D")
 	entries := fs.DirEntries{da, oA, db, oB, dc, oC, dd, oD}
-	newEntries, err := filterAndSortDir(entries, true, "", nil, nil)
+	newEntries, err := filterAndSortDir(context.Background(), entries, true, "", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t,
 		newEntries,
@@ -86,10 +87,10 @@ func TestFilterAndSortCheckDirRoot(t *testing.T) {
 
 type unknownDirEntry string
 
-func (o unknownDirEntry) String() string         { return string(o) }
-func (o unknownDirEntry) Remote() string         { return string(o) }
-func (o unknownDirEntry) ModTime() (t time.Time) { return t }
-func (o unknownDirEntry) Size() int64            { return 0 }
+func (o unknownDirEntry) String() string                            { return string(o) }
+func (o unknownDirEntry) Remote() string                            { return string(o) }
+func (o unknownDirEntry) ModTime(ctx context.Context) (t time.Time) { return t }
+func (o unknownDirEntry) Size() int64                               { return 0 }
 
 func TestFilterAndSortUnknown(t *testing.T) {
 	// Check that an unknown entry produces an error
@@ -98,7 +99,7 @@ func TestFilterAndSortUnknown(t *testing.T) {
 	ub := unknownDirEntry("b")
 	oB := mockobject.Object("B/sub")
 	entries := fs.DirEntries{da, oA, ub, oB}
-	newEntries, err := filterAndSortDir(entries, true, "", nil, nil)
+	newEntries, err := filterAndSortDir(context.Background(), entries, true, "", nil, nil)
 	assert.Error(t, err, "error")
 	assert.Nil(t, newEntries)
 }

--- a/fs/mimetype.go
+++ b/fs/mimetype.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"mime"
 	"path"
 	"strings"
@@ -17,10 +18,10 @@ func MimeTypeFromName(remote string) (mimeType string) {
 
 // MimeType returns the MimeType from the object, either by calling
 // the MimeTyper interface or using MimeTypeFromName
-func MimeType(o ObjectInfo) (mimeType string) {
+func MimeType(ctx context.Context, o ObjectInfo) (mimeType string) {
 	// Read the MimeType from the optional interface if available
 	if do, ok := o.(MimeTyper); ok {
-		mimeType = do.MimeType()
+		mimeType = do.MimeType(ctx)
 		// Debugf(o, "Read MimeType as %q", mimeType)
 		if mimeType != "" {
 			return mimeType
@@ -33,10 +34,10 @@ func MimeType(o ObjectInfo) (mimeType string) {
 //
 // It returns "inode/directory" for directories, or uses
 // MimeType(Object)
-func MimeTypeDirEntry(item DirEntry) string {
+func MimeTypeDirEntry(ctx context.Context, item DirEntry) string {
 	switch x := item.(type) {
 	case Object:
-		return MimeType(x)
+		return MimeType(ctx, x)
 	case Directory:
 		return "inode/directory"
 	}

--- a/fs/object/object_test.go
+++ b/fs/object/object_test.go
@@ -2,6 +2,7 @@ package object_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -23,26 +24,26 @@ func TestStaticObject(t *testing.T) {
 	assert.Equal(t, object.MemoryFs, o.Fs())
 	assert.Equal(t, remote, o.Remote())
 	assert.Equal(t, remote, o.String())
-	assert.Equal(t, now, o.ModTime())
+	assert.Equal(t, now, o.ModTime(context.Background()))
 	assert.Equal(t, size, o.Size())
 	assert.Equal(t, true, o.Storable())
 
-	Hash, err := o.Hash(hash.MD5)
+	Hash, err := o.Hash(context.Background(), hash.MD5)
 	assert.NoError(t, err)
 	assert.Equal(t, "", Hash)
 
 	o = object.NewStaticObjectInfo(remote, now, size, true, nil, nil)
-	_, err = o.Hash(hash.MD5)
+	_, err = o.Hash(context.Background(), hash.MD5)
 	assert.Equal(t, hash.ErrUnsupported, err)
 
 	hs := map[hash.Type]string{
 		hash.MD5: "potato",
 	}
 	o = object.NewStaticObjectInfo(remote, now, size, true, hs, nil)
-	Hash, err = o.Hash(hash.MD5)
+	Hash, err = o.Hash(context.Background(), hash.MD5)
 	assert.NoError(t, err)
 	assert.Equal(t, "potato", Hash)
-	_, err = o.Hash(hash.SHA1)
+	_, err = o.Hash(context.Background(), hash.SHA1)
 	assert.Equal(t, hash.ErrUnsupported, err)
 }
 
@@ -55,27 +56,27 @@ func TestMemoryFs(t *testing.T) {
 	assert.Equal(t, hash.Supported, f.Hashes())
 	assert.Equal(t, &fs.Features{}, f.Features())
 
-	entries, err := f.List("")
+	entries, err := f.List(context.Background(), "")
 	assert.NoError(t, err)
 	assert.Nil(t, entries)
 
-	o, err := f.NewObject("obj")
+	o, err := f.NewObject(context.Background(), "obj")
 	assert.Equal(t, fs.ErrorObjectNotFound, err)
 	assert.Nil(t, o)
 
 	buf := bytes.NewBufferString("potato")
 	now := time.Now()
 	src := object.NewStaticObjectInfo("remote", now, int64(buf.Len()), true, nil, nil)
-	o, err = f.Put(buf, src)
+	o, err = f.Put(context.Background(), buf, src)
 	assert.NoError(t, err)
-	hash, err := o.Hash(hash.SHA1)
+	hash, err := o.Hash(context.Background(), hash.SHA1)
 	assert.NoError(t, err)
 	assert.Equal(t, "3e2e95f5ad970eadfa7e17eaf73da97024aa5359", hash)
 
-	err = f.Mkdir("dir")
+	err = f.Mkdir(context.Background(), "dir")
 	assert.Error(t, err)
 
-	err = f.Rmdir("dir")
+	err = f.Rmdir(context.Background(), "dir")
 	assert.Equal(t, fs.ErrorDirNotFound, err)
 }
 
@@ -91,22 +92,22 @@ func TestMemoryObject(t *testing.T) {
 	assert.Equal(t, object.MemoryFs, o.Fs())
 	assert.Equal(t, remote, o.Remote())
 	assert.Equal(t, remote, o.String())
-	assert.Equal(t, now, o.ModTime())
+	assert.Equal(t, now, o.ModTime(context.Background()))
 	assert.Equal(t, int64(len(content)), o.Size())
 	assert.Equal(t, true, o.Storable())
 
-	Hash, err := o.Hash(hash.MD5)
+	Hash, err := o.Hash(context.Background(), hash.MD5)
 	assert.NoError(t, err)
 	assert.Equal(t, "8ee2027983915ec78acc45027d874316", Hash)
 
-	Hash, err = o.Hash(hash.SHA1)
+	Hash, err = o.Hash(context.Background(), hash.SHA1)
 	assert.NoError(t, err)
 	assert.Equal(t, "3e2e95f5ad970eadfa7e17eaf73da97024aa5359", Hash)
 
 	newNow := now.Add(time.Minute)
-	err = o.SetModTime(newNow)
+	err = o.SetModTime(context.Background(), newNow)
 	assert.NoError(t, err)
-	assert.Equal(t, newNow, o.ModTime())
+	assert.Equal(t, newNow, o.ModTime(context.Background()))
 
 	checkOpen := func(rc io.ReadCloser, expected string) {
 		actual, err := ioutil.ReadAll(rc)
@@ -117,18 +118,18 @@ func TestMemoryObject(t *testing.T) {
 	}
 
 	checkContent := func(o fs.Object, expected string) {
-		rc, err := o.Open()
+		rc, err := o.Open(context.Background())
 		assert.NoError(t, err)
 		checkOpen(rc, expected)
 	}
 
 	checkContent(o, string(content))
 
-	rc, err := o.Open(&fs.RangeOption{Start: 1, End: 3})
+	rc, err := o.Open(context.Background(), &fs.RangeOption{Start: 1, End: 3})
 	assert.NoError(t, err)
 	checkOpen(rc, "ot")
 
-	rc, err = o.Open(&fs.SeekOption{Offset: 3})
+	rc, err = o.Open(context.Background(), &fs.SeekOption{Offset: 3})
 	assert.NoError(t, err)
 	checkOpen(rc, "ato")
 
@@ -137,10 +138,10 @@ func TestMemoryObject(t *testing.T) {
 	newContent := bytes.NewBufferString("Rutabaga")
 	assert.True(t, newContent.Len() < cap(content)) // fits within cap(content)
 	src := object.NewStaticObjectInfo(remote, newNow, int64(newContent.Len()), true, nil, nil)
-	err = o.Update(newContent, src)
+	err = o.Update(context.Background(), newContent, src)
 	assert.NoError(t, err)
 	checkContent(o, "Rutabaga")
-	assert.Equal(t, newNow, o.ModTime())
+	assert.Equal(t, newNow, o.ModTime(context.Background()))
 	assert.Equal(t, "Rutaba", string(content)) // check we re-used the buffer
 
 	// not within the buffer
@@ -149,7 +150,7 @@ func TestMemoryObject(t *testing.T) {
 	newContent = bytes.NewBufferString(newStr)
 	assert.True(t, newContent.Len() > cap(content)) // does not fit within cap(content)
 	src = object.NewStaticObjectInfo(remote, newNow, int64(newContent.Len()), true, nil, nil)
-	err = o.Update(newContent, src)
+	err = o.Update(context.Background(), newContent, src)
 	assert.NoError(t, err)
 	checkContent(o, newStr)
 	assert.Equal(t, "Rutaba", string(content)) // check we didn't re-use the buffer
@@ -158,7 +159,7 @@ func TestMemoryObject(t *testing.T) {
 	newStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	newContent = bytes.NewBufferString(newStr)
 	src = object.NewStaticObjectInfo(remote, newNow, -1, true, nil, nil)
-	err = o.Update(newContent, src)
+	err = o.Update(context.Background(), newContent, src)
 	assert.NoError(t, err)
 	checkContent(o, newStr)
 
@@ -166,10 +167,10 @@ func TestMemoryObject(t *testing.T) {
 	newStr = ""
 	newContent = bytes.NewBufferString(newStr)
 	src = object.NewStaticObjectInfo(remote, newNow, 0, true, nil, nil)
-	err = o.Update(newContent, src)
+	err = o.Update(context.Background(), newContent, src)
 	assert.NoError(t, err)
 	checkContent(o, newStr)
 
-	err = o.Remove()
+	err = o.Remove(context.Background())
 	assert.Error(t, err)
 }

--- a/fs/operations/dedupe_test.go
+++ b/fs/operations/dedupe_test.go
@@ -1,6 +1,7 @@
 package operations_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -37,12 +38,12 @@ func TestDeduplicateInteractive(t *testing.T) {
 	skipIfCantDedupe(t, r.Fremote)
 	skipIfNoHash(t, r.Fremote)
 
-	file1 := r.WriteUncheckedObject("one", "This is one", t1)
-	file2 := r.WriteUncheckedObject("one", "This is one", t1)
-	file3 := r.WriteUncheckedObject("one", "This is one", t1)
+	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
+	file2 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
+	file3 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
 	r.CheckWithDuplicates(t, file1, file2, file3)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateInteractive)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateInteractive)
 	require.NoError(t, err)
 
 	fstest.CheckItems(t, r.Fremote, file1)
@@ -54,17 +55,17 @@ func TestDeduplicateSkip(t *testing.T) {
 	skipIfCantDedupe(t, r.Fremote)
 	haveHash := r.Fremote.Hashes().GetOne() != hash.None
 
-	file1 := r.WriteUncheckedObject("one", "This is one", t1)
+	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
 	files := []fstest.Item{file1}
 	if haveHash {
-		file2 := r.WriteUncheckedObject("one", "This is one", t1)
+		file2 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
 		files = append(files, file2)
 	}
-	file3 := r.WriteUncheckedObject("one", "This is another one", t1)
+	file3 := r.WriteUncheckedObject(context.Background(), "one", "This is another one", t1)
 	files = append(files, file3)
 	r.CheckWithDuplicates(t, files...)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateSkip)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateSkip)
 	require.NoError(t, err)
 
 	r.CheckWithDuplicates(t, file1, file3)
@@ -75,18 +76,18 @@ func TestDeduplicateFirst(t *testing.T) {
 	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
-	file1 := r.WriteUncheckedObject("one", "This is one", t1)
-	file2 := r.WriteUncheckedObject("one", "This is one A", t1)
-	file3 := r.WriteUncheckedObject("one", "This is one BB", t1)
+	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
+	file2 := r.WriteUncheckedObject(context.Background(), "one", "This is one A", t1)
+	file3 := r.WriteUncheckedObject(context.Background(), "one", "This is one BB", t1)
 	r.CheckWithDuplicates(t, file1, file2, file3)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateFirst)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateFirst)
 	require.NoError(t, err)
 
 	// list until we get one object
 	var objects, size int64
 	for try := 1; try <= *fstest.ListRetries; try++ {
-		objects, size, err = operations.Count(r.Fremote)
+		objects, size, err = operations.Count(context.Background(), r.Fremote)
 		require.NoError(t, err)
 		if objects == 1 {
 			break
@@ -104,12 +105,12 @@ func TestDeduplicateNewest(t *testing.T) {
 	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
-	file1 := r.WriteUncheckedObject("one", "This is one", t1)
-	file2 := r.WriteUncheckedObject("one", "This is one too", t2)
-	file3 := r.WriteUncheckedObject("one", "This is another one", t3)
+	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
+	file2 := r.WriteUncheckedObject(context.Background(), "one", "This is one too", t2)
+	file3 := r.WriteUncheckedObject(context.Background(), "one", "This is another one", t3)
 	r.CheckWithDuplicates(t, file1, file2, file3)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateNewest)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateNewest)
 	require.NoError(t, err)
 
 	fstest.CheckItems(t, r.Fremote, file3)
@@ -120,12 +121,12 @@ func TestDeduplicateOldest(t *testing.T) {
 	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
-	file1 := r.WriteUncheckedObject("one", "This is one", t1)
-	file2 := r.WriteUncheckedObject("one", "This is one too", t2)
-	file3 := r.WriteUncheckedObject("one", "This is another one", t3)
+	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
+	file2 := r.WriteUncheckedObject(context.Background(), "one", "This is one too", t2)
+	file3 := r.WriteUncheckedObject(context.Background(), "one", "This is another one", t3)
 	r.CheckWithDuplicates(t, file1, file2, file3)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateOldest)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateOldest)
 	require.NoError(t, err)
 
 	fstest.CheckItems(t, r.Fremote, file1)
@@ -136,12 +137,12 @@ func TestDeduplicateLargest(t *testing.T) {
 	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
-	file1 := r.WriteUncheckedObject("one", "This is one", t1)
-	file2 := r.WriteUncheckedObject("one", "This is one too", t2)
-	file3 := r.WriteUncheckedObject("one", "This is another one", t3)
+	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
+	file2 := r.WriteUncheckedObject(context.Background(), "one", "This is one too", t2)
+	file3 := r.WriteUncheckedObject(context.Background(), "one", "This is another one", t3)
 	r.CheckWithDuplicates(t, file1, file2, file3)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateLargest)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateLargest)
 	require.NoError(t, err)
 
 	fstest.CheckItems(t, r.Fremote, file3)
@@ -152,16 +153,16 @@ func TestDeduplicateRename(t *testing.T) {
 	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
-	file1 := r.WriteUncheckedObject("one.txt", "This is one", t1)
-	file2 := r.WriteUncheckedObject("one.txt", "This is one too", t2)
-	file3 := r.WriteUncheckedObject("one.txt", "This is another one", t3)
-	file4 := r.WriteUncheckedObject("one-1.txt", "This is not a duplicate", t1)
+	file1 := r.WriteUncheckedObject(context.Background(), "one.txt", "This is one", t1)
+	file2 := r.WriteUncheckedObject(context.Background(), "one.txt", "This is one too", t2)
+	file3 := r.WriteUncheckedObject(context.Background(), "one.txt", "This is another one", t3)
+	file4 := r.WriteUncheckedObject(context.Background(), "one-1.txt", "This is not a duplicate", t1)
 	r.CheckWithDuplicates(t, file1, file2, file3, file4)
 
-	err := operations.Deduplicate(r.Fremote, operations.DeduplicateRename)
+	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateRename)
 	require.NoError(t, err)
 
-	require.NoError(t, walk.ListR(r.Fremote, "", true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
+	require.NoError(t, walk.ListR(context.Background(), r.Fremote, "", true, -1, walk.ListObjects, func(entries fs.DirEntries) error {
 		entries.ForObject(func(o fs.Object) {
 			remote := o.Remote()
 			if remote != "one-1.txt" &&
@@ -196,23 +197,23 @@ func TestMergeDirs(t *testing.T) {
 		t.Skip("Can't merge directories")
 	}
 
-	file1 := r.WriteObject("dupe1/one.txt", "This is one", t1)
-	file2 := r.WriteObject("dupe2/two.txt", "This is one too", t2)
-	file3 := r.WriteObject("dupe3/three.txt", "This is another one", t3)
+	file1 := r.WriteObject(context.Background(), "dupe1/one.txt", "This is one", t1)
+	file2 := r.WriteObject(context.Background(), "dupe2/two.txt", "This is one too", t2)
+	file3 := r.WriteObject(context.Background(), "dupe3/three.txt", "This is another one", t3)
 
-	objs, dirs, err := walk.GetAll(r.Fremote, "", true, 1)
+	objs, dirs, err := walk.GetAll(context.Background(), r.Fremote, "", true, 1)
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dirs))
 	assert.Equal(t, 0, len(objs))
 
-	err = mergeDirs(dirs)
+	err = mergeDirs(context.Background(), dirs)
 	require.NoError(t, err)
 
 	file2.Path = "dupe1/two.txt"
 	file3.Path = "dupe1/three.txt"
 	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
 
-	objs, dirs, err = walk.GetAll(r.Fremote, "", true, 1)
+	objs, dirs, err = walk.GetAll(context.Background(), r.Fremote, "", true, 1)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dirs))
 	assert.Equal(t, 0, len(objs))

--- a/fs/operations/listdirsorted_test.go
+++ b/fs/operations/listdirsorted_test.go
@@ -1,6 +1,7 @@
 package operations_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ncw/rclone/fs"
@@ -23,13 +24,13 @@ func TestListDirSorted(t *testing.T) {
 	}()
 
 	files := []fstest.Item{
-		r.WriteObject("a.txt", "hello world", t1),
-		r.WriteObject("zend.txt", "hello", t1),
-		r.WriteObject("sub dir/hello world", "hello world", t1),
-		r.WriteObject("sub dir/hello world2", "hello world", t1),
-		r.WriteObject("sub dir/ignore dir/.ignore", "", t1),
-		r.WriteObject("sub dir/ignore dir/should be ignored", "to ignore", t1),
-		r.WriteObject("sub dir/sub sub dir/hello world3", "hello world", t1),
+		r.WriteObject(context.Background(), "a.txt", "hello world", t1),
+		r.WriteObject(context.Background(), "zend.txt", "hello", t1),
+		r.WriteObject(context.Background(), "sub dir/hello world", "hello world", t1),
+		r.WriteObject(context.Background(), "sub dir/hello world2", "hello world", t1),
+		r.WriteObject(context.Background(), "sub dir/ignore dir/.ignore", "", t1),
+		r.WriteObject(context.Background(), "sub dir/ignore dir/should be ignored", "to ignore", t1),
+		r.WriteObject(context.Background(), "sub dir/sub sub dir/hello world3", "hello world", t1),
 	}
 	fstest.CheckItems(t, r.Fremote, files...)
 	var items fs.DirEntries
@@ -50,20 +51,20 @@ func TestListDirSorted(t *testing.T) {
 		return name
 	}
 
-	items, err = list.DirSorted(r.Fremote, true, "")
+	items, err = list.DirSorted(context.Background(), r.Fremote, true, "")
 	require.NoError(t, err)
 	require.Len(t, items, 3)
 	assert.Equal(t, "a.txt", str(0))
 	assert.Equal(t, "sub dir/", str(1))
 	assert.Equal(t, "zend.txt", str(2))
 
-	items, err = list.DirSorted(r.Fremote, false, "")
+	items, err = list.DirSorted(context.Background(), r.Fremote, false, "")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, "sub dir/", str(0))
 	assert.Equal(t, "zend.txt", str(1))
 
-	items, err = list.DirSorted(r.Fremote, true, "sub dir")
+	items, err = list.DirSorted(context.Background(), r.Fremote, true, "sub dir")
 	require.NoError(t, err)
 	require.Len(t, items, 4)
 	assert.Equal(t, "sub dir/hello world", str(0))
@@ -71,7 +72,7 @@ func TestListDirSorted(t *testing.T) {
 	assert.Equal(t, "sub dir/ignore dir/", str(2))
 	assert.Equal(t, "sub dir/sub sub dir/", str(3))
 
-	items, err = list.DirSorted(r.Fremote, false, "sub dir")
+	items, err = list.DirSorted(context.Background(), r.Fremote, false, "sub dir")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, "sub dir/ignore dir/", str(0))
@@ -80,23 +81,23 @@ func TestListDirSorted(t *testing.T) {
 	// testing ignore file
 	filter.Active.Opt.ExcludeFile = ".ignore"
 
-	items, err = list.DirSorted(r.Fremote, false, "sub dir")
+	items, err = list.DirSorted(context.Background(), r.Fremote, false, "sub dir")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, "sub dir/sub sub dir/", str(0))
 
-	items, err = list.DirSorted(r.Fremote, false, "sub dir/ignore dir")
+	items, err = list.DirSorted(context.Background(), r.Fremote, false, "sub dir/ignore dir")
 	require.NoError(t, err)
 	require.Len(t, items, 0)
 
-	items, err = list.DirSorted(r.Fremote, true, "sub dir/ignore dir")
+	items, err = list.DirSorted(context.Background(), r.Fremote, true, "sub dir/ignore dir")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, "sub dir/ignore dir/.ignore", str(0))
 	assert.Equal(t, "sub dir/ignore dir/should be ignored", str(1))
 
 	filter.Active.Opt.ExcludeFile = ""
-	items, err = list.DirSorted(r.Fremote, false, "sub dir/ignore dir")
+	items, err = list.DirSorted(context.Background(), r.Fremote, false, "sub dir/ignore dir")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, "sub dir/ignore dir/.ignore", str(0))

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"path"
 	"time"
 
@@ -78,7 +79,7 @@ type ListJSONOpt struct {
 }
 
 // ListJSON lists fsrc using the options in opt calling callback for each item
-func ListJSON(fsrc fs.Fs, remote string, opt *ListJSONOpt, callback func(*ListJSONItem) error) error {
+func ListJSON(ctx context.Context, fsrc fs.Fs, remote string, opt *ListJSONOpt, callback func(*ListJSONItem) error) error {
 	var cipher crypt.Cipher
 	if opt.ShowEncrypted {
 		fsInfo, _, _, config, err := fs.ConfigFs(fsrc.Name() + ":" + fsrc.Root())
@@ -97,7 +98,7 @@ func ListJSON(fsrc fs.Fs, remote string, opt *ListJSONOpt, callback func(*ListJS
 	canGetTier := features.GetTier
 	format := formatForPrecision(fsrc.Precision())
 	isBucket := features.BucketBased && remote == "" && fsrc.Root() == "" // if bucket based remote listing the root mark directories as buckets
-	err := walk.ListR(fsrc, remote, false, ConfigMaxDepth(opt.Recurse), walk.ListAll, func(entries fs.DirEntries) (err error) {
+	err := walk.ListR(ctx, fsrc, remote, false, ConfigMaxDepth(opt.Recurse), walk.ListAll, func(entries fs.DirEntries) (err error) {
 		for _, entry := range entries {
 			switch entry.(type) {
 			case fs.Directory:
@@ -116,10 +117,10 @@ func ListJSON(fsrc fs.Fs, remote string, opt *ListJSONOpt, callback func(*ListJS
 				Path:     entry.Remote(),
 				Name:     path.Base(entry.Remote()),
 				Size:     entry.Size(),
-				MimeType: fs.MimeTypeDirEntry(entry),
+				MimeType: fs.MimeTypeDirEntry(ctx, entry),
 			}
 			if !opt.NoModTime {
-				item.ModTime = Timestamp{When: entry.ModTime(), Format: format}
+				item.ModTime = Timestamp{When: entry.ModTime(ctx), Format: format}
 			}
 			if cipher != nil {
 				switch entry.(type) {
@@ -161,7 +162,7 @@ func ListJSON(fsrc fs.Fs, remote string, opt *ListJSONOpt, callback func(*ListJS
 				if opt.ShowHash {
 					item.Hashes = make(map[string]string)
 					for _, hashType := range x.Fs().Hashes().Array() {
-						hash, err := x.Hash(hashType)
+						hash, err := x.Hash(ctx, hashType)
 						if err != nil {
 							fs.Errorf(x, "Failed to read hash: %v", err)
 						} else if hash != "" {

--- a/fs/operations/multithread_test.go
+++ b/fs/operations/multithread_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -50,20 +51,20 @@ func TestMultithreadCopy(t *testing.T) {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
 			contents := fstest.RandomString(test.size)
 			t1 := fstest.Time("2001-02-03T04:05:06.499999999Z")
-			file1 := r.WriteObject("file1", contents, t1)
+			file1 := r.WriteObject(context.Background(), "file1", contents, t1)
 			fstest.CheckItems(t, r.Fremote, file1)
 			fstest.CheckItems(t, r.Flocal)
 
-			src, err := r.Fremote.NewObject("file1")
+			src, err := r.Fremote.NewObject(context.Background(), "file1")
 			require.NoError(t, err)
 
-			dst, err := multiThreadCopy(r.Flocal, "file1", src, 2)
+			dst, err := multiThreadCopy(context.Background(), r.Flocal, "file1", src, 2)
 			require.NoError(t, err)
 			assert.Equal(t, src.Size(), dst.Size())
 			assert.Equal(t, "file1", dst.Remote())
 
 			fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1}, nil, fs.ModTimeNotSupported)
-			require.NoError(t, dst.Remove())
+			require.NoError(t, dst.Remove(context.Background()))
 		})
 	}
 

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -21,6 +21,7 @@ package operations_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -62,23 +63,23 @@ func TestMkdir(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 
-	err := operations.Mkdir(r.Fremote, "")
+	err := operations.Mkdir(context.Background(), r.Fremote, "")
 	require.NoError(t, err)
 	fstest.CheckListing(t, r.Fremote, []fstest.Item{})
 
-	err = operations.Mkdir(r.Fremote, "")
+	err = operations.Mkdir(context.Background(), r.Fremote, "")
 	require.NoError(t, err)
 }
 
 func TestLsd(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteObject("sub dir/hello world", "hello world", t1)
+	file1 := r.WriteObject(context.Background(), "sub dir/hello world", "hello world", t1)
 
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	var buf bytes.Buffer
-	err := operations.ListDir(r.Fremote, &buf)
+	err := operations.ListDir(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	res := buf.String()
 	assert.Contains(t, res, "sub dir\n")
@@ -87,13 +88,13 @@ func TestLsd(t *testing.T) {
 func TestLs(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteBoth("potato2", "------------------------------------------------------------", t1)
-	file2 := r.WriteBoth("empty space", "", t2)
+	file1 := r.WriteBoth(context.Background(), "potato2", "------------------------------------------------------------", t1)
+	file2 := r.WriteBoth(context.Background(), "empty space", "", t2)
 
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	var buf bytes.Buffer
-	err := operations.List(r.Fremote, &buf)
+	err := operations.List(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	res := buf.String()
 	assert.Contains(t, res, "        0 empty space\n")
@@ -103,8 +104,8 @@ func TestLs(t *testing.T) {
 func TestLsWithFilesFrom(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteBoth("potato2", "------------------------------------------------------------", t1)
-	file2 := r.WriteBoth("empty space", "", t2)
+	file1 := r.WriteBoth(context.Background(), "potato2", "------------------------------------------------------------", t1)
+	file2 := r.WriteBoth(context.Background(), "empty space", "", t2)
 
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
@@ -122,7 +123,7 @@ func TestLsWithFilesFrom(t *testing.T) {
 	}()
 
 	var buf bytes.Buffer
-	err = operations.List(r.Fremote, &buf)
+	err = operations.List(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "       60 potato2\n", buf.String())
 
@@ -134,7 +135,7 @@ func TestLsWithFilesFrom(t *testing.T) {
 	}()
 
 	buf.Reset()
-	err = operations.List(r.Fremote, &buf)
+	err = operations.List(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "       60 potato2\n", buf.String())
 }
@@ -142,13 +143,13 @@ func TestLsWithFilesFrom(t *testing.T) {
 func TestLsLong(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteBoth("potato2", "------------------------------------------------------------", t1)
-	file2 := r.WriteBoth("empty space", "", t2)
+	file1 := r.WriteBoth(context.Background(), "potato2", "------------------------------------------------------------", t1)
+	file2 := r.WriteBoth(context.Background(), "empty space", "", t2)
 
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	var buf bytes.Buffer
-	err := operations.ListLong(r.Fremote, &buf)
+	err := operations.ListLong(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	res := buf.String()
 	lines := strings.Split(strings.Trim(res, "\n"), "\n")
@@ -187,15 +188,15 @@ func TestLsLong(t *testing.T) {
 func TestHashSums(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteBoth("potato2", "------------------------------------------------------------", t1)
-	file2 := r.WriteBoth("empty space", "", t2)
+	file1 := r.WriteBoth(context.Background(), "potato2", "------------------------------------------------------------", t1)
+	file2 := r.WriteBoth(context.Background(), "empty space", "", t2)
 
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	// MD5 Sum
 
 	var buf bytes.Buffer
-	err := operations.Md5sum(r.Fremote, &buf)
+	err := operations.Md5sum(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	res := buf.String()
 	if !strings.Contains(res, "d41d8cd98f00b204e9800998ecf8427e  empty space\n") &&
@@ -212,7 +213,7 @@ func TestHashSums(t *testing.T) {
 	// SHA1 Sum
 
 	buf.Reset()
-	err = operations.Sha1sum(r.Fremote, &buf)
+	err = operations.Sha1sum(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	res = buf.String()
 	if !strings.Contains(res, "da39a3ee5e6b4b0d3255bfef95601890afd80709  empty space\n") &&
@@ -229,7 +230,7 @@ func TestHashSums(t *testing.T) {
 	// Dropbox Hash Sum
 
 	buf.Reset()
-	err = operations.DropboxHashSum(r.Fremote, &buf)
+	err = operations.DropboxHashSum(context.Background(), r.Fremote, &buf)
 	require.NoError(t, err)
 	res = buf.String()
 	if !strings.Contains(res, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  empty space\n") &&
@@ -274,9 +275,9 @@ func TestSuffixName(t *testing.T) {
 func TestCount(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteBoth("potato2", "------------------------------------------------------------", t1)
-	file2 := r.WriteBoth("empty space", "", t2)
-	file3 := r.WriteBoth("sub dir/potato3", "hello", t2)
+	file1 := r.WriteBoth(context.Background(), "potato2", "------------------------------------------------------------", t1)
+	file2 := r.WriteBoth(context.Background(), "empty space", "", t2)
+	file3 := r.WriteBoth(context.Background(), "sub dir/potato3", "hello", t2)
 
 	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
 
@@ -284,7 +285,7 @@ func TestCount(t *testing.T) {
 	fs.Config.MaxDepth = 1
 	defer func() { fs.Config.MaxDepth = -1 }()
 
-	objects, size, err := operations.Count(r.Fremote)
+	objects, size, err := operations.Count(context.Background(), r.Fremote)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), objects)
 	assert.Equal(t, int64(60), size)
@@ -293,9 +294,9 @@ func TestCount(t *testing.T) {
 func TestDelete(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteObject("small", "1234567890", t2)                                                                                           // 10 bytes
-	file2 := r.WriteObject("medium", "------------------------------------------------------------", t1)                                        // 60 bytes
-	file3 := r.WriteObject("large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
+	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                                                           // 10 bytes
+	file2 := r.WriteObject(context.Background(), "medium", "------------------------------------------------------------", t1)                                        // 60 bytes
+	file3 := r.WriteObject(context.Background(), "large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
 	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
 
 	filter.Active.Opt.MaxSize = 60
@@ -303,12 +304,12 @@ func TestDelete(t *testing.T) {
 		filter.Active.Opt.MaxSize = -1
 	}()
 
-	err := operations.Delete(r.Fremote)
+	err := operations.Delete(context.Background(), r.Fremote)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Fremote, file3)
 }
 
-func testCheck(t *testing.T, checkFunction func(fdst, fsrc fs.Fs, oneway bool) error) {
+func testCheck(t *testing.T, checkFunction func(ctx context.Context, fdst, fsrc fs.Fs, oneway bool) error) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 
@@ -320,7 +321,7 @@ func testCheck(t *testing.T, checkFunction func(fdst, fsrc fs.Fs, oneway bool) e
 		defer func() {
 			log.SetOutput(os.Stderr)
 		}()
-		err := checkFunction(r.Fremote, r.Flocal, oneway)
+		err := checkFunction(context.Background(), r.Fremote, r.Flocal, oneway)
 		gotErrors := accounting.Stats.GetErrors()
 		gotChecks := accounting.Stats.GetChecks()
 		if wantErrors == 0 && err != nil {
@@ -341,7 +342,7 @@ func testCheck(t *testing.T, checkFunction func(fdst, fsrc fs.Fs, oneway bool) e
 		fs.Debugf(r.Fremote, "%d: Ending check test", i)
 	}
 
-	file1 := r.WriteBoth("rutabaga", "is tasty", t3)
+	file1 := r.WriteBoth(context.Background(), "rutabaga", "is tasty", t3)
 	fstest.CheckItems(t, r.Fremote, file1)
 	fstest.CheckItems(t, r.Flocal, file1)
 	check(1, 0, 1, false)
@@ -350,15 +351,15 @@ func testCheck(t *testing.T, checkFunction func(fdst, fsrc fs.Fs, oneway bool) e
 	fstest.CheckItems(t, r.Flocal, file1, file2)
 	check(2, 1, 1, false)
 
-	file3 := r.WriteObject("empty space", "", t2)
+	file3 := r.WriteObject(context.Background(), "empty space", "", t2)
 	fstest.CheckItems(t, r.Fremote, file1, file3)
 	check(3, 2, 1, false)
 
 	file2r := file2
 	if fs.Config.SizeOnly {
-		file2r = r.WriteObject("potato2", "--Some-Differences-But-Size-Only-Is-Enabled-----------------", t1)
+		file2r = r.WriteObject(context.Background(), "potato2", "--Some-Differences-But-Size-Only-Is-Enabled-----------------", t1)
 	} else {
-		r.WriteObject("potato2", "------------------------------------------------------------", t1)
+		r.WriteObject(context.Background(), "potato2", "------------------------------------------------------------", t1)
 	}
 	fstest.CheckItems(t, r.Fremote, file1, file2r, file3)
 	check(4, 1, 2, false)
@@ -367,7 +368,7 @@ func testCheck(t *testing.T, checkFunction func(fdst, fsrc fs.Fs, oneway bool) e
 	fstest.CheckItems(t, r.Flocal, file1, file2, file3)
 	check(5, 0, 3, false)
 
-	file4 := r.WriteObject("remotepotato", "------------------------------------------------------------", t1)
+	file4 := r.WriteObject(context.Background(), "remotepotato", "------------------------------------------------------------", t1)
 	fstest.CheckItems(t, r.Fremote, file1, file2r, file3, file4)
 	check(6, 1, 3, false)
 	check(7, 0, 3, true)
@@ -390,8 +391,8 @@ func TestCheckSizeOnly(t *testing.T) {
 func TestCat(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	file1 := r.WriteBoth("file1", "ABCDEFGHIJ", t1)
-	file2 := r.WriteBoth("file2", "012345678", t2)
+	file1 := r.WriteBoth(context.Background(), "file1", "ABCDEFGHIJ", t1)
+	file2 := r.WriteBoth(context.Background(), "file2", "012345678", t2)
 
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
@@ -407,7 +408,7 @@ func TestCat(t *testing.T) {
 		{1, 3, "BCD", "123"},
 	} {
 		var buf bytes.Buffer
-		err := operations.Cat(r.Fremote, &buf, test.offset, test.count)
+		err := operations.Cat(context.Background(), r.Fremote, &buf, test.offset, test.count)
 		require.NoError(t, err)
 		res := buf.String()
 
@@ -440,11 +441,11 @@ func TestRcat(t *testing.T) {
 		path2 := prefix + "big_file_from_pipe"
 
 		in := ioutil.NopCloser(strings.NewReader(data1))
-		_, err := operations.Rcat(r.Fremote, path1, in, t1)
+		_, err := operations.Rcat(context.Background(), r.Fremote, path1, in, t1)
 		require.NoError(t, err)
 
 		in = ioutil.NopCloser(strings.NewReader(data2))
-		_, err = operations.Rcat(r.Fremote, path2, in, t2)
+		_, err = operations.Rcat(context.Background(), r.Fremote, path2, in, t2)
 		require.NoError(t, err)
 
 		file1 := fstest.NewItem(path1, data1, t1)
@@ -459,21 +460,21 @@ func TestRcat(t *testing.T) {
 func TestPurge(t *testing.T) {
 	r := fstest.NewRunIndividual(t) // make new container (azureblob has delayed mkdir after rmdir)
 	defer r.Finalise()
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
 	// Make some files and dirs
-	r.ForceMkdir(r.Fremote)
-	file1 := r.WriteObject("A1/B1/C1/one", "aaa", t1)
+	r.ForceMkdir(context.Background(), r.Fremote)
+	file1 := r.WriteObject(context.Background(), "A1/B1/C1/one", "aaa", t1)
 	//..and dirs we expect to delete
-	require.NoError(t, operations.Mkdir(r.Fremote, "A2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B2/C2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B1/C3"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A3"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A3/B3"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A3/B3/C4"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B2/C2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B1/C3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A3/B3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A3/B3/C4"))
 	//..and one more file at the end
-	file2 := r.WriteObject("A1/two", "bbb", t2)
+	file2 := r.WriteObject(context.Background(), "A1/two", "bbb", t2)
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -496,7 +497,7 @@ func TestPurge(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	require.NoError(t, operations.Purge(r.Fremote, "A1/B1"))
+	require.NoError(t, operations.Purge(context.Background(), r.Fremote, "A1/B1"))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -516,7 +517,7 @@ func TestPurge(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	require.NoError(t, operations.Purge(r.Fremote, ""))
+	require.NoError(t, operations.Purge(context.Background(), r.Fremote, ""))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -531,21 +532,21 @@ func TestPurge(t *testing.T) {
 func TestRmdirsNoLeaveRoot(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
 	// Make some files and dirs we expect to keep
-	r.ForceMkdir(r.Fremote)
-	file1 := r.WriteObject("A1/B1/C1/one", "aaa", t1)
+	r.ForceMkdir(context.Background(), r.Fremote)
+	file1 := r.WriteObject(context.Background(), "A1/B1/C1/one", "aaa", t1)
 	//..and dirs we expect to delete
-	require.NoError(t, operations.Mkdir(r.Fremote, "A2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B2/C2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B1/C3"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A3"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A3/B3"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A3/B3/C4"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B2/C2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B1/C3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A3/B3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A3/B3/C4"))
 	//..and one more file at the end
-	file2 := r.WriteObject("A1/two", "bbb", t2)
+	file2 := r.WriteObject(context.Background(), "A1/two", "bbb", t2)
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -568,7 +569,7 @@ func TestRmdirsNoLeaveRoot(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	require.NoError(t, operations.Rmdirs(r.Fremote, "A3/B3/C4", false))
+	require.NoError(t, operations.Rmdirs(context.Background(), r.Fremote, "A3/B3/C4", false))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -590,7 +591,7 @@ func TestRmdirsNoLeaveRoot(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	require.NoError(t, operations.Rmdirs(r.Fremote, "", false))
+	require.NoError(t, operations.Rmdirs(context.Background(), r.Fremote, "", false))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -611,13 +612,13 @@ func TestRmdirsNoLeaveRoot(t *testing.T) {
 func TestRmdirsLeaveRoot(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
-	r.ForceMkdir(r.Fremote)
+	r.ForceMkdir(context.Background(), r.Fremote)
 
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B1"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B1/C1"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B1"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B1/C1"))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -631,7 +632,7 @@ func TestRmdirsLeaveRoot(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	require.NoError(t, operations.Rmdirs(r.Fremote, "A1", true))
+	require.NoError(t, operations.Rmdirs(context.Background(), r.Fremote, "A1", true))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -653,7 +654,7 @@ func TestRcatSize(t *testing.T) {
 	file2 := r.WriteFile("potato2", body, t2)
 	// Test with known length
 	bodyReader := ioutil.NopCloser(strings.NewReader(body))
-	obj, err := operations.RcatSize(r.Fremote, file1.Path, bodyReader, int64(len(body)), file1.ModTime)
+	obj, err := operations.RcatSize(context.Background(), r.Fremote, file1.Path, bodyReader, int64(len(body)), file1.ModTime)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(body)), obj.Size())
 	assert.Equal(t, file1.Path, obj.Remote())
@@ -661,7 +662,7 @@ func TestRcatSize(t *testing.T) {
 	// Test with unknown length
 	bodyReader = ioutil.NopCloser(strings.NewReader(body)) // reset Reader
 	ioutil.NopCloser(strings.NewReader(body))
-	obj, err = operations.RcatSize(r.Fremote, file2.Path, bodyReader, -1, file2.ModTime)
+	obj, err = operations.RcatSize(context.Background(), r.Fremote, file2.Path, bodyReader, -1, file2.ModTime)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(body)), obj.Size())
 	assert.Equal(t, file2.Path, obj.Remote())
@@ -677,7 +678,7 @@ func TestCopyURL(t *testing.T) {
 	contents := "file contents\n"
 	file1 := r.WriteFile("file1", contents, t1)
 	file2 := r.WriteFile("file2", contents, t1)
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 	fstest.CheckItems(t, r.Fremote)
 
 	// check when reading from regular HTTP server
@@ -688,7 +689,7 @@ func TestCopyURL(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	o, err := operations.CopyURL(r.Fremote, "file1", ts.URL)
+	o, err := operations.CopyURL(context.Background(), r.Fremote, "file1", ts.URL)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(contents)), o.Size())
 
@@ -704,7 +705,7 @@ func TestCopyURL(t *testing.T) {
 	tss := httptest.NewTLSServer(handler)
 	defer tss.Close()
 
-	o, err = operations.CopyURL(r.Fremote, "file2", tss.URL)
+	o, err = operations.CopyURL(context.Background(), r.Fremote, "file2", tss.URL)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(contents)), o.Size())
 	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1, file2}, nil, fs.ModTimeNotSupported)
@@ -720,7 +721,7 @@ func TestMoveFile(t *testing.T) {
 	file2 := file1
 	file2.Path = "sub/file2"
 
-	err := operations.MoveFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	err := operations.MoveFile(context.Background(), r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	fstest.CheckItems(t, r.Fremote, file2)
@@ -728,12 +729,12 @@ func TestMoveFile(t *testing.T) {
 	r.WriteFile("file1", "file1 contents", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	err = operations.MoveFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	err = operations.MoveFile(context.Background(), r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	fstest.CheckItems(t, r.Fremote, file2)
 
-	err = operations.MoveFile(r.Fremote, r.Fremote, file2.Path, file2.Path)
+	err = operations.MoveFile(context.Background(), r.Fremote, r.Fremote, file2.Path, file2.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	fstest.CheckItems(t, r.Fremote, file2)
@@ -752,7 +753,7 @@ func TestCaseInsensitiveMoveFile(t *testing.T) {
 	file2 := file1
 	file2.Path = "sub/file2"
 
-	err := operations.MoveFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	err := operations.MoveFile(context.Background(), r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	fstest.CheckItems(t, r.Fremote, file2)
@@ -760,7 +761,7 @@ func TestCaseInsensitiveMoveFile(t *testing.T) {
 	r.WriteFile("file1", "file1 contents", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	err = operations.MoveFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	err = operations.MoveFile(context.Background(), r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	fstest.CheckItems(t, r.Fremote, file2)
@@ -768,7 +769,7 @@ func TestCaseInsensitiveMoveFile(t *testing.T) {
 	file2Capitalized := file2
 	file2Capitalized.Path = "sub/File2"
 
-	err = operations.MoveFile(r.Fremote, r.Fremote, file2Capitalized.Path, file2.Path)
+	err = operations.MoveFile(context.Background(), r.Fremote, r.Fremote, file2Capitalized.Path, file2.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	fstest.CheckItems(t, r.Fremote, file2Capitalized)
@@ -787,10 +788,10 @@ func TestMoveFileBackupDir(t *testing.T) {
 	file1 := r.WriteFile("dst/file1", "file1 contents", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	file1old := r.WriteObject("dst/file1", "file1 contents old", t1)
+	file1old := r.WriteObject(context.Background(), "dst/file1", "file1 contents old", t1)
 	fstest.CheckItems(t, r.Fremote, file1old)
 
-	err := operations.MoveFile(r.Fremote, r.Flocal, file1.Path, file1.Path)
+	err := operations.MoveFile(context.Background(), r.Fremote, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal)
 	file1old.Path = "backup/dst/file1"
@@ -807,17 +808,17 @@ func TestCopyFile(t *testing.T) {
 	file2 := file1
 	file2.Path = "sub/file2"
 
-	err := operations.CopyFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	err := operations.CopyFile(context.Background(), r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
 	fstest.CheckItems(t, r.Fremote, file2)
 
-	err = operations.CopyFile(r.Fremote, r.Flocal, file2.Path, file1.Path)
+	err = operations.CopyFile(context.Background(), r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
 	fstest.CheckItems(t, r.Fremote, file2)
 
-	err = operations.CopyFile(r.Fremote, r.Fremote, file2.Path, file2.Path)
+	err = operations.CopyFile(context.Background(), r.Fremote, r.Fremote, file2.Path, file2.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
 	fstest.CheckItems(t, r.Fremote, file2)
@@ -836,10 +837,10 @@ func TestCopyFileBackupDir(t *testing.T) {
 	file1 := r.WriteFile("dst/file1", "file1 contents", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	file1old := r.WriteObject("dst/file1", "file1 contents old", t1)
+	file1old := r.WriteObject(context.Background(), "dst/file1", "file1 contents old", t1)
 	fstest.CheckItems(t, r.Fremote, file1old)
 
-	err := operations.CopyFile(r.Fremote, r.Flocal, file1.Path, file1.Path)
+	err := operations.CopyFile(context.Background(), r.Fremote, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
 	file1old.Path = "backup/dst/file1"
@@ -1135,19 +1136,19 @@ func TestDirMove(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
 	// Make some files and dirs
-	r.ForceMkdir(r.Fremote)
+	r.ForceMkdir(context.Background(), r.Fremote)
 	files := []fstest.Item{
-		r.WriteObject("A1/one", "one", t1),
-		r.WriteObject("A1/two", "two", t2),
-		r.WriteObject("A1/B1/three", "three", t3),
-		r.WriteObject("A1/B1/C1/four", "four", t1),
-		r.WriteObject("A1/B1/C2/five", "five", t2),
+		r.WriteObject(context.Background(), "A1/one", "one", t1),
+		r.WriteObject(context.Background(), "A1/two", "two", t2),
+		r.WriteObject(context.Background(), "A1/B1/three", "three", t3),
+		r.WriteObject(context.Background(), "A1/B1/C1/four", "four", t1),
+		r.WriteObject(context.Background(), "A1/B1/C2/five", "five", t2),
 	}
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B2"))
-	require.NoError(t, operations.Mkdir(r.Fremote, "A1/B1/C3"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B2"))
+	require.NoError(t, operations.Mkdir(context.Background(), r.Fremote, "A1/B1/C3"))
 
 	fstest.CheckListingWithPrecision(
 		t,
@@ -1164,7 +1165,7 @@ func TestDirMove(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	require.NoError(t, operations.DirMove(r.Fremote, "A1", "A2"))
+	require.NoError(t, operations.DirMove(context.Background(), r.Fremote, "A1", "A2"))
 
 	for i := range files {
 		files[i].Path = strings.Replace(files[i].Path, "A1/", "A2/", -1)
@@ -1194,7 +1195,7 @@ func TestDirMove(t *testing.T) {
 		features.DirMove = oldDirMove
 	}()
 
-	require.NoError(t, operations.DirMove(r.Fremote, "A2", "A3"))
+	require.NoError(t, operations.DirMove(context.Background(), r.Fremote, "A2", "A3"))
 
 	for i := range files {
 		files[i].Path = strings.Replace(files[i].Path, "A2/", "A3/", -1)

--- a/fs/operations/reopen_test.go
+++ b/fs/operations/reopen_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -29,8 +30,8 @@ type reOpenTestObject struct {
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
 //
 // This will break after reading the number of bytes in breaks
-func (o *reOpenTestObject) Open(options ...fs.OpenOption) (io.ReadCloser, error) {
-	rc, err := o.Object.Open(options...)
+func (o *reOpenTestObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	rc, err := o.Object.Open(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func TestReOpen(t *testing.T) {
 					breaks: breaks,
 				}
 				hashOption := &fs.HashesOption{Hashes: hash.NewHashSet(hash.MD5)}
-				return newReOpen(src, hashOption, rangeOption, maxRetries)
+				return newReOpen(context.Background(), src, hashOption, rangeOption, maxRetries)
 			}
 
 			t.Run("Basics", func(t *testing.T) {

--- a/fs/rc/config.go
+++ b/fs/rc/config.go
@@ -5,6 +5,8 @@
 package rc
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 )
 
@@ -36,7 +38,7 @@ func init() {
 }
 
 // Show the list of all the option blocks
-func rcOptionsBlocks(in Params) (out Params, err error) {
+func rcOptionsBlocks(ctx context.Context, in Params) (out Params, err error) {
 	options := []string{}
 	for name := range optionBlock {
 		options = append(options, name)
@@ -61,7 +63,7 @@ map to the external options very easily with a few exceptions.
 }
 
 // Show the list of all the option blocks
-func rcOptionsGet(in Params) (out Params, err error) {
+func rcOptionsGet(ctx context.Context, in Params) (out Params, err error) {
 	out = make(Params)
 	for name, options := range optionBlock {
 		out[name] = options
@@ -103,7 +105,7 @@ And this sets NOTICE level logs (normal without -v)
 }
 
 // Set an option in an option block
-func rcOptionsSet(in Params) (out Params, err error) {
+func rcOptionsSet(ctx context.Context, in Params) (out Params, err error) {
 	for name, options := range in {
 		current := optionBlock[name]
 		if current == nil {

--- a/fs/rc/config_test.go
+++ b/fs/rc/config_test.go
@@ -1,6 +1,7 @@
 package rc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestOptionsBlocks(t *testing.T) {
 	call := Calls.Get("options/blocks")
 	require.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, Params{"options": []string{"potato"}}, out)
@@ -59,7 +60,7 @@ func TestOptionsGet(t *testing.T) {
 	call := Calls.Get("options/get")
 	require.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, Params{"potato": &testOptions}, out)
@@ -83,7 +84,7 @@ func TestOptionsSet(t *testing.T) {
 			"Int": 50,
 		},
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.Nil(t, out)
 	assert.Equal(t, 50, testOptions.Int)
@@ -91,7 +92,7 @@ func TestOptionsSet(t *testing.T) {
 	assert.Equal(t, 1, reloaded)
 
 	// error from reload
-	_, err = call.Fn(in)
+	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error while reloading")
 
@@ -101,7 +102,7 @@ func TestOptionsSet(t *testing.T) {
 			"Int": 50,
 		},
 	}
-	_, err = call.Fn(in)
+	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown option block")
 
@@ -109,7 +110,7 @@ func TestOptionsSet(t *testing.T) {
 	in = Params{
 		"potato": []string{"a", "b"},
 	}
-	_, err = call.Fn(in)
+	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write options")
 

--- a/fs/rc/internal.go
+++ b/fs/rc/internal.go
@@ -3,6 +3,7 @@
 package rc
 
 import (
+	"context"
 	"os"
 	"runtime"
 
@@ -35,7 +36,7 @@ check that parameter passing is working properly.`,
 }
 
 // Echo the input to the output parameters
-func rcNoop(in Params) (out Params, err error) {
+func rcNoop(ctx context.Context, in Params) (out Params, err error) {
 	return in, nil
 }
 
@@ -51,7 +52,7 @@ Useful for testing error handling.`,
 }
 
 // Return an error regardless
-func rcError(in Params) (out Params, err error) {
+func rcError(ctx context.Context, in Params) (out Params, err error) {
 	return nil, errors.Errorf("arbitrary error on input %+v", in)
 }
 
@@ -67,7 +68,7 @@ the commands response.`,
 }
 
 // List the registered commands
-func rcList(in Params) (out Params, err error) {
+func rcList(ctx context.Context, in Params) (out Params, err error) {
 	out = make(Params)
 	out["commands"] = Calls.List()
 	return out, nil
@@ -85,7 +86,7 @@ Useful for stopping rclone process.`,
 }
 
 // Return PID of current process
-func rcPid(in Params) (out Params, err error) {
+func rcPid(ctx context.Context, in Params) (out Params, err error) {
 	out = make(Params)
 	out["pid"] = os.Getpid()
 	return out, nil
@@ -111,7 +112,7 @@ The most interesting values for most people are:
 }
 
 // Return the memory statistics
-func rcMemStats(in Params) (out Params, err error) {
+func rcMemStats(ctx context.Context, in Params) (out Params, err error) {
 	out = make(Params)
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
@@ -152,7 +153,7 @@ memory problems.
 }
 
 // Do a garbage collection run
-func rcGc(in Params) (out Params, err error) {
+func rcGc(ctx context.Context, in Params) (out Params, err error) {
 	runtime.GC()
 	return nil, nil
 }
@@ -177,7 +178,7 @@ This shows the current version of go and the go runtime
 }
 
 // Return version info
-func rcVersion(in Params) (out Params, err error) {
+func rcVersion(ctx context.Context, in Params) (out Params, err error) {
 	decomposed, err := version.New(fs.Version)
 	if err != nil {
 		return nil, err
@@ -209,7 +210,7 @@ Returns
 }
 
 // Return obscured string
-func rcObscure(in Params) (out Params, err error) {
+func rcObscure(ctx context.Context, in Params) (out Params, err error) {
 	clear, err := in.GetString("clear")
 	if err != nil {
 		return nil, err

--- a/fs/rc/internal_test.go
+++ b/fs/rc/internal_test.go
@@ -1,6 +1,7 @@
 package rc
 
 import (
+	"context"
 	"runtime"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestInternalNoop(t *testing.T) {
 		"String": "hello",
 		"Int":    42,
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, in, out)
@@ -28,7 +29,7 @@ func TestInternalError(t *testing.T) {
 	call := Calls.Get("rc/error")
 	assert.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.Error(t, err)
 	require.Nil(t, out)
 }
@@ -37,7 +38,7 @@ func TestInternalList(t *testing.T) {
 	call := Calls.Get("rc/list")
 	assert.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, Params{"commands": Calls.List()}, out)
@@ -47,7 +48,7 @@ func TestCorePid(t *testing.T) {
 	call := Calls.Get("core/pid")
 	assert.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	pid := out["pid"]
@@ -60,7 +61,7 @@ func TestCoreMemstats(t *testing.T) {
 	call := Calls.Get("core/memstats")
 	assert.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	sys := out["Sys"]
@@ -73,7 +74,7 @@ func TestCoreGC(t *testing.T) {
 	call := Calls.Get("core/gc")
 	assert.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.Nil(t, out)
 	assert.Equal(t, Params(nil), out)
@@ -83,7 +84,7 @@ func TestCoreVersion(t *testing.T) {
 	call := Calls.Get("core/version")
 	assert.NotNil(t, call)
 	in := Params{}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, fs.Version, out["version"])
@@ -101,7 +102,7 @@ func TestCoreObscure(t *testing.T) {
 	in := Params{
 		"clear": "potato",
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, in["clear"], obscure.MustReveal(out["obscured"].(string)))

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -187,7 +187,7 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 	if isAsync {
 		out, err = rc.StartJob(call.Fn, in)
 	} else {
-		out, err = call.Fn(in)
+		out, err = call.Fn(r.Context(), in)
 	}
 	if err != nil {
 		writeError(path, in, w, err, http.StatusInternalServerError)
@@ -230,7 +230,7 @@ func (s *Server) serveRemote(w http.ResponseWriter, r *http.Request, path string
 	}
 	if path == "" || strings.HasSuffix(path, "/") {
 		path = strings.Trim(path, "/")
-		entries, err := list.DirSorted(f, false, path)
+		entries, err := list.DirSorted(r.Context(), f, false, path)
 		if err != nil {
 			writeError(path, nil, w, errors.Wrap(err, "failed to list directory"), http.StatusInternalServerError)
 			return
@@ -244,7 +244,7 @@ func (s *Server) serveRemote(w http.ResponseWriter, r *http.Request, path string
 		directory.Serve(w, r)
 	} else {
 		path = strings.Trim(path, "/")
-		o, err := f.NewObject(path)
+		o, err := f.NewObject(r.Context(), path)
 		if err != nil {
 			writeError(path, nil, w, errors.Wrap(err, "failed to find object"), http.StatusInternalServerError)
 			return

--- a/fs/rc/registry.go
+++ b/fs/rc/registry.go
@@ -3,6 +3,7 @@
 package rc
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"sync"
@@ -11,7 +12,7 @@ import (
 )
 
 // Func defines a type for a remote control function
-type Func func(in Params) (out Params, err error)
+type Func func(ctx context.Context, in Params) (out Params, err error)
 
 // Call defines info about a remote control function and is used in
 // the Add function to create new entry points.

--- a/fs/sync/rc.go
+++ b/fs/sync/rc.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"context"
+
 	"github.com/ncw/rclone/fs/rc"
 )
 
@@ -14,8 +16,8 @@ func init() {
 		rc.Add(rc.Call{
 			Path:         "sync/" + name,
 			AuthRequired: true,
-			Fn: func(in rc.Params) (rc.Params, error) {
-				return rcSyncCopyMove(in, name)
+			Fn: func(ctx context.Context, in rc.Params) (rc.Params, error) {
+				return rcSyncCopyMove(ctx, in, name)
 			},
 			Title: name + " a directory from source remote to destination remote",
 			Help: `This takes the following parameters
@@ -30,7 +32,7 @@ See the [` + name + ` command](/commands/rclone_` + name + `/) command for more 
 }
 
 // Sync/Copy/Move a file
-func rcSyncCopyMove(in rc.Params, name string) (out rc.Params, err error) {
+func rcSyncCopyMove(ctx context.Context, in rc.Params, name string) (out rc.Params, err error) {
 	srcFs, err := rc.GetFsNamed(in, "srcFs")
 	if err != nil {
 		return nil, err
@@ -45,15 +47,15 @@ func rcSyncCopyMove(in rc.Params, name string) (out rc.Params, err error) {
 	}
 	switch name {
 	case "sync":
-		return nil, Sync(dstFs, srcFs, createEmptySrcDirs)
+		return nil, Sync(ctx, dstFs, srcFs, createEmptySrcDirs)
 	case "copy":
-		return nil, CopyDir(dstFs, srcFs, createEmptySrcDirs)
+		return nil, CopyDir(ctx, dstFs, srcFs, createEmptySrcDirs)
 	case "move":
 		deleteEmptySrcDirs, err := in.GetBool("deleteEmptySrcDirs")
 		if rc.NotErrParamNotFound(err) {
 			return nil, err
 		}
-		return nil, MoveDir(dstFs, srcFs, deleteEmptySrcDirs, createEmptySrcDirs)
+		return nil, MoveDir(ctx, dstFs, srcFs, deleteEmptySrcDirs, createEmptySrcDirs)
 	}
 	panic("unknown rcSyncCopyMove type")
 }

--- a/fs/sync/rc_test.go
+++ b/fs/sync/rc_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ncw/rclone/fs/cache"
@@ -26,11 +27,11 @@ func rcNewRun(t *testing.T, method string) (*fstest.Run, *rc.Call) {
 func TestRcCopy(t *testing.T) {
 	r, call := rcNewRun(t, "sync/copy")
 	defer r.Finalise()
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
-	file1 := r.WriteBoth("file1", "file1 contents", t1)
+	file1 := r.WriteBoth(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteFile("subdir/file2", "file2 contents", t2)
-	file3 := r.WriteObject("subdir/subsubdir/file3", "file3 contents", t3)
+	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/file3", "file3 contents", t3)
 
 	fstest.CheckItems(t, r.Flocal, file1, file2)
 	fstest.CheckItems(t, r.Fremote, file1, file3)
@@ -39,7 +40,7 @@ func TestRcCopy(t *testing.T) {
 		"srcFs": r.LocalName,
 		"dstFs": r.FremoteName,
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
@@ -51,11 +52,11 @@ func TestRcCopy(t *testing.T) {
 func TestRcMove(t *testing.T) {
 	r, call := rcNewRun(t, "sync/move")
 	defer r.Finalise()
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
-	file1 := r.WriteBoth("file1", "file1 contents", t1)
+	file1 := r.WriteBoth(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteFile("subdir/file2", "file2 contents", t2)
-	file3 := r.WriteObject("subdir/subsubdir/file3", "file3 contents", t3)
+	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/file3", "file3 contents", t3)
 
 	fstest.CheckItems(t, r.Flocal, file1, file2)
 	fstest.CheckItems(t, r.Fremote, file1, file3)
@@ -64,7 +65,7 @@ func TestRcMove(t *testing.T) {
 		"srcFs": r.LocalName,
 		"dstFs": r.FremoteName,
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
@@ -76,11 +77,11 @@ func TestRcMove(t *testing.T) {
 func TestRcSync(t *testing.T) {
 	r, call := rcNewRun(t, "sync/sync")
 	defer r.Finalise()
-	r.Mkdir(r.Fremote)
+	r.Mkdir(context.Background(), r.Fremote)
 
-	file1 := r.WriteBoth("file1", "file1 contents", t1)
+	file1 := r.WriteBoth(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteFile("subdir/file2", "file2 contents", t2)
-	file3 := r.WriteObject("subdir/subsubdir/file3", "file3 contents", t3)
+	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/file3", "file3 contents", t3)
 
 	fstest.CheckItems(t, r.Flocal, file1, file2)
 	fstest.CheckItems(t, r.Fremote, file1, file3)
@@ -89,7 +90,7 @@ func TestRcSync(t *testing.T) {
 		"srcFs": r.LocalName,
 		"dstFs": r.FremoteName,
 	}
-	out, err := call.Fn(in)
+	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -8,6 +8,7 @@ package fstests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -119,7 +120,7 @@ func findObject(t *testing.T, f fs.Fs, Name string) fs.Object {
 	var err error
 	sleepTime := 1 * time.Second
 	for i := 1; i <= *fstest.ListRetries; i++ {
-		obj, err = f.NewObject(Name)
+		obj, err = f.NewObject(context.Background(), Name)
 		if err == nil {
 			break
 		}
@@ -163,7 +164,7 @@ func testPut(t *testing.T, f fs.Fs, file *fstest.Item) (string, fs.Object) {
 
 		file.Size = int64(buf.Len())
 		obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
-		obj, err = f.Put(in, obji)
+		obj, err = f.Put(context.Background(), in, obji)
 		return err
 	})
 	file.Hashes = uploadHash.Sums()
@@ -187,7 +188,7 @@ func testPutLarge(t *testing.T, f fs.Fs, file *fstest.Item) {
 		in := io.TeeReader(r, uploadHash)
 
 		obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
-		obj, err = f.Put(in, obji)
+		obj, err = f.Put(context.Background(), in, obji)
 		return err
 	})
 	file.Hashes = uploadHash.Sums()
@@ -199,7 +200,7 @@ func testPutLarge(t *testing.T, f fs.Fs, file *fstest.Item) {
 
 	// Download the object and check it is OK
 	downloadHash := hash.NewMultiHasher()
-	download, err := obj.Open()
+	download, err := obj.Open(context.Background())
 	require.NoError(t, err)
 	n, err := io.Copy(downloadHash, download)
 	require.NoError(t, err)
@@ -208,7 +209,7 @@ func testPutLarge(t *testing.T, f fs.Fs, file *fstest.Item) {
 	assert.Equal(t, file.Hashes, downloadHash.Sums())
 
 	// Remove the object
-	require.NoError(t, obj.Remove())
+	require.NoError(t, obj.Remove(context.Background()))
 }
 
 // errorReader just returns an error on Read
@@ -224,7 +225,7 @@ func (er errorReader) Read(p []byte) (n int, err error) {
 // read the contents of an object as a string
 func readObject(t *testing.T, obj fs.Object, limit int64, options ...fs.OpenOption) string {
 	what := fmt.Sprintf("readObject(%q) limit=%d, options=%+v", obj, limit, options)
-	in, err := obj.Open(options...)
+	in, err := obj.Open(context.Background(), options...)
 	require.NoError(t, err, what)
 	var r io.Reader = in
 	if limit >= 0 {
@@ -409,12 +410,12 @@ func Run(t *testing.T, opt *Opt) {
 		if isBucketBasedButNotRoot(remote) {
 			t.Skip("Skipping test as non root bucket based remote")
 		}
-		err := remote.Rmdir("")
+		err := remote.Rmdir(context.Background(), "")
 		assert.Error(t, err, "Expecting error on Rmdir non existent")
 	})
 
 	// Make the directory
-	err = remote.Mkdir("")
+	err = remote.Mkdir(context.Background(), "")
 	require.NoError(t, err)
 	fstest.CheckListing(t, remote, []fstest.Item{})
 
@@ -452,7 +453,7 @@ func Run(t *testing.T, opt *Opt) {
 	// TestFsRmdirEmpty tests deleting an empty directory
 	t.Run("FsRmdirEmpty", func(t *testing.T) {
 		skipIfNotOk(t)
-		err := remote.Rmdir("")
+		err := remote.Rmdir(context.Background(), "")
 		require.NoError(t, err)
 	})
 
@@ -462,26 +463,26 @@ func Run(t *testing.T, opt *Opt) {
 	t.Run("FsMkdir", func(t *testing.T) {
 		skipIfNotOk(t)
 
-		err := remote.Mkdir("")
+		err := remote.Mkdir(context.Background(), "")
 		require.NoError(t, err)
 		fstest.CheckListing(t, remote, []fstest.Item{})
 
-		err = remote.Mkdir("")
+		err = remote.Mkdir(context.Background(), "")
 		require.NoError(t, err)
 
 		// TestFsMkdirRmdirSubdir tests making and removing a sub directory
 		t.Run("FsMkdirRmdirSubdir", func(t *testing.T) {
 			skipIfNotOk(t)
 			dir := "dir/subdir"
-			err := operations.Mkdir(remote, dir)
+			err := operations.Mkdir(context.Background(), remote, dir)
 			require.NoError(t, err)
 			fstest.CheckListingWithPrecision(t, remote, []fstest.Item{}, []string{"dir", "dir/subdir"}, fs.GetModifyWindow(remote))
 
-			err = operations.Rmdir(remote, dir)
+			err = operations.Rmdir(context.Background(), remote, dir)
 			require.NoError(t, err)
 			fstest.CheckListingWithPrecision(t, remote, []fstest.Item{}, []string{"dir"}, fs.GetModifyWindow(remote))
 
-			err = operations.Rmdir(remote, "dir")
+			err = operations.Rmdir(context.Background(), remote, "dir")
 			require.NoError(t, err)
 			fstest.CheckListingWithPrecision(t, remote, []fstest.Item{}, []string{}, fs.GetModifyWindow(remote))
 		})
@@ -495,7 +496,7 @@ func Run(t *testing.T, opt *Opt) {
 		// TestFsListDirEmpty tests listing the directories from an empty directory
 		TestFsListDirEmpty := func(t *testing.T) {
 			skipIfNotOk(t)
-			objs, dirs, err := walk.GetAll(remote, "", true, 1)
+			objs, dirs, err := walk.GetAll(context.Background(), remote, "", true, 1)
 			require.NoError(t, err)
 			assert.Equal(t, []string{}, objsToNames(objs))
 			assert.Equal(t, []string{}, dirsToNames(dirs))
@@ -511,7 +512,7 @@ func Run(t *testing.T, opt *Opt) {
 		// TestFsListDirNotFound tests listing the directories from an empty directory
 		TestFsListDirNotFound := func(t *testing.T) {
 			skipIfNotOk(t)
-			objs, dirs, err := walk.GetAll(remote, "does not exist", true, 1)
+			objs, dirs, err := walk.GetAll(context.Background(), remote, "does not exist", true, 1)
 			if !remote.Features().CanHaveEmptyDirectories {
 				if err != fs.ErrorDirNotFound {
 					assert.NoError(t, err)
@@ -533,11 +534,11 @@ func Run(t *testing.T, opt *Opt) {
 		t.Run("FsNewObjectNotFound", func(t *testing.T) {
 			skipIfNotOk(t)
 			// Object in an existing directory
-			o, err := remote.NewObject("potato")
+			o, err := remote.NewObject(context.Background(), "potato")
 			assert.Nil(t, o)
 			assert.Equal(t, fs.ErrorObjectNotFound, err)
 			// Now try an object in a non existing directory
-			o, err = remote.NewObject("directory/not/found/potato")
+			o, err = remote.NewObject(context.Background(), "directory/not/found/potato")
 			assert.Nil(t, o)
 			assert.Equal(t, fs.ErrorObjectNotFound, err)
 		})
@@ -559,11 +560,11 @@ func Run(t *testing.T, opt *Opt) {
 			in := io.MultiReader(buf, er)
 
 			obji := object.NewStaticObjectInfo(file2.Path, file2.ModTime, 2*N, true, nil, nil)
-			_, err := remote.Put(in, obji)
+			_, err := remote.Put(context.Background(), in, obji)
 			// assert.Nil(t, obj) - FIXME some remotes return the object even on nil
 			assert.NotNil(t, err)
 
-			obj, err := remote.NewObject(file2.Path)
+			obj, err := remote.NewObject(context.Background(), file2.Path)
 			assert.Nil(t, obj)
 			assert.Equal(t, fs.ErrorObjectNotFound, err)
 		})
@@ -681,7 +682,7 @@ func Run(t *testing.T, opt *Opt) {
 				t.Skip("FS has no OpenWriterAt interface")
 			}
 			path := "writer-at-subdir/writer-at-file"
-			out, err := openWriterAt(path, -1)
+			out, err := openWriterAt(context.Background(), path, -1)
 			require.NoError(t, err)
 
 			var n int
@@ -700,8 +701,8 @@ func Run(t *testing.T, opt *Opt) {
 			obj := findObject(t, remote, path)
 			assert.Equal(t, "abcdefghi", readObject(t, obj, -1), "contents of file differ")
 
-			assert.NoError(t, obj.Remove())
-			assert.NoError(t, remote.Rmdir("writer-at-subdir"))
+			assert.NoError(t, obj.Remove(context.Background()))
+			assert.NoError(t, remote.Rmdir(context.Background(), "writer-at-subdir"))
 		})
 
 		// TestFsChangeNotify tests that changes are properly
@@ -717,13 +718,13 @@ func Run(t *testing.T, opt *Opt) {
 				t.Skip("FS has no ChangeNotify interface")
 			}
 
-			err := operations.Mkdir(remote, "dir")
+			err := operations.Mkdir(context.Background(), remote, "dir")
 			require.NoError(t, err)
 
 			pollInterval := make(chan time.Duration)
 			dirChanges := map[string]struct{}{}
 			objChanges := map[string]struct{}{}
-			doChangeNotify(func(x string, e fs.EntryType) {
+			doChangeNotify(context.Background(), func(x string, e fs.EntryType) {
 				fs.Debugf(nil, "doChangeNotify(%q, %+v)", x, e)
 				if strings.HasPrefix(x, file1.Path[:5]) || strings.HasPrefix(x, file2.Path[:5]) {
 					fs.Debugf(nil, "Ignoring notify for file1 or file2: %q, %v", x, e)
@@ -741,7 +742,7 @@ func Run(t *testing.T, opt *Opt) {
 			var dirs []string
 			for _, idx := range []int{1, 3, 2} {
 				dir := fmt.Sprintf("dir/subdir%d", idx)
-				err = operations.Mkdir(remote, dir)
+				err = operations.Mkdir(context.Background(), remote, dir)
 				require.NoError(t, err)
 				dirs = append(dirs, dir)
 			}
@@ -786,11 +787,11 @@ func Run(t *testing.T, opt *Opt) {
 
 			// tidy up afterwards
 			for _, o := range objs {
-				assert.NoError(t, o.Remove())
+				assert.NoError(t, o.Remove(context.Background()))
 			}
 			dirs = append(dirs, "dir")
 			for _, dir := range dirs {
-				assert.NoError(t, remote.Rmdir(dir))
+				assert.NoError(t, remote.Rmdir(context.Background(), dir))
 			}
 		})
 
@@ -811,9 +812,9 @@ func Run(t *testing.T, opt *Opt) {
 				list := func(dir string, expectedDirNames, expectedObjNames []string) {
 					var objNames, dirNames []string
 					for i := 1; i <= *fstest.ListRetries; i++ {
-						objs, dirs, err := walk.GetAll(remote, dir, true, 1)
+						objs, dirs, err := walk.GetAll(context.Background(), remote, dir, true, 1)
 						if errors.Cause(err) == fs.ErrorDirNotFound {
-							objs, dirs, err = walk.GetAll(remote, fstest.WinPath(dir), true, 1)
+							objs, dirs, err = walk.GetAll(context.Background(), remote, fstest.WinPath(dir), true, 1)
 						}
 						require.NoError(t, err)
 						objNames = objsToNames(objs)
@@ -859,7 +860,7 @@ func Run(t *testing.T, opt *Opt) {
 			// Test the files are all there with walk.ListR recursive listings
 			t.Run("FsListR", func(t *testing.T) {
 				skipIfNotOk(t)
-				objs, dirs, err := walk.GetAll(remote, "", true, -1)
+				objs, dirs, err := walk.GetAll(context.Background(), remote, "", true, -1)
 				require.NoError(t, err)
 				assert.Equal(t, []string{
 					"hello_ sausage",
@@ -877,7 +878,7 @@ func Run(t *testing.T, opt *Opt) {
 			// walk.ListR recursive listings on a sub dir
 			t.Run("FsListRSubdir", func(t *testing.T) {
 				skipIfNotOk(t)
-				objs, dirs, err := walk.GetAll(remote, path.Dir(path.Dir(path.Dir(path.Dir(file2.Path)))), true, -1)
+				objs, dirs, err := walk.GetAll(context.Background(), remote, path.Dir(path.Dir(path.Dir(path.Dir(file2.Path)))), true, -1)
 				require.NoError(t, err)
 				assert.Equal(t, []string{
 					"hello_ sausage/êé",
@@ -894,7 +895,7 @@ func Run(t *testing.T, opt *Opt) {
 				skipIfNotOk(t)
 				rootRemote, err := fs.NewFs(remoteName)
 				require.NoError(t, err)
-				_, dirs, err := walk.GetAll(rootRemote, "", true, 1)
+				_, dirs, err := walk.GetAll(context.Background(), rootRemote, "", true, 1)
 				require.NoError(t, err)
 				assert.Contains(t, dirsToNames(dirs), subRemoteLeaf, "Remote leaf not found")
 			}
@@ -916,7 +917,7 @@ func Run(t *testing.T, opt *Opt) {
 				for i := 0; i < 2; i++ {
 					dir, _ := path.Split(fileName)
 					dir = dir[:len(dir)-1]
-					objs, dirs, err = walk.GetAll(remote, dir, true, -1)
+					objs, dirs, err = walk.GetAll(context.Background(), remote, dir, true, -1)
 					if err != fs.ErrorDirNotFound {
 						break
 					}
@@ -938,7 +939,7 @@ func Run(t *testing.T, opt *Opt) {
 			// TestFsListLevel2 tests List works for 2 levels
 			TestFsListLevel2 := func(t *testing.T) {
 				skipIfNotOk(t)
-				objs, dirs, err := walk.GetAll(remote, "", true, 2)
+				objs, dirs, err := walk.GetAll(context.Background(), remote, "", true, 2)
 				if err == fs.ErrorLevelNotSupported {
 					return
 				}
@@ -977,7 +978,7 @@ func Run(t *testing.T, opt *Opt) {
 			t.Run("FsNewObjectDir", func(t *testing.T) {
 				skipIfNotOk(t)
 				dir := path.Dir(file2.Path)
-				obj, err := remote.NewObject(dir)
+				obj, err := remote.NewObject(context.Background(), dir)
 				assert.Nil(t, obj)
 				assert.NotNil(t, err)
 			})
@@ -998,7 +999,7 @@ func Run(t *testing.T, opt *Opt) {
 
 				// do the copy
 				src := findObject(t, remote, file2.Path)
-				dst, err := doCopy(src, file2Copy.Path)
+				dst, err := doCopy(context.Background(), src, file2Copy.Path)
 				if err == fs.ErrorCantCopy {
 					t.Skip("FS can't copy")
 				}
@@ -1011,7 +1012,7 @@ func Run(t *testing.T, opt *Opt) {
 				assert.Equal(t, file2Copy.Path, dst.Remote())
 
 				// Delete copy
-				err = dst.Remove()
+				err = dst.Remove(context.Background())
 				require.NoError(t, err)
 
 			})
@@ -1038,7 +1039,7 @@ func Run(t *testing.T, opt *Opt) {
 				file2Move.Path = "other.txt"
 				file2Move.WinPath = ""
 				src := findObject(t, remote, file2.Path)
-				dst, err := doMove(src, file2Move.Path)
+				dst, err := doMove(context.Background(), src, file2Move.Path)
 				if err == fs.ErrorCantMove {
 					t.Skip("FS can't move")
 				}
@@ -1053,7 +1054,7 @@ func Run(t *testing.T, opt *Opt) {
 				// Check conflict on "rename, then move"
 				file1Move.Path = "moveTest/other.txt"
 				src = findObject(t, remote, file1.Path)
-				_, err = doMove(src, file1Move.Path)
+				_, err = doMove(context.Background(), src, file1Move.Path)
 				require.NoError(t, err)
 				fstest.CheckListing(t, remote, []fstest.Item{file1Move, file2Move})
 				// 1: moveTest/other.txt
@@ -1061,21 +1062,21 @@ func Run(t *testing.T, opt *Opt) {
 
 				// Check conflict on "move, then rename"
 				src = findObject(t, remote, file1Move.Path)
-				_, err = doMove(src, file1.Path)
+				_, err = doMove(context.Background(), src, file1.Path)
 				require.NoError(t, err)
 				fstest.CheckListing(t, remote, []fstest.Item{file1, file2Move})
 				// 1: file name.txt
 				// 2: other.txt
 
 				src = findObject(t, remote, file2Move.Path)
-				_, err = doMove(src, file2.Path)
+				_, err = doMove(context.Background(), src, file2.Path)
 				require.NoError(t, err)
 				fstest.CheckListing(t, remote, []fstest.Item{file1, file2})
 				// 1: file name.txt
 				// 2: hello sausage?/../z.txt
 
 				// Tidy up moveTest directory
-				require.NoError(t, remote.Rmdir("moveTest"))
+				require.NoError(t, remote.Rmdir(context.Background(), "moveTest"))
 			})
 
 			// Move src to this remote using server side move operations.
@@ -1099,7 +1100,7 @@ func Run(t *testing.T, opt *Opt) {
 				}
 
 				// Check it can't move onto itself
-				err := doDirMove(remote, "", "")
+				err := doDirMove(context.Background(), remote, "", "")
 				require.Equal(t, fs.ErrorDirExists, err)
 
 				// new remote
@@ -1109,12 +1110,12 @@ func Run(t *testing.T, opt *Opt) {
 
 				const newName = "new_name/sub_new_name"
 				// try the move
-				err = newRemote.Features().DirMove(remote, "", newName)
+				err = newRemote.Features().DirMove(context.Background(), remote, "", newName)
 				require.NoError(t, err)
 
 				// check remotes
 				// remote should not exist here
-				_, err = remote.List("")
+				_, err = remote.List(context.Background(), "")
 				assert.Equal(t, fs.ErrorDirNotFound, errors.Cause(err))
 				//fstest.CheckListingWithPrecision(t, remote, []fstest.Item{}, []string{}, remote.Precision())
 				file1Copy := file1
@@ -1132,7 +1133,7 @@ func Run(t *testing.T, opt *Opt) {
 				}, newRemote.Precision())
 
 				// move it back
-				err = doDirMove(newRemote, newName, "")
+				err = doDirMove(context.Background(), newRemote, newName, "")
 				require.NoError(t, err)
 
 				// check remotes
@@ -1153,7 +1154,7 @@ func Run(t *testing.T, opt *Opt) {
 				if isBucketBasedButNotRoot(remote) {
 					t.Skip("Skipping test as non root bucket based remote")
 				}
-				err := remote.Rmdir("")
+				err := remote.Rmdir(context.Background(), "")
 				require.Error(t, err, "Expecting error on RMdir on non empty remote")
 			})
 
@@ -1217,7 +1218,7 @@ func Run(t *testing.T, opt *Opt) {
 			TestObjectModTime := func(t *testing.T) {
 				skipIfNotOk(t)
 				obj := findObject(t, remote, file1.Path)
-				file1.CheckModTime(t, obj, obj.ModTime(), remote.Precision())
+				file1.CheckModTime(t, obj, obj.ModTime(context.Background()), remote.Precision())
 			}
 			t.Run("ObjectModTime", TestObjectModTime)
 
@@ -1229,7 +1230,7 @@ func Run(t *testing.T, opt *Opt) {
 				if !ok {
 					t.Skip("MimeType method not supported")
 				}
-				mimeType := do.MimeType()
+				mimeType := do.MimeType(context.Background())
 				if strings.ContainsRune(mimeType, ';') {
 					assert.Equal(t, "text/plain; charset=utf-8", mimeType)
 				} else {
@@ -1242,14 +1243,14 @@ func Run(t *testing.T, opt *Opt) {
 				skipIfNotOk(t)
 				newModTime := fstest.Time("2011-12-13T14:15:16.999999999Z")
 				obj := findObject(t, remote, file1.Path)
-				err := obj.SetModTime(newModTime)
+				err := obj.SetModTime(context.Background(), newModTime)
 				if err == fs.ErrorCantSetModTime || err == fs.ErrorCantSetModTimeWithoutDelete {
 					t.Log(err)
 					return
 				}
 				require.NoError(t, err)
 				file1.ModTime = newModTime
-				file1.CheckModTime(t, obj, obj.ModTime(), remote.Precision())
+				file1.CheckModTime(t, obj, obj.ModTime(context.Background()), remote.Precision())
 				// And make a new object and read it from there too
 				TestObjectModTime(t)
 			})
@@ -1316,7 +1317,7 @@ func Run(t *testing.T, opt *Opt) {
 				file1.Size = int64(buf.Len())
 				obj := findObject(t, remote, file1.Path)
 				obji := object.NewStaticObjectInfo(file1.Path, file1.ModTime, int64(len(contents)), true, nil, obj.Fs())
-				err := obj.Update(in, obji)
+				err := obj.Update(context.Background(), in, obji)
 				require.NoError(t, err)
 				file1.Hashes = hash.Sums()
 
@@ -1373,34 +1374,34 @@ func Run(t *testing.T, opt *Opt) {
 				}
 
 				// if object not found
-				link, err := doPublicLink(file1.Path + "_does_not_exist")
+				link, err := doPublicLink(context.Background(), file1.Path+"_does_not_exist")
 				require.Error(t, err, "Expected to get error when file doesn't exist")
 				require.Equal(t, "", link, "Expected link to be empty on error")
 
 				// sharing file for the first time
-				link1, err := doPublicLink(file1.Path)
+				link1, err := doPublicLink(context.Background(), file1.Path)
 				require.NoError(t, err)
 				require.NotEqual(t, "", link1, "Link should not be empty")
 
-				link2, err := doPublicLink(file2.Path)
+				link2, err := doPublicLink(context.Background(), file2.Path)
 				require.NoError(t, err)
 				require.NotEqual(t, "", link2, "Link should not be empty")
 
 				require.NotEqual(t, link1, link2, "Links to different files should differ")
 
 				// sharing file for the 2nd time
-				link1, err = doPublicLink(file1.Path)
+				link1, err = doPublicLink(context.Background(), file1.Path)
 				require.NoError(t, err)
 				require.NotEqual(t, "", link1, "Link should not be empty")
 
 				// sharing directory for the first time
 				path := path.Dir(file2.Path)
-				link3, err := doPublicLink(path)
+				link3, err := doPublicLink(context.Background(), path)
 				require.NoError(t, err)
 				require.NotEqual(t, "", link3, "Link should not be empty")
 
 				// sharing directory for the second time
-				link3, err = doPublicLink(path)
+				link3, err = doPublicLink(context.Background(), path)
 				require.NoError(t, err)
 				require.NotEqual(t, "", link3, "Link should not be empty")
 
@@ -1411,10 +1412,10 @@ func Run(t *testing.T, opt *Opt) {
 				// ensure sub remote isn't empty
 				buf := bytes.NewBufferString("somecontent")
 				obji := object.NewStaticObjectInfo("somefile", time.Now(), int64(buf.Len()), true, nil, nil)
-				_, err = subRemote.Put(buf, obji)
+				_, err = subRemote.Put(context.Background(), buf, obji)
 				require.NoError(t, err)
 
-				link4, err := subRemote.Features().PublicLink("")
+				link4, err := subRemote.Features().PublicLink(context.Background(), "")
 				require.NoError(t, err, "Sharing root in a sub-remote should work")
 				require.NotEqual(t, "", link4, "Link should not be empty")
 			})
@@ -1463,7 +1464,7 @@ func Run(t *testing.T, opt *Opt) {
 			t.Run("ObjectRemove", func(t *testing.T) {
 				skipIfNotOk(t)
 				obj := findObject(t, remote, file1.Path)
-				err := obj.Remove()
+				err := obj.Remove(context.Background())
 				require.NoError(t, err)
 				// check listing without modtime as TestPublicLink may change the modtime
 				fstest.CheckListingWithPrecision(t, remote, []fstest.Item{file2}, nil, fs.ModTimeNotSupported)
@@ -1496,7 +1497,7 @@ func Run(t *testing.T, opt *Opt) {
 
 					file.Size = -1
 					obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
-					obj, err = remote.Features().PutStream(in, obji)
+					obj, err = remote.Features().PutStream(context.Background(), in, obji)
 					return err
 				})
 				file.Hashes = uploadHash.Sums()
@@ -1518,7 +1519,7 @@ func Run(t *testing.T, opt *Opt) {
 				}
 
 				// Can't really check the output much!
-				usage, err := doAbout()
+				usage, err := doAbout(context.Background())
 				require.NoError(t, err)
 				require.NotNil(t, usage)
 				assert.NotEqual(t, int64(0), usage.Total)
@@ -1550,9 +1551,9 @@ func Run(t *testing.T, opt *Opt) {
 				in := bytes.NewBufferString(contents)
 
 				obji := object.NewStaticObjectInfo("unknown-size-put.txt", fstest.Time("2002-02-03T04:05:06.499999999Z"), -1, true, nil, nil)
-				obj, err := remote.Put(in, obji)
+				obj, err := remote.Put(context.Background(), in, obji)
 				if err == nil {
-					require.NoError(t, obj.Remove(), "successfully uploaded unknown-sized file but failed to remove")
+					require.NoError(t, obj.Remove(context.Background()), "successfully uploaded unknown-sized file but failed to remove")
 				}
 				// if err != nil: it's okay as long as no panic
 			})
@@ -1574,9 +1575,9 @@ func Run(t *testing.T, opt *Opt) {
 
 				obj := findObject(t, remote, unknownSizeUpdateFile.Path)
 				obji := object.NewStaticObjectInfo(unknownSizeUpdateFile.Path, unknownSizeUpdateFile.ModTime, -1, true, nil, obj.Fs())
-				err := obj.Update(in, obji)
+				err := obj.Update(context.Background(), in, obji)
 				if err == nil {
-					require.NoError(t, obj.Remove(), "successfully updated object with unknown-sized source but failed to remove")
+					require.NoError(t, obj.Remove(context.Background()), "successfully updated object with unknown-sized source but failed to remove")
 				}
 				// if err != nil: it's okay as long as no panic
 			})
@@ -1598,21 +1599,21 @@ func Run(t *testing.T, opt *Opt) {
 			colonIndex := strings.IndexRune(deepRemoteName, ':')
 			firstSlashIndex := strings.IndexRune(deepRemoteName, '/')
 			firstDir := deepRemoteName[colonIndex+1 : firstSlashIndex]
-			_, err = deepRemote.NewObject(firstDir)
+			_, err = deepRemote.NewObject(context.Background(), firstDir)
 			require.Equal(t, fs.ErrorObjectNotFound, err)
 			// If err is not fs.ErrorObjectNotFound, it means the backend is
 			// somehow confused about root and absolute root.
 		})
 
 		// Purge the folder
-		err = operations.Purge(remote, "")
+		err = operations.Purge(context.Background(), remote, "")
 		require.NoError(t, err)
 		purged = true
 		fstest.CheckListing(t, remote, []fstest.Item{})
 
 		// Check purging again if not bucket based
 		if !isBucketBasedButNotRoot(remote) {
-			err = operations.Purge(remote, "")
+			err = operations.Purge(context.Background(), remote, "")
 			assert.Error(t, err, "Expecting error after on second purge")
 		}
 
@@ -1620,7 +1621,7 @@ func Run(t *testing.T, opt *Opt) {
 
 	// Check directory is purged
 	if !purged {
-		_ = operations.Purge(remote, "")
+		_ = operations.Purge(context.Background(), remote, "")
 	}
 
 	// Remove the local directory so we don't clutter up /tmp

--- a/fstest/mockfs/mockfs.go
+++ b/fstest/mockfs/mockfs.go
@@ -1,6 +1,7 @@
 package mockfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -69,13 +70,13 @@ func (f *Fs) Features() *fs.Features {
 //
 // This should return ErrDirNotFound if the directory isn't
 // found.
-func (f *Fs) List(dir string) (entries fs.DirEntries, err error) {
+func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
 	return nil, nil
 }
 
 // NewObject finds the Object at remote.  If it can't be found
 // it returns the error ErrorObjectNotFound.
-func (f *Fs) NewObject(remote string) (fs.Object, error) {
+func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	return nil, fs.ErrorObjectNotFound
 }
 
@@ -84,21 +85,21 @@ func (f *Fs) NewObject(remote string) (fs.Object, error) {
 // May create the object even if it returns an error - if so
 // will return the object and the error, otherwise will return
 // nil and the error
-func (f *Fs) Put(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
 	return nil, ErrNotImplemented
 }
 
 // Mkdir makes the directory (container, bucket)
 //
 // Shouldn't return an error if it already exists
-func (f *Fs) Mkdir(dir string) error {
+func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 	return ErrNotImplemented
 }
 
 // Rmdir removes the directory (container, bucket) if empty
 //
 // Return an error if it doesn't exist or isn't empty
-func (f *Fs) Rmdir(dir string) error {
+func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	return ErrNotImplemented
 }
 

--- a/fstest/mockobject/mockobject.go
+++ b/fstest/mockobject/mockobject.go
@@ -3,6 +3,7 @@ package mockobject
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -39,13 +40,13 @@ func (o Object) Remote() string {
 
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
-func (o Object) Hash(hash.Type) (string, error) {
+func (o Object) Hash(ctx context.Context, t hash.Type) (string, error) {
 	return "", errNotImpl
 }
 
 // ModTime returns the modification date of the file
 // It should return a best guess if one isn't available
-func (o Object) ModTime() (t time.Time) {
+func (o Object) ModTime(ctx context.Context) (t time.Time) {
 	return t
 }
 
@@ -58,22 +59,22 @@ func (o Object) Storable() bool {
 }
 
 // SetModTime sets the metadata on the object to set the modification date
-func (o Object) SetModTime(time.Time) error {
+func (o Object) SetModTime(ctx context.Context, t time.Time) error {
 	return errNotImpl
 }
 
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
-func (o Object) Open(options ...fs.OpenOption) (io.ReadCloser, error) {
+func (o Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
 	return nil, errNotImpl
 }
 
 // Update in to the object with the modTime given of the given size
-func (o Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+func (o Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	return errNotImpl
 }
 
 // Remove this object
-func (o Object) Remove() error {
+func (o Object) Remove(ctx context.Context) error {
 	return errNotImpl
 }
 
@@ -107,7 +108,7 @@ func (o Object) WithContent(content []byte, mode SeekMode) fs.Object {
 	}
 }
 
-func (o *contentMockObject) Open(options ...fs.OpenOption) (io.ReadCloser, error) {
+func (o *contentMockObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
 	var offset, limit int64 = 0, -1
 	for _, option := range options {
 		switch x := option.(type) {

--- a/fstest/test_all/clean.go
+++ b/fstest/test_all/clean.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"regexp"
 
@@ -25,7 +26,7 @@ func cleanFs(remote string) error {
 	if err != nil {
 		return err
 	}
-	entries, err := list.DirSorted(f, true, "")
+	entries, err := list.DirSorted(context.Background(), f, true, "")
 	if err != nil {
 		return err
 	}
@@ -46,7 +47,7 @@ func cleanFs(remote string) error {
 				fs.Errorf(fullPath, "%v", err)
 				return nil
 			}
-			err = operations.Purge(dir, "")
+			err = operations.Purge(context.Background(), dir, "")
 			if err != nil {
 				err = errors.Wrap(err, "Purge failed")
 				lastErr = err

--- a/vfs/dir_handle_test.go
+++ b/vfs/dir_handle_test.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"io"
 	"os"
 	"testing"
@@ -43,9 +44,9 @@ func TestDirHandleReaddir(t *testing.T) {
 	defer r.Finalise()
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("dir/file1", "file1 contents", t1)
-	file2 := r.WriteObject("dir/file2", "file2- contents", t2)
-	file3 := r.WriteObject("dir/subdir/file3", "file3-- contents", t3)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
+	file2 := r.WriteObject(context.Background(), "dir/file2", "file2- contents", t2)
+	file3 := r.WriteObject(context.Background(), "dir/subdir/file3", "file3-- contents", t3)
 	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
 
 	node, err := vfs.Stat("dir")

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -16,7 +17,7 @@ import (
 func dirCreate(t *testing.T, r *fstest.Run) (*VFS, *Dir, fstest.Item) {
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("dir/file1", "file1 contents", t1)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	node, err := vfs.Stat("dir")
@@ -142,7 +143,7 @@ func TestDirWalk(t *testing.T) {
 	defer r.Finalise()
 	vfs, _, file1 := dirCreate(t, r)
 
-	file2 := r.WriteObject("fil/a/b/c", "super long file", t1)
+	file2 := r.WriteObject(context.Background(), "fil/a/b/c", "super long file", t1)
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	root, err := vfs.Root()
@@ -257,9 +258,9 @@ func TestDirReadDirAll(t *testing.T) {
 	defer r.Finalise()
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("dir/file1", "file1 contents", t1)
-	file2 := r.WriteObject("dir/file2", "file2- contents", t2)
-	file3 := r.WriteObject("dir/subdir/file3", "file3-- contents", t3)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
+	file2 := r.WriteObject(context.Background(), "dir/file2", "file2- contents", t2)
+	file3 := r.WriteObject(context.Background(), "dir/subdir/file3", "file3-- contents", t3)
 	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
 
 	node, err := vfs.Stat("dir")
@@ -475,7 +476,7 @@ func TestDirRename(t *testing.T) {
 	}
 
 	vfs, dir, file1 := dirCreate(t, r)
-	file3 := r.WriteObject("dir/file3", "file3 contents!", t1)
+	file3 := r.WriteObject(context.Background(), "dir/file3", "file3 contents!", t1)
 	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1, file3}, []string{"dir"}, r.Fremote.Precision())
 
 	root, err := vfs.Root()

--- a/vfs/file_test.go
+++ b/vfs/file_test.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -13,7 +14,7 @@ import (
 func fileCreate(t *testing.T, r *fstest.Run) (*VFS, *File, fstest.Item) {
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("dir/file1", "file1 contents", t1)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	node, err := vfs.Stat("dir/file1")

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
@@ -14,7 +15,7 @@ import (
 func (vfs *VFS) addRC() {
 	rc.Add(rc.Call{
 		Path: "vfs/forget",
-		Fn: func(in rc.Params) (out rc.Params, err error) {
+		Fn: func(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 			root, err := vfs.Root()
 			if err != nil {
 				return nil, err
@@ -65,7 +66,7 @@ starting with dir will forget that dir, eg
 	})
 	rc.Add(rc.Call{
 		Path: "vfs/refresh",
-		Fn: func(in rc.Params) (out rc.Params, err error) {
+		Fn: func(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 			root, err := vfs.Root()
 			if err != nil {
 				return nil, err
@@ -253,7 +254,7 @@ func rcPollFunc(vfs *VFS) (rcPollFunc rc.Func) {
 			},
 		}, nil
 	}
-	return func(in rc.Params) (out rc.Params, err error) {
+	return func(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 		interval, intervalPresent, err := getInterval(in)
 		if err != nil {
 			return nil, err

--- a/vfs/read.go
+++ b/vfs/read.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"io"
 	"os"
 	"sync"
@@ -65,7 +66,7 @@ func (fh *ReadFileHandle) openPending() (err error) {
 		return nil
 	}
 	o := fh.file.getObject()
-	r, err := chunkedreader.New(o, int64(fh.file.d.vfs.Opt.ChunkSize), int64(fh.file.d.vfs.Opt.ChunkSizeLimit)).Open()
+	r, err := chunkedreader.New(context.TODO(), o, int64(fh.file.d.vfs.Opt.ChunkSize), int64(fh.file.d.vfs.Opt.ChunkSizeLimit)).Open()
 	if err != nil {
 		return err
 	}
@@ -122,7 +123,7 @@ func (fh *ReadFileHandle) seek(offset int64, reopen bool) (err error) {
 	}
 	if !reopen {
 		fs.Debugf(fh.remote, "ReadFileHandle.seek from %d to %d (fs.RangeSeeker)", fh.offset, offset)
-		_, err = r.RangeSeek(offset, io.SeekStart, -1)
+		_, err = r.RangeSeek(context.TODO(), offset, io.SeekStart, -1)
 		if err != nil {
 			fs.Debugf(fh.remote, "ReadFileHandle.Read fs.RangeSeeker failed: %v", err)
 			return err
@@ -136,7 +137,7 @@ func (fh *ReadFileHandle) seek(offset int64, reopen bool) (err error) {
 		}
 		// re-open with a seek
 		o := fh.file.getObject()
-		r = chunkedreader.New(o, int64(fh.file.d.vfs.Opt.ChunkSize), int64(fh.file.d.vfs.Opt.ChunkSizeLimit))
+		r = chunkedreader.New(context.TODO(), o, int64(fh.file.d.vfs.Opt.ChunkSize), int64(fh.file.d.vfs.Opt.ChunkSizeLimit))
 		_, err := r.Seek(offset, 0)
 		if err != nil {
 			fs.Debugf(fh.remote, "ReadFileHandle.Read seek failed: %v", err)
@@ -289,7 +290,7 @@ func (fh *ReadFileHandle) checkHash() error {
 
 	o := fh.file.getObject()
 	for hashType, dstSum := range fh.hash.Sums() {
-		srcSum, err := o.Hash(hashType)
+		srcSum, err := o.Hash(context.TODO(), hashType)
 		if err != nil {
 			return err
 		}

--- a/vfs/read_test.go
+++ b/vfs/read_test.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"io"
 	"os"
 	"testing"
@@ -14,7 +15,7 @@ import (
 func readHandleCreate(t *testing.T, r *fstest.Run) (*VFS, *ReadFileHandle) {
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("dir/file1", "0123456789abcdef", t1)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "0123456789abcdef", t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	h, err := vfs.OpenFile("dir/file1", os.O_RDONLY, 0777)

--- a/vfs/read_write_test.go
+++ b/vfs/read_write_test.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -25,7 +26,7 @@ func rwHandleCreateReadOnly(t *testing.T, r *fstest.Run) (*VFS, *RWFileHandle) {
 	opt.CacheMode = CacheModeFull
 	vfs := New(r.Fremote, &opt)
 
-	file1 := r.WriteObject("dir/file1", "0123456789abcdef", t1)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "0123456789abcdef", t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	h, err := vfs.OpenFile("dir/file1", os.O_RDONLY, 0777)

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -229,7 +229,7 @@ func New(f fs.Fs, opt *Options) *VFS {
 	// Start polling function
 	if do := vfs.f.Features().ChangeNotify; do != nil {
 		vfs.pollChan = make(chan time.Duration)
-		do(vfs.root.ForgetPath, vfs.pollChan)
+		do(context.TODO(), vfs.root.ForgetPath, vfs.pollChan)
 		vfs.pollChan <- vfs.Opt.PollInterval
 	} else {
 		fs.Infof(f, "poll-interval is not supported by this remote")
@@ -480,7 +480,7 @@ func (vfs *VFS) Statfs() (total, used, free int64) {
 	}
 	if vfs.usageTime.IsZero() || time.Since(vfs.usageTime) >= vfs.Opt.DirCacheTime {
 		var err error
-		vfs.usage, err = doAbout()
+		vfs.usage, err = doAbout(context.TODO())
 		vfs.usageTime = time.Now()
 		if err != nil {
 			fs.Errorf(vfs.f, "Statfs failed: %v", err)

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -3,6 +3,7 @@
 package vfs
 
 import (
+	"context"
 	"io"
 	"os"
 	"testing"
@@ -130,8 +131,8 @@ func TestVFSStat(t *testing.T) {
 	defer r.Finalise()
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("file1", "file1 contents", t1)
-	file2 := r.WriteObject("dir/file2", "file2 contents", t2)
+	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
+	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	node, err := vfs.Stat("file1")
@@ -167,8 +168,8 @@ func TestVFSStatParent(t *testing.T) {
 	defer r.Finalise()
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("file1", "file1 contents", t1)
-	file2 := r.WriteObject("dir/file2", "file2 contents", t2)
+	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
+	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	node, leaf, err := vfs.StatParent("file1")
@@ -201,8 +202,8 @@ func TestVFSOpenFile(t *testing.T) {
 	defer r.Finalise()
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("file1", "file1 contents", t1)
-	file2 := r.WriteObject("dir/file2", "file2 contents", t2)
+	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
+	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
 	fstest.CheckItems(t, r.Fremote, file1, file2)
 
 	fd, err := vfs.OpenFile("file1", os.O_RDONLY, 0777)
@@ -238,7 +239,7 @@ func TestVFSRename(t *testing.T) {
 	}
 	vfs := New(r.Fremote, nil)
 
-	file1 := r.WriteObject("dir/file2", "file2 contents", t2)
+	file1 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	err := vfs.Rename("dir/file2", "dir/file1")

--- a/vfs/write.go
+++ b/vfs/write.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"io"
 	"os"
 	"sync"
@@ -65,7 +66,7 @@ func (fh *WriteFileHandle) openPending() (err error) {
 	pipeReader, fh.pipeWriter = io.Pipe()
 	go func() {
 		// NB Rcat deals with Stats.Transferring etc
-		o, err := operations.Rcat(fh.file.d.f, fh.remote, pipeReader, time.Now())
+		o, err := operations.Rcat(context.TODO(), fh.file.d.f, fh.remote, pipeReader, time.Now())
 		if err != nil {
 			fs.Errorf(fh.remote, "WriteFileHandle.New Rcat failed: %v", err)
 		}

--- a/vfs/write_test.go
+++ b/vfs/write_test.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"os"
 	"sync"
 	"testing"
@@ -230,11 +231,11 @@ var (
 func canSetModTime(t *testing.T, r *fstest.Run) bool {
 	canSetModTimeOnce.Do(func() {
 		mtime1 := time.Date(2008, time.November, 18, 17, 32, 31, 0, time.UTC)
-		_ = r.WriteObject("time_test", "stuff", mtime1)
-		obj, err := r.Fremote.NewObject("time_test")
+		_ = r.WriteObject(context.Background(), "time_test", "stuff", mtime1)
+		obj, err := r.Fremote.NewObject(context.Background(), "time_test")
 		require.NoError(t, err)
 		mtime2 := time.Date(2009, time.November, 18, 17, 32, 31, 0, time.UTC)
-		err = obj.SetModTime(mtime2)
+		err = obj.SetModTime(context.Background(), mtime2)
 		switch err {
 		case nil:
 			canSetModTimeValue = true
@@ -243,7 +244,7 @@ func canSetModTime(t *testing.T, r *fstest.Run) bool {
 		default:
 			require.NoError(t, err)
 		}
-		require.NoError(t, obj.Remove())
+		require.NoError(t, obj.Remove(context.Background()))
 		fs.Debugf(nil, "Can set mod time: %v", canSetModTimeValue)
 	})
 	return canSetModTimeValue


### PR DESCRIPTION
Changes:   

- Change rclone/fs interfaces to accept context.Context
- Update interface implementations to use context.Context
- Change top level usage to propagate context to lover level functions

Context propagation is needed for stopping transfers and passing other request-scoped values.

Fixes: #3257