### PR TITLE
 Add tracking for transfer history

### DIFF
--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -5,6 +5,7 @@
 package ftp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -215,7 +216,7 @@ func (d *Driver) ListDir(path string, callback func(ftp.FileInfo) error) (err er
 
 	// Account the transfer
 	accounting.Stats.Transferring(path)
-	defer accounting.Stats.DoneTransferring(path, true)
+	defer accounting.Stats.DoneTransferring(context.TODO(), path, nil)
 
 	for _, file := range dirEntries {
 		err = callback(&FileInfo{file, file.Mode(), d.vfs.Opt.UID, d.vfs.Opt.GID})
@@ -312,7 +313,7 @@ func (d *Driver) GetFile(path string, offset int64) (size int64, fr io.ReadClose
 
 	// Account the transfer
 	accounting.Stats.Transferring(path)
-	defer accounting.Stats.DoneTransferring(path, true)
+	defer accounting.Stats.DoneTransferring(context.TODO(), path, nil)
 
 	return node.Size(), handle, nil
 }

--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -188,7 +188,7 @@ func (s *server) serveFile(w http.ResponseWriter, r *http.Request, remote string
 
 	// Account the transfer
 	accounting.Stats.Transferring(remote)
-	defer accounting.Stats.DoneTransferring(remote, true)
+	defer accounting.Stats.DoneTransferring(r.Context(), remote, nil)
 	// FIXME in = fs.NewAccount(in, obj).WithBuffer() // account the transfer
 
 	// Serve the file

--- a/cmd/serve/httplib/serve/dir.go
+++ b/cmd/serve/httplib/serve/dir.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -76,7 +77,7 @@ func Error(what interface{}, w http.ResponseWriter, text string, err error) {
 func (d *Directory) Serve(w http.ResponseWriter, r *http.Request) {
 	// Account the transfer
 	accounting.Stats.Transferring(d.DirRemote)
-	defer accounting.Stats.DoneTransferring(d.DirRemote, true)
+	defer accounting.Stats.DoneTransferring(context.TODO(), d.DirRemote, nil)
 
 	fs.Infof(d.DirRemote, "%s: Serving directory", r.RemoteAddr)
 

--- a/cmd/serve/httplib/serve/serve.go
+++ b/cmd/serve/httplib/serve/serve.go
@@ -76,21 +76,10 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 		return
 	}
 	accounting.Stats.Transferring(o.Remote())
-	in := accounting.NewAccount(file, o) // account the transfer (no buffering)
 	defer func() {
-		closeErr := in.Close()
-		if closeErr != nil {
-			fs.Errorf(o, "Get request: close failed: %v", closeErr)
-			if err == nil {
-				err = closeErr
-			}
-		}
-		ok := err == nil
-		accounting.Stats.DoneTransferring(o.Remote(), ok)
-		if !ok {
-			accounting.Stats.Error(err)
-		}
+		accounting.Stats.DoneTransferring(r.Context(), o.Remote(), err)
 	}()
+	in := accounting.Stats.NewAccount(r.Context(), file, o) // account the transfer (no buffering)
 
 	w.WriteHeader(code)
 

--- a/fs/accounting/accounting_test.go
+++ b/fs/accounting/accounting_test.go
@@ -2,6 +2,7 @@ package accounting
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -27,36 +28,32 @@ var (
 
 func TestNewAccountSizeName(t *testing.T) {
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1}))
-	acc := NewAccountSizeName(in, 1, "test")
+	acc := NewAccountSizeName(context.Background(), in, 1, "test")
 	assert.Equal(t, in, acc.in)
-	assert.Equal(t, acc, Stats.inProgress.get("test"))
 	err := acc.Close()
 	assert.NoError(t, err)
-	assert.Nil(t, Stats.inProgress.get("test"))
 }
 
 func TestNewAccount(t *testing.T) {
 	obj := mockobject.Object("test")
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1}))
-	acc := NewAccount(in, obj)
+	acc := NewAccount(context.Background(), in, obj)
 	assert.Equal(t, in, acc.in)
-	assert.Equal(t, acc, Stats.inProgress.get("test"))
 	err := acc.Close()
 	assert.NoError(t, err)
-	assert.Nil(t, Stats.inProgress.get("test"))
 }
 
 func TestAccountWithBuffer(t *testing.T) {
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1}))
 
-	acc := NewAccountSizeName(in, -1, "test")
+	acc := Stats.NewAccountSizeName(context.Background(), in, -1, "test")
 	acc.WithBuffer()
 	// should have a buffer for an unknown size
 	_, ok := acc.in.(*asyncreader.AsyncReader)
 	require.True(t, ok)
 	assert.NoError(t, acc.Close())
 
-	acc = NewAccountSizeName(in, 1, "test")
+	acc = NewAccountSizeName(context.Background(), in, 1, "test")
 	acc.WithBuffer()
 	// should not have a buffer for a small size
 	_, ok = acc.in.(*asyncreader.AsyncReader)
