### PR TITLE
fs/config: Add method to reload configfile from disk

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -1340,6 +1340,16 @@ func FileDeleteKey(section, key string) bool {
 
 var matchEnv = regexp.MustCompile(`^RCLONE_CONFIG_(.*?)_TYPE=.*$`)
 
+// FileRefresh ensures the latest configFile is loaded from disk
+func FileRefresh() error {
+	reloadedConfigFile, err := loadConfigFile()
+	if err != nil {
+		return err
+	}
+	configFile = reloadedConfigFile
+	return nil
+}
+
 // FileSections returns the sections in the config file
 // including any defined by environment variables.
 func FileSections() []string {


### PR DESCRIPTION
Fixes #3268

#### What is the purpose of this change?

Allowing a configfile to be re-read from disk when you expect there might have been changes that were written from an other please.

#### Was the change discussed in an issue or in the forum before?

Yes in #3268

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
