### PR TITLE
fichier: make FolderID int and adjust related code - fixes #3359

### DIFF
--- a/backend/fichier/api.go
+++ b/backend/fichier/api.go
@@ -88,7 +88,7 @@ func (f *Fs) listSharedFiles(ctx context.Context, id string) (entries fs.DirEntr
 	return entries, nil
 }
 
-func (f *Fs) listFiles(directoryID string) (filesList *FilesList, err error) {
+func (f *Fs) listFiles(directoryID int) (filesList *FilesList, err error) {
 	// fs.Debugf(f, "Requesting files for dir `%s`", directoryID)
 	request := ListFilesRequest{
 		FolderID: directoryID,
@@ -111,7 +111,7 @@ func (f *Fs) listFiles(directoryID string) (filesList *FilesList, err error) {
 	return filesList, nil
 }
 
-func (f *Fs) listFolders(directoryID string) (foldersList *FoldersList, err error) {
+func (f *Fs) listFolders(directoryID int) (foldersList *FoldersList, err error) {
 	// fs.Debugf(f, "Requesting folders for id `%s`", directoryID)
 
 	request := ListFolderRequest{
@@ -148,12 +148,17 @@ func (f *Fs) listDir(ctx context.Context, dir string) (entries fs.DirEntries, er
 		return nil, err
 	}
 
-	files, err := f.listFiles(directoryID)
+	folderID, err := strconv.Atoi(directoryID)
 	if err != nil {
 		return nil, err
 	}
 
-	folders, err := f.listFolders(directoryID)
+	files, err := f.listFiles(folderID)
+	if err != nil {
+		return nil, err
+	}
+
+	folders, err := f.listFolders(folderID)
 	if err != nil {
 		return nil, err
 	}
@@ -199,12 +204,12 @@ func getRemote(dir, fileName string) string {
 	return dir + "/" + fileName
 }
 
-func (f *Fs) makeFolder(leaf, directoryID string) (response *MakeFolderResponse, err error) {
+func (f *Fs) makeFolder(leaf string, folderID int) (response *MakeFolderResponse, err error) {
 	name := replaceReservedChars(leaf)
 	// fs.Debugf(f, "Creating folder `%s` in id `%s`", name, directoryID)
 
 	request := MakeFolderRequest{
-		FolderID: directoryID,
+		FolderID: folderID,
 		Name:     name,
 	}
 
@@ -227,11 +232,11 @@ func (f *Fs) makeFolder(leaf, directoryID string) (response *MakeFolderResponse,
 	return response, err
 }
 
-func (f *Fs) removeFolder(name, directoryID string) (response *GenericOKResponse, err error) {
+func (f *Fs) removeFolder(name string, folderID int) (response *GenericOKResponse, err error) {
 	// fs.Debugf(f, "Removing folder with id `%s`", directoryID)
 
 	request := &RemoveFolderRequest{
-		FolderID: directoryID,
+		FolderID: folderID,
 	}
 
 	opts := rest.Opts{

--- a/backend/fichier/fichier.go
+++ b/backend/fichier/fichier.go
@@ -70,7 +70,11 @@ type Fs struct {
 
 // FindLeaf finds a directory of name leaf in the folder with ID pathID
 func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
-	folders, err := f.listFolders(pathID)
+	folderID, err := strconv.Atoi(pathID)
+	if err != nil {
+		return "", false, err
+	}
+	folders, err := f.listFolders(folderID)
 	if err != nil {
 		return "", false, err
 	}
@@ -87,7 +91,11 @@ func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut strin
 
 // CreateDir makes a directory with pathID as parent and name leaf
 func (f *Fs) CreateDir(ctx context.Context, pathID, leaf string) (newID string, err error) {
-	resp, err := f.makeFolder(leaf, pathID)
+	folderID, err := strconv.Atoi(pathID)
+	if err != nil {
+		return "", err
+	}
+	resp, err := f.makeFolder(leaf, folderID)
 	if err != nil {
 		return "", err
 	}
@@ -239,7 +247,11 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 		return nil, err
 	}
 
-	files, err := f.listFiles(directoryID)
+	folderID, err := strconv.Atoi(directoryID)
+	if err != nil {
+		return nil, err
+	}
+	files, err := f.listFiles(folderID)
 	if err != nil {
 		return nil, err
 	}
@@ -371,12 +383,17 @@ func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 		return err
 	}
 
-	did, err := f.dirCache.FindDir(ctx, dir, false)
+	directoryID, err := f.dirCache.FindDir(ctx, dir, false)
 	if err != nil {
 		return err
 	}
 
-	_, err = f.removeFolder(dir, did)
+	folderID, err := strconv.Atoi(directoryID)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.removeFolder(dir, folderID)
 	if err != nil {
 		return err
 	}

--- a/backend/fichier/structs.go
+++ b/backend/fichier/structs.go
@@ -2,12 +2,12 @@ package fichier
 
 // ListFolderRequest is the request structure of the corresponding request
 type ListFolderRequest struct {
-	FolderID string `json:"folder_id"`
+	FolderID int `json:"folder_id"`
 }
 
 // ListFilesRequest is the request structure of the corresponding request
 type ListFilesRequest struct {
-	FolderID string `json:"folder_id"`
+	FolderID int `json:"folder_id"`
 }
 
 // DownloadRequest is the request structure of the corresponding request
@@ -18,7 +18,7 @@ type DownloadRequest struct {
 
 // RemoveFolderRequest is the request structure of the corresponding request
 type RemoveFolderRequest struct {
-	FolderID string `json:"folder_id"`
+	FolderID int `json:"folder_id"`
 }
 
 // RemoveFileRequest is the request structure of the corresponding request
@@ -40,7 +40,7 @@ type GenericOKResponse struct {
 // MakeFolderRequest is the request structure of the corresponding request
 type MakeFolderRequest struct {
 	Name     string `json:"name"`
-	FolderID string `json:"folder_id"`
+	FolderID int    `json:"folder_id"`
 }
 
 // MakeFolderResponse is the response structure of the corresponding request
@@ -108,12 +108,12 @@ type Folder struct {
 	CreateDate string `json:"create_date"`
 	ID         int    `json:"id"`
 	Name       string `json:"name"`
-	Pass       string `json:"pass"`
+	Pass       int    `json:"pass"`
 }
 
 // FoldersList is the structure how 1Fichier returns a list of Folders
 type FoldersList struct {
-	FolderID   string   `json:"folder_id"`
+	FolderID   int      `json:"folder_id"`
 	Name       string   `json:"name"`
 	Status     string   `json:"Status"`
 	SubFolders []Folder `json:"sub_folders"`


### PR DESCRIPTION
API now provides folder_id and pass as number which go doens't want to unmarshal into string so make them int instead. Requires a little more converting between string and int because of dir cache but not a big deal.