@@ -66,7 +63,7 @@ func TestAccountWithBuffer(t *testing.T) {
 
 func TestAccountGetUpdateReader(t *testing.T) {
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1}))
-	acc := NewAccountSizeName(in, 1, "test")
+	acc := NewAccountSizeName(context.Background(), in, 1, "test")
 
 	assert.Equal(t, in, acc.GetReader())
 
@@ -80,7 +77,7 @@ func TestAccountGetUpdateReader(t *testing.T) {
 
 func TestAccountRead(t *testing.T) {
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1, 2, 3}))
-	acc := NewAccountSizeName(in, 1, "test")
+	acc := NewAccountSizeName(context.Background(), in, 1, "test")
 
 	assert.True(t, acc.start.IsZero())
 	assert.Equal(t, 0, acc.lpBytes)
@@ -112,7 +109,7 @@ func TestAccountRead(t *testing.T) {
 
 func TestAccountString(t *testing.T) {
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1, 2, 3}))
-	acc := NewAccountSizeName(in, 3, "test")
+	acc := NewAccountSizeName(context.Background(), in, 3, "test")
 
 	// FIXME not an exhaustive test!
 
@@ -131,7 +128,7 @@ func TestAccountString(t *testing.T) {
 // Test the Accounter interface methods on Account and accountStream
 func TestAccountAccounter(t *testing.T) {
 	in := ioutil.NopCloser(bytes.NewBuffer([]byte{1, 2, 3}))
-	acc := NewAccountSizeName(in, 3, "test")
+	acc := NewAccountSizeName(context.Background(), in, 3, "test")
 
 	assert.True(t, in == acc.OldStream())
 
@@ -195,7 +192,7 @@ func TestAccountMaxTransfer(t *testing.T) {
 	Stats.ResetCounters()
 
 	in := ioutil.NopCloser(bytes.NewBuffer(make([]byte, 100)))
-	acc := NewAccountSizeName(in, 1, "test")
+	acc := NewAccountSizeName(context.Background(), in, 1, "test")
 
 	var b = make([]byte, 10)
 

--- a/fs/accounting/mstime.go
+++ b/fs/accounting/mstime.go
@@ -1,0 +1,27 @@
+package accounting
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// msTime is helper type for representing unix epoch timestamp in milliseconds.
+type msTime time.Time
+
+func (t msTime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatInt(time.Time(t).UnixNano()/1e6, 10)), nil
+}
+
+func (t *msTime) UnmarshalJSON(s []byte) (err error) {
+	r := strings.Replace(string(s), `"`, ``, -1)
+
+	q, err := strconv.ParseInt(r, 10, 64)
+	if err != nil {
+		return err
+	}
+	*(*time.Time)(t) = time.Unix(q/1000, (q-q/1000)*1000)
+	return
+}
+
+func (t msTime) String() string { return time.Time(t).String() }

--- a/fs/accounting/transferred.go
+++ b/fs/accounting/transferred.go
@@ -1,0 +1,74 @@
+package accounting
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ncw/rclone/fs"
+)
+
+// transferred holds a synchronized map of in progress transfers.
+type transferred struct {
+	done          chan struct{}
+	checkDuration time.Duration
+	interval      time.Duration
+	mu            sync.Mutex
+	items         []AccountSnapshot
+}
+
+// newTransferred makes a new transferred object.
+func newTransferred() *transferred {
+	tr := &transferred{
+		items:         []AccountSnapshot{},
+		checkDuration: fs.Config.TransferredExpireDuration,
+		interval:      fs.Config.TransferredExpireInterval,
+		done:          make(chan struct{}),
+	}
+	go tr.watchForExpired()
+	return tr
+}
+
+// add adds new snapshot to the transferred list.
+func (tr *transferred) add(acc AccountSnapshot) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.items = append(tr.items, acc)
+}
+
+// watchForExpired removes all snaphots older than maxAge.
+func (tr *transferred) watchForExpired() {
+	ticker := time.NewTicker(tr.interval)
+	for {
+		select {
+		case <-tr.done:
+			return
+		case <-ticker.C:
+			tr.clearExpired(tr.checkDuration)
+		}
+	}
+}
+
+// clearExpired removes all snaphots older than maxAge.
+func (tr *transferred) clearExpired(maxAge time.Duration) {
+	limit := time.Now().UTC().Add(-maxAge)
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	// In place filtering by reusing items storage.
+	tmp := tr.items[:0]
+	for _, i := range tr.items {
+		if limit.Before(time.Time(i.Timestamp)) {
+			tmp = append(tmp, i)
+		}
+	}
+	tr.items = tmp
+}
+
+func (tr *transferred) snapshots() []AccountSnapshot {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return tr.items
+}
+
+func (tr *transferred) close() {
+	close(tr.done)
+}

