### PR TITLE
Update docs on S3 policy to include ListAllMyBuckets permission

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -351,6 +351,8 @@ permissions are required to be available on the bucket being written to:
 * `PutObject`
 * `PutObjectACL`
 
+When using the `lsd` subcommand, the `ListAllMyBuckets` permission is required.
+
 Example policy:
 
 ```
@@ -373,7 +375,12 @@ Example policy:
               "arn:aws:s3:::BUCKET_NAME/*",
               "arn:aws:s3:::BUCKET_NAME"
             ]
-        }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:ListAllMyBuckets",
+            "Resource": "arn:aws:s3:::*"
+        }	
     ]
 }
 ```


### PR DESCRIPTION
This permission is required for `rclone lsd`.

#### Was the change discussed in an issue or in the forum before?

PR that added the policy docs: https://github.com/ncw/rclone/issues/1455

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
