### PR TITLE
march: return errors when listing dirs

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -778,7 +778,7 @@ func CheckFn(ctx context.Context, fdst, fsrc fs.Fs, check checkFn, oneway bool) 
 		Callback: c,
 	}
 	fs.Infof(fdst, "Waiting for checks to finish")
-	m.Run()
+	err := m.Run()
 
 	if c.dstFilesMissing > 0 {
 		fs.Logf(fdst, "%d files missing", c.dstFilesMissing)
@@ -797,7 +797,7 @@ func CheckFn(ctx context.Context, fdst, fsrc fs.Fs, check checkFn, oneway bool) 
 	if c.differences > 0 {
 		return errors.Errorf("%d differences found", c.differences)
 	}
-	return nil
+	return err
 }
 
 // Check the files in fsrc and fdst according to Size and hash

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -378,6 +378,19 @@ func TestCheck(t *testing.T) {
 	testCheck(t, operations.Check)
 }
 
+func TestCheckFsError(t *testing.T) {
+	dstFs, err := fs.NewFs("non-existent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcFs, err := fs.NewFs("non-existent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = operations.Check(context.Background(), dstFs, srcFs, false)
+	require.Error(t, err)
+}
+
 func TestCheckDownload(t *testing.T) {
 	testCheck(t, operations.CheckDownload)
 }

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -666,7 +666,7 @@ func (s *syncCopyMove) run() error {
 		Callback:      s,
 		DstIncludeAll: filter.Active.Opt.DeleteExcluded,
 	}
-	m.Run()
+	s.processError(m.Run())
 
 	s.stopTrackRenames()
 	if s.trackRenames {

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -64,6 +64,20 @@ func TestCopy(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 }
 
+func TestCopyMissingDirectory(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+	r.Mkdir(context.Background(), r.Fremote)
+
+	nonExistingFs, err := fs.NewFs("/non-existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = CopyDir(context.Background(), r.Fremote, nonExistingFs, false)
+	require.Error(t, err)
+}
+
 // Now with --no-traverse
 func TestCopyNoTraverse(t *testing.T) {
 	r := fstest.NewRun(t)


### PR DESCRIPTION
#### Was the change discussed in an issue or in the forum before?

Partially fixes #3172

#### What is the purpose of this change?

As described in linked issue errors in file system access are not returned when copying/moving. This change corrects that by catching any listing errors.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