--- a/fs/config.go
+++ b/fs/config.go
@@ -38,66 +38,68 @@ var (
 
 // ConfigInfo is filesystem config options
 type ConfigInfo struct {
-	LogLevel               LogLevel
-	StatsLogLevel          LogLevel
-	DryRun                 bool
-	CheckSum               bool
-	SizeOnly               bool
-	IgnoreTimes            bool
-	IgnoreExisting         bool
-	IgnoreErrors           bool
-	ModifyWindow           time.Duration
-	Checkers               int
-	Transfers              int
-	ConnectTimeout         time.Duration // Connect timeout
-	Timeout                time.Duration // Data channel timeout
-	Dump                   DumpFlags
-	InsecureSkipVerify     bool // Skip server certificate verification
-	DeleteMode             DeleteMode
-	MaxDelete              int64
-	TrackRenames           bool // Track file renames.
-	LowLevelRetries        int
-	UpdateOlder            bool // Skip files that are newer on the destination
-	NoGzip                 bool // Disable compression
-	MaxDepth               int
-	IgnoreSize             bool
-	IgnoreChecksum         bool
-	IgnoreCaseSync         bool
-	NoTraverse             bool
-	NoUpdateModTime        bool
-	DataRateUnit           string
-	BackupDir              string
-	Suffix                 string
-	SuffixKeepExtension    bool
-	UseListR               bool
-	BufferSize             SizeSuffix
-	BwLimit                BwTimetable
-	TPSLimit               float64
-	TPSLimitBurst          int
-	BindAddr               net.IP
-	DisableFeatures        []string
-	UserAgent              string
-	Immutable              bool
-	AutoConfirm            bool
-	StreamingUploadCutoff  SizeSuffix
-	StatsFileNameLength    int
-	AskPassword            bool
-	UseServerModTime       bool
-	MaxTransfer            SizeSuffix
-	MaxBacklog             int
-	StatsOneLine           bool
-	StatsOneLineDate       bool   // If we want a date prefix at all
-	StatsOneLineDateFormat string // If we want to customize the prefix
-	Progress               bool
-	Cookie                 bool
-	UseMmap                bool
-	CaCert                 string // Client Side CA
-	ClientCert             string // Client Side Cert
-	ClientKey              string // Client Side Key
-	MultiThreadCutoff      SizeSuffix
-	MultiThreadStreams     int
-	RcJobExpireDuration    time.Duration
-	RcJobExpireInterval    time.Duration
+	LogLevel                  LogLevel
+	StatsLogLevel             LogLevel
+	DryRun                    bool
+	CheckSum                  bool
+	SizeOnly                  bool
+	IgnoreTimes               bool
+	IgnoreExisting            bool
+	IgnoreErrors              bool
+	ModifyWindow              time.Duration
+	Checkers                  int
+	Transfers                 int
+	ConnectTimeout            time.Duration // Connect timeout
+	Timeout                   time.Duration // Data channel timeout
+	Dump                      DumpFlags
+	InsecureSkipVerify        bool // Skip server certificate verification
+	DeleteMode                DeleteMode
+	MaxDelete                 int64
+	TrackRenames              bool // Track file renames.
+	LowLevelRetries           int
+	UpdateOlder               bool // Skip files that are newer on the destination
+	NoGzip                    bool // Disable compression
+	MaxDepth                  int
+	IgnoreSize                bool
+	IgnoreChecksum            bool
+	IgnoreCaseSync            bool
+	NoTraverse                bool
+	NoUpdateModTime           bool
+	DataRateUnit              string
+	BackupDir                 string
+	Suffix                    string
+	SuffixKeepExtension       bool
+	UseListR                  bool
+	BufferSize                SizeSuffix
+	BwLimit                   BwTimetable
+	TPSLimit                  float64
+	TPSLimitBurst             int
+	BindAddr                  net.IP
+	DisableFeatures           []string
+	UserAgent                 string
+	Immutable                 bool
+	AutoConfirm               bool
+	StreamingUploadCutoff     SizeSuffix
+	StatsFileNameLength       int
+	AskPassword               bool
+	UseServerModTime          bool
+	MaxTransfer               SizeSuffix
+	MaxBacklog                int
+	StatsOneLine              bool
+	StatsOneLineDate          bool   // If we want a date prefix at all
+	StatsOneLineDateFormat    string // If we want to customize the prefix
+	Progress                  bool
+	Cookie                    bool
+	UseMmap                   bool
+	CaCert                    string // Client Side CA
+	ClientCert                string // Client Side Cert
+	ClientKey                 string // Client Side Key
+	MultiThreadCutoff         SizeSuffix
+	MultiThreadStreams        int
+	RcJobExpireDuration       time.Duration
+	RcJobExpireInterval       time.Duration
+	TransferredExpireDuration time.Duration
+	TransferredExpireInterval time.Duration
 }
 
 // NewConfig creates a new config with everything set to the default
@@ -133,6 +135,8 @@ func NewConfig() *ConfigInfo {
 	c.MultiThreadStreams = 4
 	c.RcJobExpireDuration = 60 * time.Second
 	c.RcJobExpireInterval = 10 * time.Second
+	c.TransferredExpireDuration = 60 * time.Second
+	c.TransferredExpireInterval = 10 * time.Second
 
 	return c
 }

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -100,6 +100,8 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.IntVarP(flagSet, &fs.Config.MultiThreadStreams, "multi-thread-streams", "", fs.Config.MultiThreadStreams, "Max number of streams to use for multi-thread downloads.")
 	flags.DurationVarP(flagSet, &fs.Config.RcJobExpireDuration, "rc-job-expire-duration", "", fs.Config.RcJobExpireDuration, "expire finished async jobs older than this value")
 	flags.DurationVarP(flagSet, &fs.Config.RcJobExpireInterval, "rc-job-expire-interval", "", fs.Config.RcJobExpireInterval, "interval to check for expired async jobs")
+	flags.DurationVarP(flagSet, &fs.Config.TransferredExpireDuration, "accounting-transferred-expire-duration", "", fs.Config.TransferredExpireDuration, "remove transferred accounting stats older than this value")
+	flags.DurationVarP(flagSet, &fs.Config.TransferredExpireInterval, "accounting-transferred-expire-interval", "", fs.Config.TransferredExpireInterval, "interval to check for expired transferred accounting stats")
 }
 
 // SetFlags converts any flags into config which weren't straight forward

