### PR TITLE
context: fix errgroup interaction with context

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1762,18 +1762,18 @@ func DirMove(ctx context.Context, f fs.Fs, srcRemote, dstRemote string) (err err
 		newPath string
 	}
 	renames := make(chan rename, fs.Config.Transfers)
-	g, ctx := errgroup.WithContext(context.Background())
+	g, gCtx := errgroup.WithContext(context.Background())
 	for i := 0; i < fs.Config.Transfers; i++ {
 		g.Go(func() error {
 			for job := range renames {
-				dstOverwritten, _ := f.NewObject(ctx, job.newPath)
-				_, err := Move(ctx, f, dstOverwritten, job.newPath, job.o)
+				dstOverwritten, _ := f.NewObject(gCtx, job.newPath)
+				_, err := Move(gCtx, f, dstOverwritten, job.newPath, job.o)
 				if err != nil {
 					return err
 				}
 				select {
-				case <-ctx.Done():
-					return ctx.Err()
+				case <-gCtx.Done():
+					return gCtx.Err()
 				default:
 				}
 


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes #3307

`errgroup` wraps context with new one that is canceled once the first Go routine from the group returns. We should use separate context for operations related to this part.

I haven't tested this as I can't run integration tests.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
