### PR TITLE
Improve accounting

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1080,16 +1080,16 @@ func (f *Fs) purge(ctx context.Context, oldOnly bool) error {
 		go func() {
 			defer wg.Done()
 			for object := range toBeDeleted {
-				accounting.Stats.Checking(object.Name)
+				accounting.Stats(ctx).Checking(object.Name)
 				checkErr(f.deleteByID(object.ID, object.Name))
-				accounting.Stats.DoneChecking(object.Name)
+				accounting.Stats(ctx).DoneChecking(object.Name)
 			}
 		}()
 	}
 	last := ""
 	checkErr(f.list(ctx, "", true, "", 0, true, func(remote string, object *api.File, isDirectory bool) error {
 		if !isDirectory {
-			accounting.Stats.Checking(remote)
+			accounting.Stats(ctx).Checking(remote)
 			if oldOnly && last != remote {
 				if object.Action == "hide" {
 					fs.Debugf(remote, "Deleting current version (id %q) as it is a hide marker", object.ID)
@@ -1105,7 +1105,7 @@ func (f *Fs) purge(ctx context.Context, oldOnly bool) error {
 				toBeDeleted <- object
 			}
 			last = remote
-			accounting.Stats.DoneChecking(remote)
+			accounting.Stats(ctx).DoneChecking(remote)
 		}
 		return nil
 	}))

--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -548,12 +548,12 @@ func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *api.Fil
 	if info != nil {
 		err := o.decodeMetaData(info)
 		if err != nil {
-			return nil, err
+			return o, err
 		}
 	} else {
 		err := o.readMetaData(ctx) // reads info and headers, returning an error
 		if err != nil {
-			return nil, err
+			return o, err
 		}
 	}
 	return o, nil
@@ -1080,16 +1080,25 @@ func (f *Fs) purge(ctx context.Context, oldOnly bool) error {
 		go func() {
 			defer wg.Done()
 			for object := range toBeDeleted {
-				accounting.Stats(ctx).Checking(object.Name)
-				checkErr(f.deleteByID(object.ID, object.Name))
-				accounting.Stats(ctx).DoneChecking(object.Name)
+				oi, err := f.newObjectWithInfo(ctx, object.Name, object)
+				if err != nil {
+					fs.Errorf(object, "Can't create object %+v", err)
+				}
+				tr := accounting.Stats(ctx).NewCheckingTransfer(oi)
+				err = f.deleteByID(object.ID, object.Name)
+				checkErr(err)
+				tr.Done(err)
 			}
 		}()
 	}
 	last := ""
 	checkErr(f.list(ctx, "", true, "", 0, true, func(remote string, object *api.File, isDirectory bool) error {
 		if !isDirectory {
-			accounting.Stats(ctx).Checking(remote)
+			oi, err := f.newObjectWithInfo(ctx, object.Name, object)
+			if err != nil {
+				fs.Errorf(object, "Can't create object %+v", err)
+			}
+			tr := accounting.Stats(ctx).NewCheckingTransfer(oi)
 			if oldOnly && last != remote {
 				if object.Action == "hide" {
 					fs.Debugf(remote, "Deleting current version (id %q) as it is a hide marker", object.ID)
@@ -1105,7 +1114,7 @@ func (f *Fs) purge(ctx context.Context, oldOnly bool) error {
 				toBeDeleted <- object
 			}
 			last = remote
-			accounting.Stats(ctx).DoneChecking(remote)
+			tr.Done(nil)
 		}
 		return nil
 	}))

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -359,7 +359,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 		err = errors.Wrapf(err, "failed to open directory %q", dir)
 		fs.Errorf(dir, "%v", err)
 		if isPerm {
-			accounting.Stats.Error(fserrors.NoRetryError(err))
+			accounting.Stats(ctx).Error(fserrors.NoRetryError(err))
 			err = nil // ignore error but fail sync
 		}
 		return nil, err
@@ -395,7 +395,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 					if fierr != nil {
 						err = errors.Wrapf(err, "failed to read directory %q", namepath)
 						fs.Errorf(dir, "%v", fierr)
-						accounting.Stats.Error(fserrors.NoRetryError(fierr)) // fail the sync
+						accounting.Stats(ctx).Error(fserrors.NoRetryError(fierr)) // fail the sync
 						continue
 					}
 					fis = append(fis, fi)
@@ -418,7 +418,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 					// Skip bad symlinks
 					err = fserrors.NoRetryError(errors.Wrap(err, "symlink"))
 					fs.Errorf(newRemote, "Listing error: %v", err)
-					accounting.Stats.Error(err)
+					accounting.Stats(ctx).Error(err)
 					continue
 				}
 				if err != nil {

--- a/cmd/progress.go
+++ b/cmd/progress.go
@@ -93,7 +93,7 @@ func printProgress(logMessage string) {
 		w, h = 80, 25
 	}
 	_ = h
-	stats := strings.TrimSpace(accounting.Stats.String())
+	stats := strings.TrimSpace(accounting.GlobalStats().String())
 	logMessage = strings.TrimSpace(logMessage)
 
 	out := func(s string) {

--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -214,8 +214,10 @@ func (d *Driver) ListDir(path string, callback func(ftp.FileInfo) error) (err er
 	}
 
 	// Account the transfer
-	accounting.Stats.Transferring(path)
-	defer accounting.Stats.DoneTransferring(path, true)
+	tr := accounting.Stats.NewTransferRemoteSize(path, node.Size())
+	defer func() {
+		tr.Done(err)
+	}()
 
 	for _, file := range dirEntries {
 		err = callback(&FileInfo{file, file.Mode(), d.vfs.Opt.UID, d.vfs.Opt.GID})
@@ -311,8 +313,8 @@ func (d *Driver) GetFile(path string, offset int64) (size int64, fr io.ReadClose
 	}
 
 	// Account the transfer
-	accounting.Stats.Transferring(path)
-	defer accounting.Stats.DoneTransferring(path, true)
+	tr := accounting.Stats.NewTransferRemoteSize(path, node.Size())
+	defer tr.Done(nil)
 
 	return node.Size(), handle, nil
 }

--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -214,7 +214,7 @@ func (d *Driver) ListDir(path string, callback func(ftp.FileInfo) error) (err er
 	}
 
 	// Account the transfer
-	tr := accounting.Stats.NewTransferRemoteSize(path, node.Size())
+	tr := accounting.GlobalStats().NewTransferRemoteSize(path, node.Size())
 	defer func() {
 		tr.Done(err)
 	}()
@@ -313,7 +313,7 @@ func (d *Driver) GetFile(path string, offset int64) (size int64, fr io.ReadClose
 	}
 
 	// Account the transfer
-	tr := accounting.Stats.NewTransferRemoteSize(path, node.Size())
+	tr := accounting.GlobalStats().NewTransferRemoteSize(path, node.Size())
 	defer tr.Done(nil)
 
 	return node.Size(), handle, nil

--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -187,7 +187,7 @@ func (s *server) serveFile(w http.ResponseWriter, r *http.Request, remote string
 	}()
 
 	// Account the transfer
-	tr := accounting.Stats.NewTransfer(obj)
+	tr := accounting.Stats(r.Context()).NewTransfer(obj)
 	defer tr.Done(nil)
 	// FIXME in = fs.NewAccount(in, obj).WithBuffer() // account the transfer
 

--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -187,8 +187,8 @@ func (s *server) serveFile(w http.ResponseWriter, r *http.Request, remote string
 	}()
 
 	// Account the transfer
-	accounting.Stats.Transferring(remote)
-	defer accounting.Stats.DoneTransferring(remote, true)
+	tr := accounting.Stats.NewTransfer(obj)
+	defer tr.Done(nil)
 	// FIXME in = fs.NewAccount(in, obj).WithBuffer() // account the transfer
 
 	// Serve the file

--- a/cmd/serve/httplib/serve/dir.go
+++ b/cmd/serve/httplib/serve/dir.go
@@ -75,8 +75,8 @@ func Error(what interface{}, w http.ResponseWriter, text string, err error) {
 // Serve serves a directory
 func (d *Directory) Serve(w http.ResponseWriter, r *http.Request) {
 	// Account the transfer
-	accounting.Stats.Transferring(d.DirRemote)
-	defer accounting.Stats.DoneTransferring(d.DirRemote, true)
+	tr := accounting.Stats.NewTransferRemoteSize(d.DirRemote, -1)
+	defer tr.Done(nil)
 
 	fs.Infof(d.DirRemote, "%s: Serving directory", r.RemoteAddr)
 

--- a/cmd/serve/httplib/serve/dir.go
+++ b/cmd/serve/httplib/serve/dir.go
@@ -75,7 +75,7 @@ func Error(what interface{}, w http.ResponseWriter, text string, err error) {
 // Serve serves a directory
 func (d *Directory) Serve(w http.ResponseWriter, r *http.Request) {
 	// Account the transfer
-	tr := accounting.Stats.NewTransferRemoteSize(d.DirRemote, -1)
+	tr := accounting.Stats(r.Context()).NewTransferRemoteSize(d.DirRemote, -1)
 	defer tr.Done(nil)
 
 	fs.Infof(d.DirRemote, "%s: Serving directory", r.RemoteAddr)

--- a/cmd/serve/httplib/serve/serve.go
+++ b/cmd/serve/httplib/serve/serve.go
@@ -75,7 +75,7 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
-	tr := accounting.Stats.NewTransfer(o)
+	tr := accounting.Stats(r.Context()).NewTransfer(o)
 	defer func() {
 		tr.Done(err)
 	}()

--- a/cmd/serve/httplib/serve/serve.go
+++ b/cmd/serve/httplib/serve/serve.go
@@ -75,22 +75,11 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
-	accounting.Stats.Transferring(o.Remote())
-	in := accounting.NewAccount(file, o) // account the transfer (no buffering)
+	tr := accounting.Stats.NewTransfer(o)
 	defer func() {
-		closeErr := in.Close()
-		if closeErr != nil {
-			fs.Errorf(o, "Get request: close failed: %v", closeErr)
-			if err == nil {
-				err = closeErr
-			}
-		}
-		ok := err == nil
-		accounting.Stats.DoneTransferring(o.Remote(), ok)
-		if !ok {
-			accounting.Stats.Error(err)
-		}
+		tr.Done(err)
 	}()
+	in := tr.Account(file) // account the transfer (no buffering)
 
 	w.WriteHeader(code)
 

--- a/cmd/serve/restic/restic.go
+++ b/cmd/serve/restic/restic.go
@@ -271,7 +271,7 @@ func (s *server) postObject(w http.ResponseWriter, r *http.Request, remote strin
 
 	_, err := operations.RcatSize(r.Context(), s.f, remote, r.Body, r.ContentLength, time.Now())
 	if err != nil {
-		accounting.Stats.Error(err)
+		accounting.Stats(r.Context()).Error(err)
 		fs.Errorf(remote, "Post request rcat error: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 

--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -150,6 +150,9 @@ The rc interface supports some special parameters which apply to
 
 ### Running asynchronous jobs with _async = true
 
+Each rc call is classified as a job and it is assigned its own id. By default
+jobs are executed immediately as they are created or synchronously.
+
 If `_async` has a true value when supplied to an rc call then it will
 return immediately with a job id and the task will be run in the
 background.  The `job/status` call can be used to get information of
@@ -207,6 +210,25 @@ $ rclone rc job/list
 	"jobids": [
 		2
 	]
+}
+```
+
+### Assigning operations to groups with _group = <value>
+
+Each rc call has it's own stats group for tracking it's metrics. By default
+grouping is done by the composite group name from prefix `job/` and  id of the
+job like so `job/1`.
+
+If `_group` has a value then stats for that request will be grouped under that
+value. This allows caller to group stats under their own name.
+
+Stats for specific group can be accessed by passing `group` to `core/stats`:
+
+```
+$ rclone rc --json '{ "group": "job/1" }' core/stats
+{
+	"speed": 12345
+	...
 }
 ```
 
@@ -342,17 +364,52 @@ This sets the bandwidth limit to that passed in.
 
 Eg
 
-    rclone rc core/bwlimit rate=1M
     rclone rc core/bwlimit rate=off
+    {
+        "bytesPerSecond": -1,
+        "rate": "off"
+    }
+    rclone rc core/bwlimit rate=1M
+    {
+        "bytesPerSecond": 1048576,
+        "rate": "1M"
+    }
+
+
+If the rate parameter is not suppied then the bandwidth is queried
+
+    rclone rc core/bwlimit
+    {
+        "bytesPerSecond": 1048576,
+        "rate": "1M"
+    }
 
 The format of the parameter is exactly the same as passed to --bwlimit
 except only one bandwidth may be specified.
+
+In either case "rate" is returned as a human readable string, and
+"bytesPerSecond" is returned as a number.
 
 ### core/gc: Runs a garbage collection.
 
 This tells the go runtime to do a garbage collection run.  It isn't
 necessary to call this normally, but it can be useful for debugging
 memory problems.
+
+### core/group_list: Returns list of stats.
+
+This returns list of stats groups currently in memory. 
+
+Returns the following values:
+```
+{
+	"groups":  an array of group names:
+		[
+			"group1",
+			"group2",
+			...
+		]
+}
 
 ### core/memstats: Returns the memory statistics
 
@@ -381,9 +438,15 @@ Useful for stopping rclone process.
 
 ### core/stats: Returns stats about current transfers.
 
-This returns all available stats
+This returns all available stats:
 
 	rclone rc core/stats
+
+If group is not provided then summed up stats for all groups will be
+returned.
+
+Parameters
+- group - name of the stats group (string)
 
 Returns the following values:
 
@@ -418,6 +481,35 @@ Returns the following values:
 Values for "transferring", "checking" and "lastError" are only assigned if data is available.
 The value for "eta" is null if an eta cannot be determined.
 
+### core/transferred: Returns stats about completed transfers.
+
+This returns stats about completed transfers:
+
+	rclone rc core/transferred
+
+If group is not provided then completed transfers for all groups will be
+returned.
+
+Parameters
+- group - name of the stats group (string)
+
+Returns the following values:
+```
+{
+	"transferred":  an array of completed transfers (including failed ones):
+		[
+			{
+				"name": name of the file,
+				"size": size of the file in bytes,
+				"bytes": total transferred bytes for this file,
+				"checked": if the transfer is only checked (skipped, deleted),
+				"timestamp": integer representing millisecond unix epoch,
+				"error": string description of the error (empty if successfull),
+				"jobid": id of the job that this transfer belongs to
+			}
+		]
+}
+
 ### core/version: Shows the current version of rclone and the go runtime.
 
 This shows the current version of go and the go runtime
@@ -451,6 +543,12 @@ Results
 - startTime - time the job started (eg "2018-10-26T18:50:20.528336039+01:00")
 - success - boolean - true for success false otherwise
 - output - output of the job as would have been returned if called synchronously
+- progress - output of the progress related to the underlying job
+
+### job/stop: Stop the running job
+
+Parameters
+- jobid - id of the job (integer)
 
 ### operations/about: Return the space used on the remote
 

--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -8,6 +8,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/ncw/rclone/fs/rc"
+
 	"github.com/ncw/rclone/fs"
 	"github.com/ncw/rclone/fs/asyncreader"
 	"github.com/ncw/rclone/fs/fserrors"
@@ -318,8 +320,8 @@ func (acc *Account) String() string {
 }
 
 // RemoteStats produces stats for this file
-func (acc *Account) RemoteStats() (out map[string]interface{}) {
-	out = make(map[string]interface{})
+func (acc *Account) RemoteStats() (out rc.Params) {
+	out = make(rc.Params)
 	a, b := acc.progress()
 	out["bytes"] = a
 	out["size"] = b

--- a/fs/accounting/inprogress.go
+++ b/fs/accounting/inprogress.go
@@ -39,3 +39,14 @@ func (ip *inProgress) get(name string) *Account {
 	defer ip.mu.Unlock()
 	return ip.m[name]
 }
+
+// merge adds items from another inProgress
+func (ip *inProgress) merge(m *inProgress) {
+	ip.mu.Lock()
+	defer ip.mu.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, val := range m.m {
+		ip.m[key] = val
+	}
+}

--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -63,9 +63,15 @@ func init() {
 		Fn:    remoteStats,
 		Title: "Returns stats about current transfers.",
 		Help: `
-This returns all available stats
+This returns all available stats:
 
 	rclone rc core/stats
+
+If group is not provided then summed up stats for all groups will be
+returned.
+
+Parameters
+- group - name of the stats group (string)
 
 Returns the following values:
 

--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -1,0 +1,189 @@
+package accounting
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ncw/rclone/fs/rc"
+
+	"github.com/ncw/rclone/fs"
+)
+
+const globalStats = "global_stats"
+
+var groups *statsGroups
+
+func remoteStats(ctx context.Context, in rc.Params) (rc.Params, error) {
+	// Check to see if we should filter by group.
+	group, err := in.GetString("group")
+	if rc.NotErrParamNotFound(err) {
+		return rc.Params{}, err
+	}
+	if group != "" {
+		return StatsGroup(group).RemoteStats()
+	}
+
+	return groups.sum().RemoteStats()
+}
+
+func init() {
+	// Init stats container
+	groups = newStatsGroups()
+
+	// Set the function pointer up in fs
+	fs.CountError = GlobalStats().Error
+
+	rc.Add(rc.Call{
+		Path:  "core/stats",
+		Fn:    remoteStats,
+		Title: "Returns stats about current transfers.",
+		Help: `
+This returns all available stats
+
+	rclone rc core/stats
+
+Returns the following values:
+
+` + "```" + `
+{
+	"speed": average speed in bytes/sec since start of the process,
+	"bytes": total transferred bytes since the start of the process,
+	"errors": number of errors,
+	"fatalError": whether there has been at least one FatalError,
+	"retryError": whether there has been at least one non-NoRetryError,
+	"checks": number of checked files,
+	"transfers": number of transferred files,
+	"deletes" : number of deleted files,
+	"elapsedTime": time in seconds since the start of the process,
+	"lastError": last occurred error,
+	"transferring": an array of currently active file transfers:
+		[
+			{
+				"bytes": total transferred bytes for this file,
+				"eta": estimated time in seconds until file transfer completion
+				"name": name of the file,
+				"percentage": progress of the file transfer in percent,
+				"speed": speed in bytes/sec,
+				"speedAvg": speed in bytes/sec as an exponentially weighted moving average,
+				"size": size of the file in bytes
+			}
+		],
+	"checking": an array of names of currently active file checks
+		[]
+}
+` + "```" + `
+Values for "transferring", "checking" and "lastError" are only assigned if data is available.
+The value for "eta" is null if an eta cannot be determined.
+`,
+	})
+}
+
+type statsGroupCtx int64
+
+const statsGroupKey statsGroupCtx = 1
+
+// WithStatsGroup returns copy of the parent context with assigned group.
+func WithStatsGroup(parent context.Context, group string) context.Context {
+	return context.WithValue(parent, statsGroupKey, group)
+}
+
+// StatsGroupFromContext returns group from the context if it's available.
+// Returns false if group is empty.
+func StatsGroupFromContext(ctx context.Context) (string, bool) {
+	statsGroup, ok := ctx.Value(statsGroupKey).(string)
+	if statsGroup == "" {
+		ok = false
+	}
+	return statsGroup, ok
+}
+
+// Stats gets stats by extracting group from context.
+func Stats(ctx context.Context) *StatsInfo {
+	group, ok := StatsGroupFromContext(ctx)
+	if !ok {
+		return GlobalStats()
+	}
+	return StatsGroup(group)
+}
+
+// StatsGroup gets stats by group name.
+func StatsGroup(group string) *StatsInfo {
+	stats := groups.get(group)
+	if stats == nil {
+		return NewStatsGroup(group)
+	}
+	return stats
+}
+
+// GlobalStats returns special stats used for global accounting.
+func GlobalStats() *StatsInfo {
+	return StatsGroup(globalStats)
+}
+
+// NewStatsGroup creates new stats under named group.
+func NewStatsGroup(group string) *StatsInfo {
+	stats := NewStats()
+	groups.set(group, stats)
+	return stats
+}
+
+// statsGroups holds a synchronized map of stats
+type statsGroups struct {
+	mu sync.Mutex
+	m  map[string]*StatsInfo
+}
+
+// newStatsGroups makes a new statsGroups object
+func newStatsGroups() *statsGroups {
+	return &statsGroups{
+		m: make(map[string]*StatsInfo),
+	}
+}
+
+// set marks the stats as belonging to a group
+func (sg *statsGroups) set(group string, acc *StatsInfo) {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sg.m[group] = acc
+}
+
+// clear discards reference to group
+func (sg *statsGroups) clear(group string) {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	delete(sg.m, group)
+}
+
+// get gets the stats for group, or nil if not found
+func (sg *statsGroups) get(group string) *StatsInfo {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	stats, ok := sg.m[group]
+	if !ok {
+		return nil
+	}
+	return stats
+}
+
+// get gets the stats for group, or nil if not found
+func (sg *statsGroups) sum() *StatsInfo {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+	sum := NewStats()
+	for _, stats := range sg.m {
+		sum.bytes += stats.bytes
+		sum.errors += stats.errors
+		sum.fatalError = sum.fatalError || stats.fatalError
+		sum.retryError = sum.retryError || stats.retryError
+		sum.checks += stats.checks
+		sum.transfers += stats.transfers
+		sum.deletes += stats.deletes
+		sum.checking.merge(stats.checking)
+		sum.transferring.merge(stats.transferring)
+		sum.inProgress.merge(stats.inProgress)
+		if sum.lastError == nil && stats.lastError != nil {
+			sum.lastError = stats.lastError
+		}
+	}
+	return sum
+}

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -128,3 +128,54 @@ func TestStatsError(t *testing.T) {
 	assert.False(t, s.HadRetryError())
 	assert.Equal(t, time.Time{}, s.RetryAfter())
 }
+
+func TestStatsTotalDuration(t *testing.T) {
+	time1 := time.Now().Add(-40 * time.Second)
+	time2 := time1.Add(10 * time.Second)
+	time3 := time2.Add(10 * time.Second)
+	time4 := time3.Add(10 * time.Second)
+	s := NewStats()
+	s.AddTransfer(&Transfer{
+		startedAt:   time2,
+		completedAt: time3,
+	})
+	s.AddTransfer(&Transfer{
+		startedAt:   time2,
+		completedAt: time2.Add(time.Second),
+	})
+	s.AddTransfer(&Transfer{
+		startedAt:   time1,
+		completedAt: time3,
+	})
+	s.AddTransfer(&Transfer{
+		startedAt:   time3,
+		completedAt: time4,
+	})
+	s.AddTransfer(&Transfer{
+		startedAt: time.Now(),
+	})
+
+	time.Sleep(time.Millisecond)
+
+	s.mu.Lock()
+	total := s.totalDuration()
+	s.mu.Unlock()
+
+	assert.True(t, 30*time.Second < total && total < 31*time.Second, total)
+}
+
+func TestStatsTotalDuration2(t *testing.T) {
+	time1 := time.Now().Add(-40 * time.Second)
+	time2 := time1.Add(10 * time.Second)
+	s := NewStats()
+	s.AddTransfer(&Transfer{
+		startedAt:   time1,
+		completedAt: time2,
+	})
+
+	s.mu.Lock()
+	total := s.totalDuration()
+	s.mu.Unlock()
+
+	assert.Equal(t, 10*time.Second, total)
+}

--- a/fs/accounting/transfer.go
+++ b/fs/accounting/transfer.go
@@ -1,0 +1,72 @@
+package accounting
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	"github.com/ncw/rclone/fs"
+)
+
+// Transfer keeps track of initiated transfers and provides access to
+// accounting functions.
+// Transfer needs to be closed on completion.
+type Transfer struct {
+	stats  *StatsInfo
+	acc    *Account
+	remote string
+	size   int64
+
+	mu          sync.Mutex
+	startedAt   time.Time
+	completedAt time.Time
+}
+
+// newTransfer instantiates new transfer
+func newTransfer(stats *StatsInfo, obj fs.Object) *Transfer {
+	return newTransferRemoteSize(stats, obj.Remote(), obj.Size())
+}
+
+func newTransferRemoteSize(stats *StatsInfo, remote string, size int64) *Transfer {
+	tr := &Transfer{
+		stats:     stats,
+		remote:    remote,
+		size:      size,
+		startedAt: time.Now(),
+	}
+	stats.AddTransfer(tr)
+	return tr
+}
+
+// Done ends the transfer.
+// Must be called after transfer is finished to run proper cleanups.
+func (tr *Transfer) Done(err error) {
+	if err != nil {
+		tr.stats.Error(err)
+	}
+	if tr.acc != nil {
+		if err := tr.acc.Close(); err != nil {
+			fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "can't close account: %+v\n", err)
+		}
+	}
+	tr.stats.DoneTransferring(tr.remote, err == nil)
+	tr.mu.Lock()
+	tr.completedAt = time.Now()
+	tr.mu.Unlock()
+}
+
+// Account returns reader that knows how to keep track of transfer progress.
+func (tr *Transfer) Account(in io.ReadCloser) *Account {
+	if tr.acc != nil {
+		return tr.acc
+	}
+	return newAccountSizeName(tr.stats, in, tr.size, tr.remote)
+}
+
+// TimeRange returns the time transfer started and ended at. If not completed
+// it will return zero time for end time.
+func (tr *Transfer) TimeRange() (time.Time, time.Time) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return tr.startedAt, tr.completedAt
+}

--- a/fs/accounting/transfer.go
+++ b/fs/accounting/transfer.go
@@ -1,6 +1,7 @@
 package accounting
 
 import (
+	"encoding/json"
 	"io"
 	"sync"
 	"time"
@@ -8,31 +9,67 @@ import (
 	"github.com/ncw/rclone/fs"
 )
 
+// TransferSnapshot represents state of an account at point in time.
+type TransferSnapshot struct {
+	Name        string    `json:"name"`
+	Size        int64     `json:"size"`
+	Bytes       int64     `json:"bytes"`
+	Checked     bool      `json:"checked"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	Error       error     `json:"-"`
+}
+
+// MarshalJSON implements json.Marshaler interface.
+func (as TransferSnapshot) MarshalJSON() ([]byte, error) {
+	err := ""
+	if as.Error != nil {
+		err = as.Error.Error()
+	}
+	type Alias TransferSnapshot
+	return json.Marshal(&struct {
+		Error string `json:"error"`
+		Alias
+	}{
+		Error: err,
+		Alias: (Alias)(as),
+	})
+}
+
 // Transfer keeps track of initiated transfers and provides access to
 // accounting functions.
 // Transfer needs to be closed on completion.
 type Transfer struct {
-	stats  *StatsInfo
-	acc    *Account
-	remote string
-	size   int64
+	stats    *StatsInfo
+	remote   string
+	size     int64
+	checking bool
 
+	// Protects all bellow
 	mu          sync.Mutex
+	acc         *Account
+	err         error
 	startedAt   time.Time
 	completedAt time.Time
 }
 
-// newTransfer instantiates new transfer
-func newTransfer(stats *StatsInfo, obj fs.Object) *Transfer {
-	return newTransferRemoteSize(stats, obj.Remote(), obj.Size())
+// newCheckingTransfer instantiates new checking of the object.
+func newCheckingTransfer(stats *StatsInfo, obj fs.Object) *Transfer {
+	return newTransferRemoteSize(stats, obj.Remote(), obj.Size(), true)
 }
 
-func newTransferRemoteSize(stats *StatsInfo, remote string, size int64) *Transfer {
+// newTransfer instantiates new transfer.
+func newTransfer(stats *StatsInfo, obj fs.Object) *Transfer {
+	return newTransferRemoteSize(stats, obj.Remote(), obj.Size(), false)
+}
+
+func newTransferRemoteSize(stats *StatsInfo, remote string, size int64, checking bool) *Transfer {
 	tr := &Transfer{
 		stats:     stats,
 		remote:    remote,
 		size:      size,
 		startedAt: time.Now(),
+		checking:  checking,
 	}
 	stats.AddTransfer(tr)
 	return tr
@@ -41,26 +78,37 @@ func newTransferRemoteSize(stats *StatsInfo, remote string, size int64) *Transfe
 // Done ends the transfer.
 // Must be called after transfer is finished to run proper cleanups.
 func (tr *Transfer) Done(err error) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
 	if err != nil {
 		tr.stats.Error(err)
+		tr.err = err
 	}
 	if tr.acc != nil {
 		if err := tr.acc.Close(); err != nil {
 			fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "can't close account: %+v\n", err)
 		}
 	}
-	tr.stats.DoneTransferring(tr.remote, err == nil)
-	tr.mu.Lock()
+	if tr.checking {
+		tr.stats.DoneChecking(tr.remote)
+	} else {
+		tr.stats.DoneTransferring(tr.remote, err == nil)
+	}
+
 	tr.completedAt = time.Now()
-	tr.mu.Unlock()
 }
 
 // Account returns reader that knows how to keep track of transfer progress.
 func (tr *Transfer) Account(in io.ReadCloser) *Account {
-	if tr.acc != nil {
-		return tr.acc
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	if tr.acc == nil {
+		tr.acc = newAccountSizeName(tr.stats, in, tr.size, tr.remote)
+
 	}
-	return newAccountSizeName(tr.stats, in, tr.size, tr.remote)
+	return tr.acc
 }
 
 // TimeRange returns the time transfer started and ended at. If not completed
@@ -69,4 +117,31 @@ func (tr *Transfer) TimeRange() (time.Time, time.Time) {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 	return tr.startedAt, tr.completedAt
+}
+
+// IsDone returns true if transfer is completed.
+func (tr *Transfer) IsDone() bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return !tr.completedAt.IsZero()
+}
+
+// Snapshot produces stats for this account at point in time.
+func (tr *Transfer) Snapshot() TransferSnapshot {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	var s, b int64 = tr.size, 0
+	if tr.acc != nil {
+		b, s = tr.acc.progress()
+	}
+	return TransferSnapshot{
+		Name:        tr.remote,
+		Checked:     tr.checking,
+		Size:        s,
+		Bytes:       b,
+		StartedAt:   tr.startedAt,
+		CompletedAt: tr.completedAt,
+		Error:       tr.err,
+	}
 }

--- a/fs/config.go
+++ b/fs/config.go
@@ -87,6 +87,7 @@ type ConfigInfo struct {
 	UseServerModTime       bool
 	MaxTransfer            SizeSuffix
 	MaxBacklog             int
+	MaxStatsGroups         int
 	StatsOneLine           bool
 	StatsOneLineDate       bool   // If we want a date prefix at all
 	StatsOneLineDateFormat string // If we want to customize the prefix
@@ -124,6 +125,7 @@ func NewConfig() *ConfigInfo {
 	c.BufferSize = SizeSuffix(16 << 20)
 	c.UserAgent = "rclone/" + Version
 	c.StreamingUploadCutoff = SizeSuffix(100 * 1024)
+	c.MaxStatsGroups = 1000
 	c.StatsFileNameLength = 45
 	c.AskPassword = true
 	c.TPSLimitBurst = 1

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -89,6 +89,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.FVarP(flagSet, &fs.Config.Dump, "dump", "", "List of items to dump from: "+fs.DumpFlagsList)
 	flags.FVarP(flagSet, &fs.Config.MaxTransfer, "max-transfer", "", "Maximum size of data to transfer.")
 	flags.IntVarP(flagSet, &fs.Config.MaxBacklog, "max-backlog", "", fs.Config.MaxBacklog, "Maximum number of objects in sync or check backlog.")
+	flags.IntVarP(flagSet, &fs.Config.MaxStatsGroups, "max-stats-groups", "", fs.Config.MaxStatsGroups, "Maximum number of stats groups to keep in memory. On max oldest is discarded.")
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLine, "stats-one-line", "", fs.Config.StatsOneLine, "Make the stats fit on one line.")
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLineDate, "stats-one-line-date", "", fs.Config.StatsOneLineDate, "Enables --stats-one-line and add current date/time prefix.")
 	flags.StringVarP(flagSet, &fs.Config.StatsOneLineDateFormat, "stats-one-line-date-format", "", fs.Config.StatsOneLineDateFormat, "Enables --stats-one-line-date and uses custom formatted date. Enclose date string in double quotes (\"). See https://golang.org/pkg/time/#Time.Format")

--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -110,7 +110,7 @@ func (mc *multiThreadCopyState) calculateChunks() {
 }
 
 // Copy src to (f, remote) using streams download threads and the OpenWriterAt feature
-func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object, streams int) (newDst fs.Object, err error) {
+func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object, streams int, tr *accounting.Transfer) (newDst fs.Object, err error) {
 	openWriterAt := f.Features().OpenWriterAt
 	if openWriterAt == nil {
 		return nil, errors.New("multi-thread copy: OpenWriterAt not supported")
@@ -132,8 +132,7 @@ func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object,
 	mc.calculateChunks()
 
 	// Make accounting
-	mc.acc = accounting.NewAccount(nil, src)
-	defer fs.CheckClose(mc.acc, &err)
+	mc.acc = tr.Account(nil)
 
 	// create write file handle
 	mc.wc, err = openWriterAt(gCtx, remote, mc.size)

--- a/fs/operations/multithread_test.go
+++ b/fs/operations/multithread_test.go
@@ -60,8 +60,8 @@ func TestMultithreadCopy(t *testing.T) {
 
 			src, err := r.Fremote.NewObject(context.Background(), "file1")
 			require.NoError(t, err)
-			accounting.Stats.ResetCounters()
-			tr := accounting.Stats.NewTransfer(src)
+			accounting.GlobalStats().ResetCounters()
+			tr := accounting.GlobalStats().NewTransfer(src)
 
 			defer func() {
 				tr.Done(err)

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -14,7 +14,7 @@
 // fstest.CheckItems() before use.  This make sure the directory
 // listing is now consistent and stops cascading errors.
 //
-// Call accounting.Stats.ResetCounters() before every fs.Sync() as it
+// Call accounting.GlobalStats().ResetCounters() before every fs.Sync() as it
 // uses the error count internally.
 
 package operations_test
@@ -315,15 +315,15 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, fdst, fsrc 
 
 	check := func(i int, wantErrors int64, wantChecks int64, oneway bool) {
 		fs.Debugf(r.Fremote, "%d: Starting check test", i)
-		accounting.Stats.ResetCounters()
+		accounting.GlobalStats().ResetCounters()
 		var buf bytes.Buffer
 		log.SetOutput(&buf)
 		defer func() {
 			log.SetOutput(os.Stderr)
 		}()
 		err := checkFunction(context.Background(), r.Fremote, r.Flocal, oneway)
-		gotErrors := accounting.Stats.GetErrors()
-		gotChecks := accounting.Stats.GetChecks()
+		gotErrors := accounting.GlobalStats().GetErrors()
+		gotChecks := accounting.GlobalStats().GetChecks()
 		if wantErrors == 0 && err != nil {
 			t.Errorf("%d: Got error when not expecting one: %v", i, err)
 		}

--- a/fs/rc/jobs/job.go
+++ b/fs/rc/jobs/job.go
@@ -1,12 +1,17 @@
 // Manage background jobs that the rc is running
 
-package rc
+package jobs
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ncw/rclone/fs/rc"
+
+	"github.com/ncw/rclone/fs/accounting"
 
 	"github.com/ncw/rclone/fs"
 	"github.com/pkg/errors"
@@ -16,13 +21,14 @@ import (
 type Job struct {
 	mu        sync.Mutex
 	ID        int64     `json:"id"`
+	Group     string    `json:"group"`
 	StartTime time.Time `json:"startTime"`
 	EndTime   time.Time `json:"endTime"`
 	Error     string    `json:"error"`
 	Finished  bool      `json:"finished"`
 	Success   bool      `json:"success"`
 	Duration  float64   `json:"duration"`
-	Output    Params    `json:"output"`
+	Output    rc.Params `json:"output"`
 	Stop      func()    `json:"-"`
 }
 
@@ -96,11 +102,11 @@ func (jobs *Jobs) Get(ID int64) *Job {
 }
 
 // mark the job as finished
-func (job *Job) finish(out Params, err error) {
+func (job *Job) finish(out rc.Params, err error) {
 	job.mu.Lock()
 	job.EndTime = time.Now()
 	if out == nil {
-		out = make(Params)
+		out = make(rc.Params)
 	}
 	job.Output = out
 	job.Duration = job.EndTime.Sub(job.StartTime).Seconds()
@@ -117,7 +123,7 @@ func (job *Job) finish(out Params, err error) {
 }
 
 // run the job until completion writing the return status
-func (job *Job) run(ctx context.Context, fn Func, in Params) {
+func (job *Job) run(ctx context.Context, fn rc.Func, in rc.Params) {
 	defer func() {
 		if r := recover(); r != nil {
 			job.finish(nil, errors.Errorf("panic received: %v", r))
@@ -126,37 +132,93 @@ func (job *Job) run(ctx context.Context, fn Func, in Params) {
 	job.finish(fn(ctx, in))
 }
 
-// NewJob start a new Job off
-func (jobs *Jobs) NewJob(fn Func, in Params) *Job {
-	ctx, cancel := context.WithCancel(context.Background())
+func getGroup(in rc.Params) string {
+	// Check to see if the group is set
+	group, err := in.GetString("_group")
+	if rc.NotErrParamNotFound(err) {
+		fs.Errorf(nil, "Can't get _group param %+v", err)
+	}
+	delete(in, "_group")
+	return group
+}
+
+// NewAsyncJob start a new asynchronous Job off
+func (jobs *Jobs) NewAsyncJob(fn rc.Func, in rc.Params) *Job {
+	id := atomic.AddInt64(&jobID, 1)
+
+	group := getGroup(in)
+	if group == "" {
+		group = fmt.Sprintf("job/%d", id)
+	}
+	ctx := accounting.WithStatsGroup(context.Background(), group)
+	ctx, cancel := context.WithCancel(ctx)
 	stop := func() {
 		cancel()
 		// Wait for cancel to propagate before returning.
 		<-ctx.Done()
 	}
 	job := &Job{
-		ID:        atomic.AddInt64(&jobID, 1),
+		ID:        id,
+		Group:     group,
 		StartTime: time.Now(),
 		Stop:      stop,
 	}
-	go job.run(ctx, fn, in)
 	jobs.mu.Lock()
 	jobs.jobs[job.ID] = job
 	jobs.mu.Unlock()
+	go job.run(ctx, fn, in)
 	return job
-
 }
 
-// StartJob starts a new job and returns a Param suitable for output
-func StartJob(fn Func, in Params) (Params, error) {
-	job := running.NewJob(fn, in)
-	out := make(Params)
+// NewSyncJob start a new synchronous Job off
+func (jobs *Jobs) NewSyncJob(ctx context.Context, in rc.Params) (*Job, context.Context) {
+	id := atomic.AddInt64(&jobID, 1)
+	group := getGroup(in)
+	if group == "" {
+		group = fmt.Sprintf("job/%d", id)
+	}
+	ctxG := accounting.WithStatsGroup(ctx, fmt.Sprintf("job/%d", id))
+	ctx, cancel := context.WithCancel(ctxG)
+	stop := func() {
+		cancel()
+		// Wait for cancel to propagate before returning.
+		<-ctx.Done()
+	}
+	job := &Job{
+		ID:        id,
+		Group:     group,
+		StartTime: time.Now(),
+		Stop:      stop,
+	}
+	jobs.mu.Lock()
+	jobs.jobs[job.ID] = job
+	jobs.mu.Unlock()
+	return job, ctx
+}
+
+// StartAsyncJob starts a new job asynchronously and returns a Param suitable
+// for output.
+func StartAsyncJob(fn rc.Func, in rc.Params) (rc.Params, error) {
+	job := running.NewAsyncJob(fn, in)
+	out := make(rc.Params)
 	out["jobid"] = job.ID
 	return out, nil
 }
 
+// ExecuteJob executes new job synchronously and returns a Param suitable for
+// output.
+func ExecuteJob(ctx context.Context, fn rc.Func, in rc.Params) (rc.Params, int64, error) {
+	job, ctx := running.NewSyncJob(ctx, in)
+	job.run(ctx, fn, in)
+	var err error
+	if !job.Success {
+		err = errors.New(job.Error)
+	}
+	return job.Output, job.ID, err
+}
+
 func init() {
-	Add(Call{
+	rc.Add(rc.Call{
 		Path:  "job/status",
 		Fn:    rcJobStatus,
 		Title: "Reads the status of the job ID",
@@ -179,7 +241,7 @@ Results
 }
 
 // Returns the status of a job
-func rcJobStatus(ctx context.Context, in Params) (out Params, err error) {
+func rcJobStatus(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	jobID, err := in.GetInt64("jobid")
 	if err != nil {
 		return nil, err
@@ -190,8 +252,8 @@ func rcJobStatus(ctx context.Context, in Params) (out Params, err error) {
 	}
 	job.mu.Lock()
 	defer job.mu.Unlock()
-	out = make(Params)
-	err = Reshape(&out, job)
+	out = make(rc.Params)
+	err = rc.Reshape(&out, job)
 	if err != nil {
 		return nil, errors.Wrap(err, "reshape failed in job status")
 	}
@@ -199,7 +261,7 @@ func rcJobStatus(ctx context.Context, in Params) (out Params, err error) {
 }
 
 func init() {
-	Add(Call{
+	rc.Add(rc.Call{
 		Path:  "job/list",
 		Fn:    rcJobList,
 		Title: "Lists the IDs of the running jobs",
@@ -212,14 +274,14 @@ Results
 }
 
 // Returns list of job ids.
-func rcJobList(ctx context.Context, in Params) (out Params, err error) {
-	out = make(Params)
+func rcJobList(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	out = make(rc.Params)
 	out["jobids"] = running.IDs()
 	return out, nil
 }
 
 func init() {
-	Add(Call{
+	rc.Add(rc.Call{
 		Path:  "job/stop",
 		Fn:    rcJobStop,
 		Title: "Stop the running job",
@@ -230,7 +292,7 @@ func init() {
 }
 
 // Stops the running job.
-func rcJobStop(ctx context.Context, in Params) (out Params, err error) {
+func rcJobStop(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	jobID, err := in.GetInt64("jobid")
 	if err != nil {
 		return nil, err
@@ -241,7 +303,7 @@ func rcJobStop(ctx context.Context, in Params) (out Params, err error) {
 	}
 	job.mu.Lock()
 	defer job.mu.Unlock()
-	out = make(Params)
+	out = make(rc.Params)
 	job.Stop()
 	return out, nil
 }

--- a/fs/rc/rcserver/rcserver_test.go
+++ b/fs/rc/rcserver/rcserver_test.go
@@ -611,10 +611,7 @@ func TestRCAsync(t *testing.T) {
 		ContentType: "application/json",
 		Body:        `{ "_async":true }`,
 		Status:      http.StatusOK,
-		Expected: `{
-	"jobid": 1
-}
-`,
+		Contains:    regexp.MustCompile(`(?s)\{.*\"jobid\":.*\}`),
 	}, {
 		Name:        "bad",
 		URL:         "rc/noop",

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1233,7 +1233,7 @@ func TestSyncCompareDest(t *testing.T) {
 	file1 := r.WriteFile("one", "one", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1247,7 +1247,7 @@ func TestSyncCompareDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1dst)
 	fstest.CheckItems(t, r.Flocal, file1b)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1263,7 +1263,7 @@ func TestSyncCompareDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file3)
 	fstest.CheckItems(t, r.Flocal, file1c)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1275,14 +1275,14 @@ func TestSyncCompareDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
 	fstest.CheckItems(t, r.Flocal, file1c, file5)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
 	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
 
 	// check new dest, new compare
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1293,7 +1293,7 @@ func TestSyncCompareDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
 	fstest.CheckItems(t, r.Flocal, file1c, file5b)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1324,7 +1324,7 @@ func TestSyncCopyDest(t *testing.T) {
 	file1 := r.WriteFile("one", "one", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1338,7 +1338,7 @@ func TestSyncCopyDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1dst)
 	fstest.CheckItems(t, r.Flocal, file1b)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1357,7 +1357,7 @@ func TestSyncCopyDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file3)
 	fstest.CheckItems(t, r.Flocal, file1c)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1374,7 +1374,7 @@ func TestSyncCopyDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4)
 	fstest.CheckItems(t, r.Flocal, file1c, file5)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1384,7 +1384,7 @@ func TestSyncCopyDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst)
 
 	// check new dest, new copy
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1396,7 +1396,7 @@ func TestSyncCopyDest(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst, file6)
 	fstest.CheckItems(t, r.Flocal, file1c, file5, file7)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -105,7 +105,7 @@ func TestSyncNoTraverse(t *testing.T) {
 
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -306,24 +306,24 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 	file1 := r.WriteFile("check sum", "-", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred exactly one file.
-	assert.Equal(t, int64(1), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	// Change last modified date only
 	file2 := r.WriteFile("check sum", "-", t2)
 	fstest.CheckItems(t, r.Flocal, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred no files
-	assert.Equal(t, int64(0), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Flocal, file2)
 	fstest.CheckItems(t, r.Fremote, file1)
 }
@@ -340,24 +340,24 @@ func TestSyncSizeOnly(t *testing.T) {
 	file1 := r.WriteFile("sizeonly", "potato", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred exactly one file.
-	assert.Equal(t, int64(1), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	// Update mtime, md5sum but not length of file
 	file2 := r.WriteFile("sizeonly", "POTATO", t2)
 	fstest.CheckItems(t, r.Flocal, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred no files
-	assert.Equal(t, int64(0), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Flocal, file2)
 	fstest.CheckItems(t, r.Fremote, file1)
 }
@@ -374,24 +374,24 @@ func TestSyncIgnoreSize(t *testing.T) {
 	file1 := r.WriteFile("ignore-size", "contents", t1)
 	fstest.CheckItems(t, r.Flocal, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred exactly one file.
-	assert.Equal(t, int64(1), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	// Update size but not date of file
 	file2 := r.WriteFile("ignore-size", "longer contents but same date", t1)
 	fstest.CheckItems(t, r.Flocal, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred no files
-	assert.Equal(t, int64(0), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Flocal, file2)
 	fstest.CheckItems(t, r.Fremote, file1)
 }
@@ -402,24 +402,24 @@ func TestSyncIgnoreTimes(t *testing.T) {
 	file1 := r.WriteBoth(context.Background(), "existing", "potato", t1)
 	fstest.CheckItems(t, r.Fremote, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred exactly 0 files because the
 	// files were identical.
-	assert.Equal(t, int64(0), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
 
 	fs.Config.IgnoreTimes = true
 	defer func() { fs.Config.IgnoreTimes = false }()
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred exactly one file even though the
 	// files were identical.
-	assert.Equal(t, int64(1), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers())
 
 	fstest.CheckItems(t, r.Flocal, file1)
 	fstest.CheckItems(t, r.Fremote, file1)
@@ -433,7 +433,7 @@ func TestSyncIgnoreExisting(t *testing.T) {
 	fs.Config.IgnoreExisting = true
 	defer func() { fs.Config.IgnoreExisting = false }()
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
@@ -441,7 +441,7 @@ func TestSyncIgnoreExisting(t *testing.T) {
 
 	// Change everything
 	r.WriteFile("existing", "newpotatoes", t2)
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	// Items should not change
@@ -488,7 +488,7 @@ func TestSyncIgnoreErrors(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	fs.CountError(errors.New("boom"))
 	assert.NoError(t, Sync(context.Background(), r.Fremote, r.Flocal, false))
 
@@ -532,7 +532,7 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	fs.Config.DryRun = true
 	defer func() { fs.Config.DryRun = false }()
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -541,7 +541,7 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 
 	fs.Config.DryRun = false
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -569,7 +569,7 @@ func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
 	fstest.CheckItems(t, r.Flocal, file1)
 	fstest.CheckItems(t, r.Fremote, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -590,7 +590,7 @@ func TestSyncDoesntUpdateModtime(t *testing.T) {
 	fstest.CheckItems(t, r.Flocal, file1)
 	fstest.CheckItems(t, r.Fremote, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -598,7 +598,7 @@ func TestSyncDoesntUpdateModtime(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	// We should have transferred exactly one file, not set the mod time
-	assert.Equal(t, int64(1), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers())
 }
 
 func TestSyncAfterAddingAFile(t *testing.T) {
@@ -610,7 +610,7 @@ func TestSyncAfterAddingAFile(t *testing.T) {
 	fstest.CheckItems(t, r.Flocal, file1, file2)
 	fstest.CheckItems(t, r.Fremote, file1)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1, file2)
@@ -625,7 +625,7 @@ func TestSyncAfterChangingFilesSizeOnly(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 	fstest.CheckItems(t, r.Flocal, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file2)
@@ -648,7 +648,7 @@ func TestSyncAfterChangingContentsOnly(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 	fstest.CheckItems(t, r.Flocal, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file2)
@@ -664,7 +664,7 @@ func TestSyncAfterRemovingAFileAndAddingAFileDryRun(t *testing.T) {
 	file3 := r.WriteBoth(context.Background(), "empty space", "-", t2)
 
 	fs.Config.DryRun = true
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	fs.Config.DryRun = false
 	require.NoError(t, err)
@@ -683,7 +683,7 @@ func TestSyncAfterRemovingAFileAndAddingAFile(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2, file3)
 	fstest.CheckItems(t, r.Flocal, file1, file3)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1, file3)
@@ -729,7 +729,7 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDir(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -798,7 +798,7 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 		fs.GetModifyWindow(r.Fremote),
 	)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	fs.CountError(errors.New("boom"))
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	assert.Equal(t, fs.ErrorNotDeleting, err)
@@ -876,7 +876,7 @@ func TestCopyDeleteBefore(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 	fstest.CheckItems(t, r.Flocal, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := CopyDir(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -899,14 +899,14 @@ func TestSyncWithExclude(t *testing.T) {
 		filter.Active.Opt.MaxSize = -1
 	}()
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Fremote, file2, file1)
 
 	// Now sync the other way round and check enormous doesn't get
 	// deleted as it is excluded from the sync
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file2, file1, file3)
@@ -929,14 +929,14 @@ func TestSyncWithExcludeAndDeleteExcluded(t *testing.T) {
 		filter.Active.Opt.DeleteExcluded = false
 	}()
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Fremote, file2)
 
 	// Check sync the other way round to make sure enormous gets
 	// deleted even though it is excluded
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file2)
@@ -971,7 +971,7 @@ func TestSyncWithUpdateOlder(t *testing.T) {
 		fs.Config.ModifyWindow = oldModifyWindow
 	}()
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Fremote, oneO, twoF, threeO, fourF, fiveF)
@@ -995,7 +995,7 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	f1 := r.WriteFile("potato", "Potato Content", t1)
 	f2 := r.WriteFile("yam", "Yam Content", t2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(context.Background(), r.Fremote, r.Flocal, false))
 
 	fstest.CheckItems(t, r.Fremote, f1, f2)
@@ -1004,7 +1004,7 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	// Now rename locally.
 	f2 = r.RenameFile(f2, "yaml")
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(context.Background(), r.Fremote, r.Flocal, false))
 
 	fstest.CheckItems(t, r.Fremote, f1, f2)
@@ -1012,15 +1012,15 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	if canTrackRenames {
 		if r.Fremote.Features().Move == nil || r.Fremote.Name() == "TestUnion" { // union remote can Move but returns CantMove error
 			// If no server side Move, we are falling back to Copy + Delete
-			assert.Equal(t, int64(1), accounting.Stats.GetTransfers()) // 1 copy
-			assert.Equal(t, int64(4), accounting.Stats.GetChecks())    // 2 file checks + 1 move + 1 delete
+			assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers()) // 1 copy
+			assert.Equal(t, int64(4), accounting.GlobalStats().GetChecks())    // 2 file checks + 1 move + 1 delete
 		} else {
-			assert.Equal(t, int64(0), accounting.Stats.GetTransfers()) // 0 copy
-			assert.Equal(t, int64(3), accounting.Stats.GetChecks())    // 2 file checks + 1 move
+			assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers()) // 0 copy
+			assert.Equal(t, int64(3), accounting.GlobalStats().GetChecks())    // 2 file checks + 1 move
 		}
 	} else {
-		assert.Equal(t, int64(2), accounting.Stats.GetChecks())    // 2 file checks
-		assert.Equal(t, int64(1), accounting.Stats.GetTransfers()) // 0 copy
+		assert.Equal(t, int64(2), accounting.GlobalStats().GetChecks())    // 2 file checks
+		assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers()) // 0 copy
 	}
 }
 
@@ -1049,7 +1049,7 @@ func testServerSideMove(t *testing.T, r *fstest.Run, withFilter, testDeleteEmpty
 	fstest.CheckItems(t, FremoteMove, file2, file3)
 
 	// Do server side move
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = MoveDir(context.Background(), FremoteMove, r.Fremote, testDeleteEmptyDirs, false)
 	require.NoError(t, err)
 
@@ -1076,7 +1076,7 @@ func testServerSideMove(t *testing.T, r *fstest.Run, withFilter, testDeleteEmpty
 	}
 
 	// Move it back to a new empty remote, dst does not exist this time
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = MoveDir(context.Background(), FremoteMove2, FremoteMove, testDeleteEmptyDirs, false)
 	require.NoError(t, err)
 
@@ -1439,7 +1439,7 @@ func testSyncBackupDir(t *testing.T, suffix string, suffixKeepExtension bool) {
 	fdst, err := fs.NewFs(r.FremoteName + "/dst")
 	require.NoError(t, err)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1464,7 +1464,7 @@ func testSyncBackupDir(t *testing.T, suffix string, suffixKeepExtension bool) {
 
 	// This should delete three and overwrite one again, checking
 	// the files got overwritten correctly in backup-dir
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -1518,7 +1518,7 @@ func testSyncSuffix(t *testing.T, suffix string, suffixKeepExtension bool) {
 	fdst, err := fs.NewFs(r.FremoteName + "/dst")
 	require.NoError(t, err)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = operations.CopyFile(context.Background(), fdst, r.Flocal, "one", "one")
 	require.NoError(t, err)
 	err = operations.CopyFile(context.Background(), fdst, r.Flocal, "two", "two")
@@ -1548,7 +1548,7 @@ func testSyncSuffix(t *testing.T, suffix string, suffixKeepExtension bool) {
 
 	// This should delete three and overwrite one again, checking
 	// the files got overwritten correctly in backup-dir
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = operations.CopyFile(context.Background(), fdst, r.Flocal, "one", "one")
 	require.NoError(t, err)
 	err = operations.CopyFile(context.Background(), fdst, r.Flocal, "two", "two")
@@ -1594,13 +1594,13 @@ func TestSyncUTFNorm(t *testing.T) {
 	file2 := r.WriteObject(context.Background(), Encoding2, "This is a old test", t2)
 	fstest.CheckItems(t, r.Fremote, file2)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
 	// We should have transferred exactly one file, but kept the
 	// normalized state of the file.
-	assert.Equal(t, int64(1), accounting.Stats.GetTransfers())
+	assert.Equal(t, int64(1), accounting.GlobalStats().GetTransfers())
 	fstest.CheckItems(t, r.Flocal, file1)
 	file1.Path = file2.Path
 	fstest.CheckItems(t, r.Fremote, file1)
@@ -1620,7 +1620,7 @@ func TestSyncImmutable(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote)
 
 	// Should succeed
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
@@ -1632,7 +1632,7 @@ func TestSyncImmutable(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file1)
 
 	// Should fail with ErrorImmutableModified and not modify local or remote files
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err = Sync(context.Background(), r.Fremote, r.Flocal, false)
 	assert.EqualError(t, err, fs.ErrorImmutableModified.Error())
 	fstest.CheckItems(t, r.Flocal, file2)
@@ -1659,7 +1659,7 @@ func TestSyncIgnoreCase(t *testing.T) {
 	fstest.CheckItems(t, r.Fremote, file2)
 
 	// Should not copy files that are differently-cased but otherwise identical
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	fstest.CheckItems(t, r.Flocal, file1)
@@ -1694,7 +1694,7 @@ func TestAbort(t *testing.T) {
 	fstest.CheckItems(t, r.Flocal, file1, file2, file3)
 	fstest.CheckItems(t, r.Fremote)
 
-	accounting.Stats.ResetCounters()
+	accounting.GlobalStats().ResetCounters()
 
 	err := Sync(context.Background(), r.Fremote, r.Flocal, false)
 	assert.Equal(t, accounting.ErrorMaxTransferLimitReached, err)

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -274,7 +274,8 @@ func CheckListingWithPrecision(t *testing.T, f fs.Fs, items []Item, expectedDirs
 		expectedDirs = filterEmptyDirs(t, items, expectedDirs)
 	}
 	is := NewItems(items)
-	oldErrors := accounting.Stats.GetErrors()
+	ctx := context.Background()
+	oldErrors := accounting.Stats(ctx).GetErrors()
 	var objs []fs.Object
 	var dirs []fs.Directory
 	var err error
@@ -283,7 +284,6 @@ func CheckListingWithPrecision(t *testing.T, f fs.Fs, items []Item, expectedDirs
 	wantListing1, wantListing2 := makeListingFromItems(items)
 	gotListing := "<unset>"
 	listingOK := false
-	ctx := context.Background()
 	for i := 1; i <= retries; i++ {
 		objs, dirs, err = walk.GetAll(ctx, f, "", true, -1)
 		if err != nil && err != fs.ErrorDirNotFound {
@@ -317,8 +317,8 @@ func CheckListingWithPrecision(t *testing.T, f fs.Fs, items []Item, expectedDirs
 	}
 	is.Done(t)
 	// Don't notice an error when listing an empty directory
-	if len(items) == 0 && oldErrors == 0 && accounting.Stats.GetErrors() == 1 {
-		accounting.Stats.ResetErrors()
+	if len(items) == 0 && oldErrors == 0 && accounting.Stats(ctx).GetErrors() == 1 {
+		accounting.Stats(ctx).ResetErrors()
 	}
 	// Check the directories
 	if expectedDirs != nil {

--- a/vfs/read.go
+++ b/vfs/read.go
@@ -71,7 +71,7 @@ func (fh *ReadFileHandle) openPending() (err error) {
 	if err != nil {
 		return err
 	}
-	tr := accounting.Stats.NewTransfer(o)
+	tr := accounting.GlobalStats().NewTransfer(o)
 	fh.done = tr.Done
 	fh.r = tr.Account(r).WithBuffer() // account the transfer
 	fh.opened = true

--- a/vfs/read_write.go
+++ b/vfs/read_write.go
@@ -87,9 +87,11 @@ func newRWFileHandle(d *Dir, f *File, remote string, flags int) (fh *RWFileHandl
 // copy an object to or from the remote while accounting for it
 func copyObj(f fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Object, err error) {
 	if operations.NeedTransfer(context.TODO(), dst, src) {
-		accounting.Stats.Transferring(src.Remote())
+		tr := accounting.Stats.NewTransfer(src)
+		defer func() {
+			tr.Done(err)
+		}()
 		newDst, err = operations.Copy(context.TODO(), f, dst, remote, src)
-		accounting.Stats.DoneTransferring(src.Remote(), err == nil)
 	} else {
 		newDst = dst
 	}

--- a/vfs/read_write.go
+++ b/vfs/read_write.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/ncw/rclone/fs"
-	"github.com/ncw/rclone/fs/accounting"
 	"github.com/ncw/rclone/fs/log"
 	"github.com/ncw/rclone/fs/operations"
 	"github.com/ncw/rclone/lib/file"
@@ -87,10 +86,6 @@ func newRWFileHandle(d *Dir, f *File, remote string, flags int) (fh *RWFileHandl
 // copy an object to or from the remote while accounting for it
 func copyObj(f fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Object, err error) {
 	if operations.NeedTransfer(context.TODO(), dst, src) {
-		tr := accounting.Stats.NewTransfer(src)
-		defer func() {
-			tr.Done(err)
-		}()
 		newDst, err = operations.Copy(context.TODO(), f, dst, remote, src)
 	} else {
 		newDst = dst


### PR DESCRIPTION
This is a continuation of #3276 based on feedback and discussion so that one can be closed.

There are two main problems that are resolved with this PR.

First problem is incorrect accounting in server mode where global stats are updated by the stats from many different transfers that may not be logically connected. Elapsed time was calculated from the creation of the stats object and all calculations that depend on it came out wrong when rclone is used as server. This was resolved by grouping transfers into stats groups. There is dedicated global stats group that is used for CLI operations. By default all requests will get "job/1" group as all request now create a job to track their errors. Jobs can be sync or async.

Second is adding reference to all completed transfers which is now available on core/transferred.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