--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -122,7 +122,7 @@ func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object,
 		return nil, errors.New("multi-thread copy: can't copy zero sized file")
 	}
 
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 	mc := &multiThreadCopyState{
 		ctx:     ctx,
 		size:    src.Size(),
@@ -132,7 +132,7 @@ func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object,
 	mc.calculateChunks()
 
 	// Make accounting
-	mc.acc = accounting.NewAccount(nil, src)
+	mc.acc = accounting.Stats.NewAccount(ctx, nil, src)
 	defer fs.CheckClose(mc.acc, &err)
 
 	// create write file handle

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -253,7 +253,7 @@ var _ fs.MimeTyper = (*overrideRemoteObject)(nil)
 func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Object, err error) {
 	accounting.Stats.Transferring(src.Remote())
 	defer func() {
-		accounting.Stats.DoneTransferring(src.Remote(), err == nil)
+		accounting.Stats.DoneTransferring(ctx, src.Remote(), err)
 	}()
 	newDst = dst
 	if fs.Config.DryRun {
@@ -326,7 +326,7 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 						dst, err = Rcat(ctx, f, remote, in0, src.ModTime(ctx))
 						newDst = dst
 					} else {
-						in := accounting.NewAccount(in0, src).WithBuffer() // account and buffer the transfer
+						in := accounting.Stats.NewAccount(ctx, in0, src).WithBuffer() // account and buffer the transfer
 						var wrappedSrc fs.ObjectInfo = src
 						// We try to pass the original object if possible
 						if src.Remote() != remote {
@@ -339,10 +339,8 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 							actionTaken = "Copied (new)"
 							dst, err = f.Put(ctx, in, wrappedSrc, hashOption)
 						}
-						closeErr := in.Close()
 						if err == nil {
 							newDst = dst
-							err = closeErr
 						}
 					}
 				}
