### PR TITLE
Attempt to fix #1810

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -86,7 +86,7 @@ when the ssh-agent contains many keys.`,
 			Default: false,
 		}, {
 			Name:    "use_insecure_cipher",
-			Help:    "Enable the use of the aes128-cbc cipher. This cipher is insecure and may allow plaintext data to be recovered by an attacker.",
+			Help:    "Enable the use of the aes128-cbc cipher and diffie-hellman-group-exchange-sha256, diffie-hellman-group-exchange-sha1 key exchange. Those algorithms are insecure and may allow plaintext data to be recovered by an attacker.",
 			Default: false,
 			Examples: []fs.OptionExample{
 				{
@@ -94,7 +94,7 @@ when the ssh-agent contains many keys.`,
 					Help:  "Use default Cipher list.",
 				}, {
 					Value: "true",
-					Help:  "Enables the use of the aes128-cbc cipher.",
+					Help:  "Enables the use of the aes128-cbc cipher and diffie-hellman-group-exchange-sha256, diffie-hellman-group-exchange-sha1 key exchange.",
 				},
 			},
 		}, {
@@ -345,6 +345,7 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 	if opt.UseInsecureCipher {
 		sshConfig.Config.SetDefaults()
 		sshConfig.Config.Ciphers = append(sshConfig.Config.Ciphers, "aes128-cbc")
+		sshConfig.Config.KeyExchanges = append(sshConfig.Config.KeyExchanges, "diffie-hellman-group-exchange-sha1", "diffie-hellman-group-exchange-sha256")
 	}
 
 	keyFile := env.ShellExpand(opt.KeyFile)

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -75,22 +75,22 @@ host> example.com
 SSH username, leave blank for current username, ncw
 user> sftpuser
 SSH port, leave blank to use default (22)
-port> 
+port>
 SSH password, leave blank to use ssh-agent.
 y) Yes type in my own password
 g) Generate random password
 n) No leave this optional password blank
 y/g/n> n
 Path to unencrypted PEM-encoded private key file, leave blank to use ssh-agent.
-key_file> 
+key_file>
 Remote config
 --------------------
 [remote]
 host = example.com
 user = sftpuser
-port = 
-pass = 
-key_file = 
+port =
+pass =
+key_file =
 --------------------
 y) Yes this is OK
 e) Edit this remote
@@ -243,7 +243,7 @@ when the ssh-agent contains many keys.
 
 #### --sftp-use-insecure-cipher
 
-Enable the use of the aes128-cbc cipher. This cipher is insecure and may allow plaintext data to be recovered by an attacker.
+Enable the use of the aes128-cbc cipher and diffie-hellman-group-exchange-sha256, diffie-hellman-group-exchange-sha1 key exchange. Those algorithms are insecure and may allow plaintext data to be recovered by an attacker.
 
 - Config:      use_insecure_cipher
 - Env Var:     RCLONE_SFTP_USE_INSECURE_CIPHER
@@ -253,7 +253,7 @@ Enable the use of the aes128-cbc cipher. This cipher is insecure and may allow p
     - "false"
         - Use default Cipher list.
     - "true"
-        - Enables the use of the aes128-cbc cipher.
+        - Enables the use of the aes128-cbc cipher and diffie-hellman-group-exchange-sha256, diffie-hellman-group-exchange-sha1 key exchange.
 
 #### --sftp-disable-hashcheck
 
@@ -325,7 +325,7 @@ return the total space, free space, and used space on the remote
 for the disk of the specified path on the remote or, if not set,
 the disk of the root on the remote.
 `about` will fail if it does not have shell
-access or if `df` is not in the remote's PATH. 
+access or if `df` is not in the remote's PATH.
 
 Note that some SFTP servers (eg Synology) the paths are different for
 SSH and SFTP so the hashes can't be calculated properly.  For them


### PR DESCRIPTION
rclone doesn't support 2 SSH key exchange algorithms `diffie-hellman-group-exchange-sha256` and `diffie-hellman-group-exchange-sha1` due to the upstream package `crypto` didn't support it.

The upstream lib `crypto` has recently added support for those algorithms in this [commit](https://github.com/golang/crypto/commit/57b3e21c3d5606066a87e63cfe07ec6b9f0db000)

However, since `diffie-hellman-group-exchange-sha256` and `diffie-hellman-group-exchange-sha1` are not recommended, see this [proposal](https://tools.ietf.org/id/draft-baushke-ssh-dh-group-sha2-05.xml). They need to be opt-in explicitly by the client, in this case, rclone.

This PR attemps to opt-in `diffie-hellman-group-exchange-sha256` and `diffie-hellman-group-exchange-sha1` when the flag `--sftp-use-insecure-cipher` is set to true.


- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)