### PR TITLE
sftp: Completely ignore all modtime checks if SetModTime=false

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -1022,16 +1022,17 @@ func (o *Object) stat() error {
 //
 // it also updates the info field
 func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
+	if !o.fs.opt.SetModTime {
+		return nil
+	}
 	c, err := o.fs.getSftpConnection()
 	if err != nil {
 		return errors.Wrap(err, "SetModTime")
 	}
-	if o.fs.opt.SetModTime {
-		err = c.sftpClient.Chtimes(o.path(), modTime, modTime)
-		o.fs.putSftpConnection(&c, err)
-		if err != nil {
-			return errors.Wrap(err, "SetModTime failed")
-		}
+	err = c.sftpClient.Chtimes(o.path(), modTime, modTime)
+	o.fs.putSftpConnection(&c, err)
+	if err != nil {
+		return errors.Wrap(err, "SetModTime failed")
 	}
 	err = o.stat()
 	if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

Adjusted the logic in the SetModTime function to completely disable all checks associated with the update if sftp-set-modtime is disabled.

This handles really odd edge cases where an SFTP server will remove the file immediately upon upload (for example, as part of a batch processing workflow). If the file is removed, the SetModTime function still attempts to stat() the file, which does not at that point in time exist.

The code should be pretty obvious in what it's doing 😄 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