@@ -430,7 +428,7 @@ func SameObject(src, dst fs.Object) bool {
 func Move(ctx context.Context, fdst fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Object, err error) {
 	accounting.Stats.Checking(src.Remote())
 	defer func() {
-		accounting.Stats.DoneChecking(src.Remote())
+		accounting.Stats.DoneCheckingObj(ctx, src)
 	}()
 	newDst = dst
 	if fs.Config.DryRun {
@@ -529,7 +527,7 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 	} else if !fs.Config.DryRun {
 		fs.Infof(dst, actioned)
 	}
-	accounting.Stats.DoneChecking(dst.Remote())
+	accounting.Stats.DoneCheckingObj(ctx, dst)
 	return err
 }
 
@@ -700,7 +698,7 @@ func (c *checkMarch) SrcOnly(src fs.DirEntry) (recurse bool) {
 // check to see if two objects are identical using the check function
 func (c *checkMarch) checkIdentical(ctx context.Context, dst, src fs.Object) (differ bool, noHash bool) {
 	accounting.Stats.Checking(src.Remote())
-	defer accounting.Stats.DoneChecking(src.Remote())
+	defer accounting.Stats.DoneCheckingObj(ctx, src)
 	if sizeDiffers(src, dst) {
 		err := errors.Errorf("Sizes differ")
 		fs.Errorf(src, "%v", err)
@@ -844,14 +842,14 @@ func CheckIdentical(ctx context.Context, dst, src fs.Object) (differ bool, err e
 	if err != nil {
 		return true, errors.Wrapf(err, "failed to open %q", dst)
 	}
-	in1 = accounting.NewAccount(in1, dst).WithBuffer() // account and buffer the transfer
+	in1 = accounting.Stats.NewAccount(ctx, in1, dst).WithBuffer() // account and buffer the transfer
 	defer fs.CheckClose(in1, &err)
 
 	in2, err := src.Open(ctx)
 	if err != nil {
 		return true, errors.Wrapf(err, "failed to open %q", src)
 	}
-	in2 = accounting.NewAccount(in2, src).WithBuffer() // account and buffer the transfer
+	in2 = accounting.Stats.NewAccount(ctx, in2, src).WithBuffer() // account and buffer the transfer
 	defer fs.CheckClose(in2, &err)
 
 	return CheckEqualReaders(in1, in2)
@@ -914,7 +912,7 @@ func ListLong(ctx context.Context, f fs.Fs, w io.Writer) error {
 	return ListFn(ctx, f, func(o fs.Object) {
 		accounting.Stats.Checking(o.Remote())
 		modTime := o.ModTime(ctx)
-		accounting.Stats.DoneChecking(o.Remote())
+		accounting.Stats.DoneCheckingObj(ctx, o)
 		syncFprintf(w, "%9d %s %s\n", o.Size(), modTime.Local().Format("2006-01-02 15:04:05.000000000"), o.Remote())
 	})
 }
@@ -952,7 +950,7 @@ func DropboxHashSum(ctx context.Context, f fs.Fs, w io.Writer) error {
 func hashSum(ctx context.Context, ht hash.Type, o fs.Object) string {
 	accounting.Stats.Checking(o.Remote())
 	sum, err := o.Hash(ctx, ht)
-	accounting.Stats.DoneChecking(o.Remote())
+	accounting.Stats.DoneCheckingObj(ctx, o)
 	if err == hash.ErrUnsupported {
 		sum = "UNSUPPORTED"
 	} else if err != nil {
@@ -1151,7 +1149,7 @@ func Cat(ctx context.Context, f fs.Fs, w io.Writer, offset, count int64) error {
 		var err error
 		accounting.Stats.Transferring(o.Remote())
 		defer func() {
-			accounting.Stats.DoneTransferring(o.Remote(), err == nil)
+			accounting.Stats.DoneTransferring(ctx, o.Remote(), err)
 		}()
 		opt := fs.RangeOption{Start: offset, End: -1}
 		size := o.Size()
@@ -1178,14 +1176,7 @@ func Cat(ctx context.Context, f fs.Fs, w io.Writer, offset, count int64) error {
 				size = count
 			}
 		}
-		in = accounting.NewAccountSizeName(in, size, o.Remote()).WithBuffer() // account and buffer the transfer
-		defer func() {
-			err = in.Close()
-			if err != nil {
-				fs.CountError(err)
-				fs.Errorf(o, "Failed to close: %v", err)
-			}
-		}()
+		in = accounting.Stats.NewAccountSizeName(ctx, in, size, o.Remote()).WithBuffer() // account and buffer the transfer
 		// take the lock just before we output stuff, so at the last possible moment
 		mu.Lock()
 		defer mu.Unlock()
@@ -1200,13 +1191,10 @@ func Cat(ctx context.Context, f fs.Fs, w io.Writer, offset, count int64) error {
 // Rcat reads data from the Reader until EOF and uploads it to a file on remote
 func Rcat(ctx context.Context, fdst fs.Fs, dstFileName string, in io.ReadCloser, modTime time.Time) (dst fs.Object, err error) {
 	accounting.Stats.Transferring(dstFileName)
-	in = accounting.NewAccountSizeName(in, -1, dstFileName).WithBuffer()
 	defer func() {
-		accounting.Stats.DoneTransferring(dstFileName, err == nil)
-		if otherErr := in.Close(); otherErr != nil {
-			fs.Debugf(fdst, "Rcat: failed to close source: %v", err)
-		}
+		accounting.Stats.DoneTransferring(ctx, dstFileName, err)
 	}()
+	in = accounting.Stats.NewAccountSizeName(ctx, in, -1, dstFileName).WithBuffer()
 
 	hashOption := &fs.HashesOption{Hashes: fdst.Hashes()}
 	hash, err := hash.NewMultiHasherTypes(fdst.Hashes())
@@ -1413,9 +1401,13 @@ func RcatSize(ctx context.Context, fdst fs.Fs, dstFileName string, in io.ReadClo
 
 	if size >= 0 {
 		// Size known use Put
+		var err error
 		accounting.Stats.Transferring(dstFileName)
-		body := ioutil.NopCloser(in)                                 // we let the server close the body
-		in := accounting.NewAccountSizeName(body, size, dstFileName) // account the transfer (no buffering)
+		defer func() {
+			accounting.Stats.DoneTransferring(ctx, dstFileName, err)
+		}()
+		body := ioutil.NopCloser(in)                                            // we let the server close the body
+		in := accounting.Stats.NewAccountSizeName(ctx, body, size, dstFileName) // account the transfer (no buffering)
 
 		if fs.Config.DryRun {
 			fs.Logf("stdin", "Not uploading as --dry-run")
@@ -1424,20 +1416,10 @@ func RcatSize(ctx context.Context, fdst fs.Fs, dstFileName string, in io.ReadClo
 			return nil, err
 		}
 
-		var err error
-		defer func() {
-			closeErr := in.Close()
-			if closeErr != nil {
-				accounting.Stats.Error(closeErr)
-				fs.Errorf(dstFileName, "Post request: close failed: %v", closeErr)
-			}
-			accounting.Stats.DoneTransferring(dstFileName, err == nil)
-		}()
 		info := object.NewStaticObjectInfo(dstFileName, modTime, size, true, nil, fdst)
 		obj, err = fdst.Put(ctx, in, info)
 		if err != nil {
 			fs.Errorf(dstFileName, "Post request put error: %v", err)
-
 			return nil, err
 		}
 	} else {
@@ -1511,11 +1493,11 @@ func moveOrCopyFile(ctx context.Context, fdst fs.Fs, fsrc fs.Fs, dstFileName str
 		accounting.Stats.Transferring(srcFileName)
 		tmpObj, err := Op(ctx, fdst, nil, tmpObjName, srcObj)
 		if err != nil {
-			accounting.Stats.DoneTransferring(srcFileName, false)
+			accounting.Stats.DoneTransferring(ctx, srcFileName, err)
 			return errors.Wrap(err, "error while moving file to temporary location")
 		}
 		_, err = Op(ctx, fdst, nil, dstFileName, tmpObj)
-		accounting.Stats.DoneTransferring(srcFileName, err == nil)
+		accounting.Stats.DoneTransferring(ctx, srcFileName, err)
 		return err
 	}
 
@@ -1539,10 +1521,10 @@ func moveOrCopyFile(ctx context.Context, fdst fs.Fs, fsrc fs.Fs, dstFileName str
 		_, err = Op(ctx, fdst, dstObj, dstFileName, srcObj)
 	} else {
 		accounting.Stats.Checking(srcFileName)
+		defer accounting.Stats.DoneCheckingObj(ctx, srcObj)
 		if !cp {
 			err = DeleteFile(ctx, srcObj)
 		}
-		defer accounting.Stats.DoneChecking(srcFileName)
 	}
 	return err
 }

--- a/fs/rc/jobs/jobs_test.go
+++ b/fs/rc/jobs/jobs_test.go
@@ -1,4 +1,4 @@
-package rc
+package jobs
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ncw/rclone/fs"
+	"github.com/ncw/rclone/fs/rc"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,10 +37,10 @@ func TestJobsExpire(t *testing.T) {
 	jobs := newJobs()
 	jobs.expireInterval = time.Millisecond
 	assert.Equal(t, false, jobs.expireRunning)
-	job := jobs.NewJob(func(ctx context.Context, in Params) (Params, error) {
+	job := jobs.NewJob(func(ctx context.Context, in rc.Params) (rc.Params, error) {
 		defer close(wait)
 		return in, nil
-	}, Params{})
+	}, rc.Params{})
 	<-wait
 	assert.Equal(t, 1, len(jobs.jobs))
 	jobs.Expire()
@@ -57,14 +58,14 @@ func TestJobsExpire(t *testing.T) {
 	jobs.mu.Unlock()
 }
 
-var noopFn = func(ctx context.Context, in Params) (Params, error) {
+var noopFn = func(ctx context.Context, in rc.Params) (rc.Params, error) {
 	return nil, nil
 }
 
 func TestJobsIDs(t *testing.T) {
 	jobs := newJobs()
-	job1 := jobs.NewJob(noopFn, Params{})
-	job2 := jobs.NewJob(noopFn, Params{})
+	job1 := jobs.NewJob(noopFn, rc.Params{})
+	job2 := jobs.NewJob(noopFn, rc.Params{})
 	wantIDs := []int64{job1.ID, job2.ID}
 	gotIDs := jobs.IDs()
 	require.Equal(t, 2, len(gotIDs))
@@ -76,17 +77,17 @@ func TestJobsIDs(t *testing.T) {
 
 func TestJobsGet(t *testing.T) {
 	jobs := newJobs()
-	job := jobs.NewJob(noopFn, Params{})
+	job := jobs.NewJob(noopFn, rc.Params{})
 	assert.Equal(t, job, jobs.Get(job.ID))
 	assert.Nil(t, jobs.Get(123123123123))
 }
 
-var longFn = func(ctx context.Context, in Params) (Params, error) {
+var longFn = func(ctx context.Context, in rc.Params) (rc.Params, error) {
 	time.Sleep(1 * time.Hour)
 	return nil, nil
 }
 
-var ctxFn = func(ctx context.Context, in Params) (Params, error) {
+var ctxFn = func(ctx context.Context, in rc.Params) (rc.Params, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -105,17 +106,17 @@ func sleepJob() {
 
 func TestJobFinish(t *testing.T) {
 	jobs := newJobs()
-	job := jobs.NewJob(longFn, Params{})
+	job := jobs.NewJob(longFn, rc.Params{})
 	sleepJob()
 
 	assert.Equal(t, true, job.EndTime.IsZero())
-	assert.Equal(t, Params(nil), job.Output)
+	assert.Equal(t, rc.Params(nil), job.Output)
 	assert.Equal(t, 0.0, job.Duration)
 	assert.Equal(t, "", job.Error)
 	assert.Equal(t, false, job.Success)
 	assert.Equal(t, false, job.Finished)
 
-	wantOut := Params{"a": 1}
+	wantOut := rc.Params{"a": 1}
 	job.finish(wantOut, nil)
 
 	assert.Equal(t, false, job.EndTime.IsZero())
@@ -125,18 +126,18 @@ func TestJobFinish(t *testing.T) {
 	assert.Equal(t, true, job.Success)
 	assert.Equal(t, true, job.Finished)
 
-	job = jobs.NewJob(longFn, Params{})
+	job = jobs.NewJob(longFn, rc.Params{})
 	sleepJob()
 	job.finish(nil, nil)
 
 	assert.Equal(t, false, job.EndTime.IsZero())
-	assert.Equal(t, Params{}, job.Output)
+	assert.Equal(t, rc.Params{}, job.Output)
 	assert.True(t, job.Duration >= floatSleepTime)
 	assert.Equal(t, "", job.Error)
 	assert.Equal(t, true, job.Success)
 	assert.Equal(t, true, job.Finished)
 
-	job = jobs.NewJob(longFn, Params{})
+	job = jobs.NewJob(longFn, rc.Params{})
 	sleepJob()
 	job.finish(wantOut, errors.New("potato"))
 
@@ -152,14 +153,14 @@ func TestJobFinish(t *testing.T) {
 // part of NewJob, now just test the panic catching
 func TestJobRunPanic(t *testing.T) {
 	wait := make(chan struct{})
-	boom := func(ctx context.Context, in Params) (Params, error) {
+	boom := func(ctx context.Context, in rc.Params) (rc.Params, error) {
 		sleepJob()
 		defer close(wait)
 		panic("boom")
 	}
 
 	jobs := newJobs()
-	job := jobs.NewJob(boom, Params{})
+	job := jobs.NewJob(boom, rc.Params{})
 	<-wait
 	runtime.Gosched() // yield to make sure job is updated
 
@@ -176,7 +177,7 @@ func TestJobRunPanic(t *testing.T) {
 
 	job.mu.Lock()
 	assert.Equal(t, false, job.EndTime.IsZero())
-	assert.Equal(t, Params{}, job.Output)
+	assert.Equal(t, rc.Params{}, job.Output)
 	assert.True(t, job.Duration >= floatSleepTime)
 	assert.Equal(t, "panic received: boom", job.Error)
 	assert.Equal(t, false, job.Success)
@@ -187,7 +188,7 @@ func TestJobRunPanic(t *testing.T) {
 func TestJobsNewJob(t *testing.T) {
 	jobID = 0
 	jobs := newJobs()
-	job := jobs.NewJob(noopFn, Params{})
+	job := jobs.NewJob(noopFn, rc.Params{})
 	assert.Equal(t, int64(1), job.ID)
 	assert.Equal(t, job, jobs.Get(1))
 	assert.NotEmpty(t, job.Stop)
@@ -195,19 +196,19 @@ func TestJobsNewJob(t *testing.T) {
 
 func TestStartJob(t *testing.T) {
 	jobID = 0
-	out, err := StartJob(longFn, Params{})
+	out, err := StartJob(longFn, rc.Params{})
 	assert.NoError(t, err)
-	assert.Equal(t, Params{"jobid": int64(1)}, out)
+	assert.Equal(t, rc.Params{"jobid": int64(1)}, out)
 }
 
 func TestRcJobStatus(t *testing.T) {
 	jobID = 0
-	_, err := StartJob(longFn, Params{})
+	_, err := StartJob(longFn, rc.Params{})
 	assert.NoError(t, err)
 
-	call := Calls.Get("job/status")
+	call := rc.Calls.Get("job/status")
 	assert.NotNil(t, call)
-	in := Params{"jobid": 1}
+	in := rc.Params{"jobid": 1}
 	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
@@ -216,12 +217,12 @@ func TestRcJobStatus(t *testing.T) {
 	assert.Equal(t, false, out["finished"])
 	assert.Equal(t, false, out["success"])
 
-	in = Params{"jobid": 123123123}
+	in = rc.Params{"jobid": 123123123}
 	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "job not found")
 
-	in = Params{"jobidx": 123123123}
+	in = rc.Params{"jobidx": 123123123}
 	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Didn't find key")
@@ -229,45 +230,45 @@ func TestRcJobStatus(t *testing.T) {
 
 func TestRcJobList(t *testing.T) {
 	jobID = 0
-	_, err := StartJob(longFn, Params{})
+	_, err := StartJob(longFn, rc.Params{})
 	assert.NoError(t, err)
 
-	call := Calls.Get("job/list")
+	call := rc.Calls.Get("job/list")
 	assert.NotNil(t, call)
-	in := Params{}
+	in := rc.Params{}
 	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	assert.Equal(t, Params{"jobids": []int64{1}}, out)
+	assert.Equal(t, rc.Params{"jobids": []int64{1}}, out)
 }
 
 func TestRcJobStop(t *testing.T) {
 	jobID = 0
-	_, err := StartJob(ctxFn, Params{})
+	_, err := StartJob(ctxFn, rc.Params{})
 	assert.NoError(t, err)
 
-	call := Calls.Get("job/stop")
+	call := rc.Calls.Get("job/stop")
 	assert.NotNil(t, call)
-	in := Params{"jobid": 1}
+	in := rc.Params{"jobid": 1}
 	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.Empty(t, out)
 
-	in = Params{"jobid": 123123123}
+	in = rc.Params{"jobid": 123123123}
 	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "job not found")
 
-	in = Params{"jobidx": 123123123}
+	in = rc.Params{"jobidx": 123123123}
 	_, err = call.Fn(context.Background(), in)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Didn't find key")
 
 	time.Sleep(10 * time.Millisecond)
 
-	call = Calls.Get("job/status")
+	call = rc.Calls.Get("job/status")
 	assert.NotNil(t, call)
-	in = Params{"jobid": 1}
+	in = rc.Params{"jobid": 1}
 	out, err = call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	require.NotNil(t, out)

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ncw/rclone/fs/config"
 	"github.com/ncw/rclone/fs/list"
 	"github.com/ncw/rclone/fs/rc"
+	"github.com/ncw/rclone/fs/rc/jobs"
 	"github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 )
@@ -185,7 +186,7 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 	fs.Debugf(nil, "rc: %q: with parameters %+v", path, in)
 	var out rc.Params
 	if isAsync {
-		out, err = rc.StartJob(call.Fn, in)
+		out, err = jobs.StartJob(call.Fn, in)
 	} else {
 		out, err = call.Fn(r.Context(), in)
 	}

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -255,7 +255,7 @@ func (s *syncCopyMove) pairChecker(in *pipe, out *pipe, wg *sync.WaitGroup) {
 				}
 			}
 		}
-		accounting.Stats.DoneChecking(src.Remote())
+		accounting.Stats.DoneCheckingObj(s.ctx, src)
 	}
 }
 
@@ -591,7 +591,7 @@ func (s *syncCopyMove) makeRenameMap() {
 					if hash != "" {
 						s.pushRenameMap(hash, obj)
 					}
-					accounting.Stats.DoneChecking(obj.Remote())
+					accounting.Stats.DoneCheckingObj(s.ctx, obj)
 				}
 			}
 		}()

--- a/vfs/read.go
+++ b/vfs/read.go
@@ -70,7 +70,7 @@ func (fh *ReadFileHandle) openPending() (err error) {
 	if err != nil {
 		return err
 	}
-	fh.r = accounting.NewAccount(r, o).WithBuffer() // account the transfer
+	fh.r = accounting.Stats.NewAccount(context.TODO(), r, o).WithBuffer() // account the transfer
 	fh.opened = true
 	accounting.Stats.Transferring(o.Remote())
 	return nil
@@ -347,7 +347,7 @@ func (fh *ReadFileHandle) close() error {
 	fh.closed = true
 
 	if fh.opened {
-		accounting.Stats.DoneTransferring(fh.remote, true)
+		accounting.Stats.DoneTransferring(context.TODO(), fh.remote, nil)
 		// Close first so that we have hashes
 		err := fh.r.Close()
 		if err != nil {

--- a/vfs/read_write.go
+++ b/vfs/read_write.go
@@ -89,7 +89,7 @@ func copyObj(f fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Ob
 	if operations.NeedTransfer(context.TODO(), dst, src) {
 		accounting.Stats.Transferring(src.Remote())
 		newDst, err = operations.Copy(context.TODO(), f, dst, remote, src)
-		accounting.Stats.DoneTransferring(src.Remote(), err == nil)
+		accounting.Stats.DoneTransferring(context.TODO(), src.Remote(), err)
 	} else {
 		newDst = dst
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Currently accounting is keeping track of transfers by only showing transfers that are currently underway. All completed transfers are removed from this list and only reference to them is incremented counter.

This makes it difficult to keep track of what was transferred or the per transfer reason of why it failed and at what point. So history of transfers is kept in memory and made available to the `core/transferred` call.

#### Implemented changes

- Change accounting to keep track of transfers that have been completed
- Add rc call for getting list of recently completed transfers
- Transfer history retention time is configurable
- If file transfers are part of an async job they are marked with jobid
- Added per file transfer error description

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
