### PR TITLE
zsh: sort the commands to keep a determinist output

### DIFF
--- a/vendor/github.com/spf13/cobra/zsh_completions.go
+++ b/vendor/github.com/spf13/cobra/zsh_completions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -81,9 +82,18 @@ func writeLevel(w io.Writer, root *Command, i int) {
 	commands := filterByLevel(root, i)
 	byParent := groupByParent(commands)
 
-	for p, c := range byParent {
-		names := names(c)
-		fmt.Fprintf(w, "      %s)\n", p)
+	// sort the parents to keep a determinist order
+	parents := make([]string, len(byParent))
+	j := 0
+	for parent := range byParent {
+		parents[j] = parent
+		j++
+	}
+	sort.StringSlice(parents).Sort()
+
+	for _, parent := range parents {
+		names := names(byParent[parent])
+		fmt.Fprintf(w, "      %s)\n", parent)
 		fmt.Fprintf(w, "        _arguments '%d: :(%s)'\n", i, strings.Join(names, " "))
 		fmt.Fprintln(w, "      ;;")
 	}


### PR DESCRIPTION
Make the rclone package build reproducible


no

For background information see https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/hash and https://reproducible-builds.org/


- [ ] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)

Based on https://github.com/spf13/cobra/pull/801

Tested By: Bernhard M. Wiedemann

The alternative fix would be to update spf13/cobra - there this codepath has been rewritten.